### PR TITLE
Dna Representation, In-Memory Structs, and Serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,20 @@
 [[package]]
+name = "base64"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -35,6 +49,7 @@ version = "0.1.0"
 name = "hc_dna"
 version = "0.1.0"
 dependencies = [
+ "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -54,6 +69,11 @@ version = "0.1.0"
 dependencies = [
  "hc_core 0.1.0",
 ]
+
+[[package]]
+name = "indexmap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
@@ -92,6 +112,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "safemem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +137,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -160,16 +186,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
+"checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
 "checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
+"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "e9a2d9a9ac5120e0f768801ca2b58ad6eec929dc9d1d616c162f208869c2ce95"
 "checksum serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)" = "0a90213fa7e0f5eac3f7afe2d5ff6b088af515052cc7303bd68c7e3b91a3fb79"
 "checksum serde_json 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "fc97cccc2959f39984524026d760c08ef0dd5f0f5948c8d31797dbfae458c875"

--- a/c_binding_tests/hc_dna/test.cpp
+++ b/c_binding_tests/hc_dna/test.cpp
@@ -1,6 +1,8 @@
 #include "test.h"
 #include "../../hc_dna_c_binding/include/hc_dna_c_binding.h"
 
+#include <stdio.h>
+
 void TestHcDna::serializeAndDeserialize() {
   Dna *dna;
   Dna *dna2;
@@ -15,10 +17,33 @@ void TestHcDna::serializeAndDeserialize() {
 
   buf = hc_dna_get_dna_spec_version(dna2);
 
-  QCOMPARE(QString(buf), QString("2.0"));
+  QCOMPARE(QString("2.0"), QString(buf));
 
   hc_dna_string_free(buf);
   hc_dna_free(dna2);
+}
+
+void TestHcDna::canGetName() {
+  Dna *dna = hc_dna_create_from_json("{\"name\":\"test\"}");
+  char *buf = hc_dna_get_name(dna);
+
+  QCOMPARE(QString("test"), QString(buf));
+
+  hc_dna_string_free(buf);
+  hc_dna_free(dna);
+}
+
+void TestHcDna::canSetName() {
+  Dna *dna = hc_dna_create();
+
+  hc_dna_set_name(dna, "test");
+
+  char *buf = hc_dna_get_name(dna);
+
+  QCOMPARE(QString("test"), QString(buf));
+
+  hc_dna_string_free(buf);
+  hc_dna_free(dna);
 }
 
 QTEST_MAIN(TestHcDna)

--- a/c_binding_tests/hc_dna/test.h
+++ b/c_binding_tests/hc_dna/test.h
@@ -7,5 +7,7 @@ class TestHcDna: public QObject
 private slots:
 
   void serializeAndDeserialize();
+  void canGetName();
+  void canSetName();
 };
 

--- a/doc/specs/dna.md
+++ b/doc/specs/dna.md
@@ -61,7 +61,7 @@ closeBundle(bundle)
             },
             //"RibosomeType":"WASM", #do we just commit to WASM only at
             //  at this stage?
-            "entry-types": [
+            "entry_types": [
 
                 {
                     "name": "post",

--- a/doc/specs/dna.md
+++ b/doc/specs/dna.md
@@ -151,7 +151,8 @@ closeBundle(bundle)
                         "membrane": "zome"
                     },
                     ,
-                    "fn_functions": [
+                    "fn_declarations": [
+                        // see above
                     ],
                      "code": ".." //s-expresion encoded wasm or Base64 encoded WASM bytecode
                 },

--- a/hc_dna/Cargo.toml
+++ b/hc_dna/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = ["neonphog <neonphog@gmail.com>"]
 
 [dependencies]
+base64 = "0.9.2"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 uuid = { version = "0.6.5", features = ["v4"] }

--- a/hc_dna/src/lib.rs
+++ b/hc_dna/src/lib.rs
@@ -1,31 +1,97 @@
-//! hc_dna is a library for working with holochain dna files.
-//!
-//! It includes utilities for representing dna structures in memory,
-//! as well as serializing and deserializing dna, mainly to json format.
-//!
-//! # Examples
-//!
-//! ```
-//! use hc_dna::Dna;
-//!
-//! let name = String::from("My Holochain App");
-//!
-//! let mut dna = Dna::new();
-//! dna.name = name.clone();
-//!
-//! let json = dna.to_json().unwrap();
-//!
-//! let dna2 = Dna::new_from_json(&json).unwrap();
-//! assert_eq!(name, dna2.name);
-//! ```
+/*!
+hc_dna is a library for working with holochain dna files.
 
+It includes utilities for representing dna structures in memory,
+as well as serializing and deserializing dna, mainly to json format.
+
+# Examples
+
+```
+use hc_dna::Dna;
+
+let name = String::from("My Holochain App");
+
+let mut dna = Dna::new();
+dna.name = name.clone();
+
+let json = dna.to_json().unwrap();
+
+let dna2 = Dna::new_from_json(&json).unwrap();
+assert_eq!(name, dna2.name);
+```
+*/
+
+extern crate base64;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
+#[macro_use]
 extern crate serde_json;
 extern crate uuid;
 
+use serde::de::{Deserializer, Visitor};
+use serde::ser::Serializer;
 use uuid::Uuid;
+
+fn _vec_u8_to_b64_str<S>(data: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let b64 = base64::encode(data);
+    s.serialize_str(&b64)
+}
+
+fn _b64_str_to_vec_u8<'de, D>(d: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Z;
+
+    impl<'de> Visitor<'de> for Z {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("string")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Vec<u8>, E>
+        where
+            E: serde::de::Error,
+        {
+            match base64::decode(value) {
+                Ok(v) => Ok(v),
+                Err(_) => Err(serde::de::Error::custom(String::from("nope"))),
+            }
+        }
+    }
+
+    d.deserialize_any(Z)
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct DnaWasm {
+    #[serde(serialize_with = "_vec_u8_to_b64_str", deserialize_with = "_b64_str_to_vec_u8")]
+    code: Vec<u8>,
+    // using a struct gives us the flexibility to extend it later
+    // should we need additional properties, like:
+    // `filename: String,`
+}
+
+impl Default for DnaWasm {
+    /// Provide defaults for wasm entries in dna structs.
+    fn default() -> Self {
+        DnaWasm {
+            code: vec![0, 1, 2, 3],
+        }
+    }
+}
+
+impl DnaWasm {
+    /// Allow sane defaults for `DnaWasm::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
 
 /// Enum for "zome" "config" "error_handling" property.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -34,10 +100,18 @@ pub enum ZomeConfigErrorHandling {
     ThrowErrors,
 }
 
+impl Default for ZomeConfigErrorHandling {
+    /// Default zome config error_handling is "throw-errors"
+    fn default() -> Self {
+        ZomeConfigErrorHandling::ThrowErrors
+    }
+}
+
 /// Represents the "config" object on a "zome".
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct ZomeConfig {
     /// How errors should be handled within this zome.
+    #[serde(default)]
     pub error_handling: ZomeConfigErrorHandling,
 }
 
@@ -68,17 +142,30 @@ pub enum ZomeEntryTypeSharing {
     Encrypted,
 }
 
+impl Default for ZomeEntryTypeSharing {
+    /// Default zome entry_type sharing is "public"
+    fn default() -> Self {
+        ZomeEntryTypeSharing::Public
+    }
+}
+
 /// Represents an individual object in the "zome" "entry_types" array.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct ZomeEntryType {
     /// The name of this entry type.
+    #[serde(default)]
     pub name: String,
 
     /// A description of this entry type.
+    #[serde(default)]
     pub description: String,
 
     /// The sharing model of this entry type (public, private, encrypted).
+    #[serde(default)]
     pub sharing: ZomeEntryTypeSharing,
+
+    #[serde(default)]
+    pub validation: DnaWasm,
 }
 
 impl Default for ZomeEntryType {
@@ -88,6 +175,7 @@ impl Default for ZomeEntryType {
             name: String::from(""),
             description: String::from(""),
             sharing: ZomeEntryTypeSharing::Public,
+            validation: DnaWasm::new(),
         }
     }
 }
@@ -103,15 +191,19 @@ impl ZomeEntryType {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Zome {
     /// The name of this zome.
+    #[serde(default)]
     pub name: String,
 
     /// A description of this zome.
+    #[serde(default)]
     pub description: String,
 
     /// Configuration associated with this zome.
+    #[serde(default)]
     pub config: ZomeConfig,
 
     /// An array of entry_types associated with this zome.
+    #[serde(default)]
     pub entry_types: Vec<ZomeEntryType>,
 }
 
@@ -134,28 +226,43 @@ impl Zome {
     }
 }
 
+fn _def_empty_object() -> serde_json::Value {
+    json!({})
+}
+
+fn _def_new_uuid() -> String {
+    Uuid::new_v4().to_string()
+}
+
 /// Represents the top-level holochain dna object.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Dna {
     /// The top-level "name" of a holochain application.
+    #[serde(default)]
     pub name: String,
 
     /// The top-level "description" of a holochain application.
+    #[serde(default)]
     pub description: String,
 
     /// The semantic version of your holochain application.
+    #[serde(default)]
     pub version: String,
 
     /// A unique identifier to distinguish your holochain application.
+    #[serde(default = "_def_new_uuid")]
     pub uuid: String,
 
     /// Which version of the holochain dna spec does this represent?
+    #[serde(default)]
     pub dna_spec_version: String,
 
     /// Any arbitrary application properties can be included in this object.
+    #[serde(default = "_def_empty_object")]
     pub properties: serde_json::Value,
 
     /// An array of zomes associated with your holochain application.
+    #[serde(default)]
     pub zomes: Vec<Zome>,
 }
 
@@ -166,31 +273,81 @@ impl Default for Dna {
             name: String::from(""),
             description: String::from(""),
             version: String::from(""),
-            uuid: Uuid::new_v4().to_string(),
+            uuid: _def_new_uuid(),
             dna_spec_version: String::from("2.0"),
-            properties: serde_json::Value::Object(serde_json::map::Map::new()),
+            properties: _def_empty_object(),
             zomes: Vec::new(),
         }
     }
 }
 
 impl Dna {
-    /// Allow sane defaults for `Dna::new()`.
+    /**
+    Create a new in-memory dna structure with some default values.
+
+    # Examples
+
+    ```
+    use hc_dna::Dna;
+
+    let dna = Dna::new();
+    assert_eq!("", dna.name);
+
+    ```
+    */
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Create a new dna struct from a json string.
+    /**
+    Create a new in-memory dna struct from a json string.
+
+    # Examples
+
+    ```
+    use hc_dna::Dna;
+
+    let dna = Dna::new_from_json(r#"{
+        "name": "MyTestApp"
+    }"#).unwrap();
+
+    assert_eq!("MyTestApp", dna.name);
+    ```
+    */
     pub fn new_from_json(dna: &str) -> serde_json::Result<Self> {
         serde_json::from_str(dna)
     }
 
-    /// Generate a json string from an in-memory dna struct.
+    /**
+    Generate a json string from an in-memory dna struct.
+
+    # Examples
+
+    ```
+    use hc_dna::Dna;
+
+    let dna = Dna::new();
+    println!("json: {}", dna.to_json().unwrap());
+
+    ```
+    */
     pub fn to_json(&self) -> serde_json::Result<String> {
         serde_json::to_string(self)
     }
 
-    /// Generate a pretty-printed json string from an in-memory dna struct.
+    /**
+    Generate a pretty-printed json string from an in-memory dna struct.
+
+    # Examples
+
+    ```
+    use hc_dna::Dna;
+
+    let dna = Dna::new();
+    println!("json: {}", dna.to_json_pretty().unwrap());
+
+    ```
+    */
     pub fn to_json_pretty(&self) -> serde_json::Result<String> {
         serde_json::to_string_pretty(self)
     }
@@ -199,6 +356,8 @@ impl Dna {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static UNIT_UUID: &'static str = "00000000-0000-0000-0000-000000000000";
 
     #[test]
     fn can_parse_and_output_json() {
@@ -225,40 +384,195 @@ mod tests {
     #[test]
     fn default_value_test() {
         let mut dna = Dna {
-            uuid: String::from("00000000-0000-0000-0000-000000000000"),
+            uuid: String::from(UNIT_UUID),
             ..Default::default()
         };
         let mut zome = Zome::new();
         zome.entry_types.push(ZomeEntryType::new());
         dna.zomes.push(zome);
 
+        println!("oeu {}", dna.to_json_pretty().unwrap());
+
         let fixture = Dna::new_from_json(
             r#"{
-            "name": "",
-            "description": "",
-            "version": "",
-            "uuid": "00000000-0000-0000-0000-000000000000",
-            "dna_spec_version": "2.0",
-            "properties": {},
-            "zomes": [
-                {
-                    "name": "",
-                    "description": "",
-                    "config": {
-                        "error_handling": "throw-errors"
-                    },
-                    "entry_types": [
-                        {
-                            "name": "",
-                            "description": "",
-                            "sharing": "public"
-                        }
-                    ]
-                }
-            ]
-        }"#,
+                "name": "",
+                "description": "",
+                "version": "",
+                "uuid": "00000000-0000-0000-0000-000000000000",
+                "dna_spec_version": "2.0",
+                "properties": {},
+                "zomes": [
+                    {
+                        "name": "",
+                        "description": "",
+                        "config": {
+                            "error_handling": "throw-errors"
+                        },
+                        "entry_types": [
+                            {
+                                "name": "",
+                                "description": "",
+                                "sharing": "public"
+                            }
+                        ]
+                    }
+                ]
+            }"#,
         ).unwrap();
 
         assert_eq!(dna, fixture);
+    }
+
+    #[test]
+    fn parse_with_defaults_dna() {
+        let dna = Dna::new_from_json(
+            r#"{
+            }"#,
+        ).unwrap();
+
+        assert!(dna.uuid.len() > 0);
+    }
+
+    #[test]
+    fn parse_with_defaults_zome() {
+        let dna = Dna::new_from_json(
+            r#"{
+                "zomes": [
+                    {}
+                ]
+            }"#,
+        ).unwrap();
+
+        assert_eq!(
+            dna.zomes[0].config.error_handling,
+            ZomeConfigErrorHandling::ThrowErrors
+        )
+    }
+
+    #[test]
+    fn parse_with_defaults_entry_type() {
+        let dna = Dna::new_from_json(
+            r#"{
+                "zomes": [
+                    {
+                        "entry_types": [
+                            {}
+                        ]
+                    }
+                ]
+            }"#,
+        ).unwrap();
+
+        assert_eq!(
+            dna.zomes[0].entry_types[0].sharing,
+            ZomeEntryTypeSharing::Public
+        );
+    }
+
+    #[test]
+    fn parse_wasm() {
+        let dna = Dna::new_from_json(
+            r#"{
+                "zomes": [
+                    {
+                        "entry_types": [
+                            {
+                                "validation": {
+                                    "code": "AAECAw=="
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }"#,
+        ).unwrap();
+
+        assert_eq!(
+            vec![0, 1, 2, 3],
+            dna.zomes[0].entry_types[0].validation.code
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn parse_fail_if_bad_type_dna() {
+        Dna::new_from_json(
+            r#"{
+                "name": 42
+            }"#,
+        ).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn parse_fail_if_bad_type_zome() {
+        Dna::new_from_json(
+            r#"{
+                "zomes": [
+                    {
+                        "name": 42
+                    }
+                ]
+            }"#,
+        ).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn parse_fail_if_bad_type_entry_type() {
+        Dna::new_from_json(
+            r#"{
+                "zomes": [
+                    {
+                        "entry_types": [
+                            {
+                                "name": 42
+                            }
+                        ]
+                    }
+                ]
+            }"#,
+        ).unwrap();
+    }
+
+    #[test]
+    fn parse_accepts_arbitrary_dna_properties() {
+        let dna = Dna::new_from_json(
+            r#"{
+                "properties": {
+                    "str": "hello",
+                    "num": 3.14159,
+                    "bool": true,
+                    "null": null,
+                    "arr": [1, 2],
+                    "obj": {"a": 1, "b": 2}
+                }
+            }"#,
+        ).unwrap();
+
+        let props = dna.properties.as_object().unwrap();
+
+        assert_eq!("hello", props.get("str").unwrap().as_str().unwrap());
+        assert_eq!(3.14159, props.get("num").unwrap().as_f64().unwrap());
+        assert_eq!(true, props.get("bool").unwrap().as_bool().unwrap());
+        assert!(props.get("null").unwrap().is_null());
+        assert_eq!(
+            1_i64,
+            props.get("arr").unwrap().as_array().unwrap()[0]
+                .as_i64()
+                .unwrap()
+        );
+        assert_eq!(
+            1_i64,
+            props
+                .get("obj")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("a")
+                .unwrap()
+                .as_i64()
+                .unwrap()
+        );
     }
 }

--- a/hc_dna/src/wasm.rs
+++ b/hc_dna/src/wasm.rs
@@ -1,0 +1,80 @@
+/*!
+hc_dna::wasm is a module for managing webassembly code
+ - within the in-memory dna struct
+ - and serialized to json
+*/
+
+extern crate base64;
+extern crate serde;
+
+use serde::de::{Deserializer, Visitor};
+use serde::ser::Serializer;
+
+/**
+Private helper for converting binary WebAssembly into base64 serialized string.
+*/
+fn _vec_u8_to_b64_str<S>(data: &Vec<u8>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let b64 = base64::encode(data);
+    s.serialize_str(&b64)
+}
+
+/**
+Private helper for converting base64 string into binary WebAssembly.
+*/
+fn _b64_str_to_vec_u8<'de, D>(d: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    /// visitor struct needed for serde deserialization
+    struct Z;
+
+    impl<'de> Visitor<'de> for Z {
+        type Value = Vec<u8>;
+
+        /// we only want to accept strings
+        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            formatter.write_str("string")
+        }
+
+        /// if we get a string, try to base64 decode into binary
+        fn visit_str<E>(self, value: &str) -> Result<Vec<u8>, E>
+        where
+            E: serde::de::Error,
+        {
+            match base64::decode(value) {
+                Ok(v) => Ok(v),
+                Err(_) => Err(serde::de::Error::custom(String::from("nope"))),
+            }
+        }
+    }
+
+    d.deserialize_any(Z)
+}
+
+/// Represents web assembly code.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct DnaWasm {
+    /// The actual binary WebAssembly bytecode goes here.
+    #[serde(serialize_with = "_vec_u8_to_b64_str", deserialize_with = "_b64_str_to_vec_u8")]
+    pub code: Vec<u8>,
+    // using a struct gives us the flexibility to extend it later
+    // should we need additional properties, like:
+    //pub filename: String,
+}
+
+impl Default for DnaWasm {
+    /// Provide defaults for wasm entries in dna structs.
+    fn default() -> Self {
+        DnaWasm { code: vec![] }
+    }
+}
+
+impl DnaWasm {
+    /// Allow sane defaults for `DnaWasm::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}

--- a/hc_dna/src/wasm.rs
+++ b/hc_dna/src/wasm.rs
@@ -46,7 +46,7 @@ where
         {
             match base64::decode(value) {
                 Ok(v) => Ok(v),
-                Err(_) => Err(serde::de::Error::custom(String::from("nope"))),
+                Err(e) => Err(serde::de::Error::custom(e)),
             }
         }
     }

--- a/hc_dna/src/zome/capabilities.rs
+++ b/hc_dna/src/zome/capabilities.rs
@@ -20,9 +20,9 @@ pub enum Membrane {
 }
 
 impl Default for Membrane {
-    /// Default zome capability membrane is "public"
+    /// Default zome capability membrane is "agent"
     fn default() -> Self {
-        Membrane::Public
+        Membrane::Agent
     }
 }
 
@@ -38,7 +38,7 @@ impl Default for CapabilityType {
     /// Defaults for a "capability" sub-object on a "zome" "capabilities" object.
     fn default() -> Self {
         CapabilityType {
-            membrane: Membrane::Public,
+            membrane: Membrane::Agent,
         }
     }
 }
@@ -124,7 +124,7 @@ mod tests {
             r#"{
                 "name": "test",
                 "capability": {
-                    "membrane": "public"
+                    "membrane": "agent"
                 },
                 "fn_declarations": [
                     {

--- a/hc_dna/src/zome/capabilities.rs
+++ b/hc_dna/src/zome/capabilities.rs
@@ -1,0 +1,149 @@
+/*!
+hc_dna::zome::capabilities is a set of structs for working with holochain dna.
+*/
+
+extern crate serde_json;
+
+use wasm::DnaWasm;
+
+/// Enum for Zome Capability "membrane" property.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Membrane {
+    #[serde(rename = "public")]
+    Public,
+    #[serde(rename = "agent")]
+    Agent,
+    #[serde(rename = "api-key")]
+    ApiKey,
+    #[serde(rename = "zome")]
+    Zome,
+}
+
+impl Default for Membrane {
+    /// Default zome capability membrane is "public"
+    fn default() -> Self {
+        Membrane::Public
+    }
+}
+
+/// Represents the "capability" sub-object on a "zome" "capabilities" object.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct CapabilityType {
+    /// How visibility should be handled for this capability.
+    #[serde(default)]
+    pub membrane: Membrane,
+}
+
+impl Default for CapabilityType {
+    /// Defaults for a "capability" sub-object on a "zome" "capabilities" object.
+    fn default() -> Self {
+        CapabilityType {
+            membrane: Membrane::Public,
+        }
+    }
+}
+
+impl CapabilityType {
+    /// Allow sane defaults for `CapabilityType::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Represents a zome "fn_declarations" object.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct FnDeclaration {
+    /// The name of this fn declaration.
+    #[serde(default)]
+    pub name: String,
+    // TODO - signature
+}
+
+impl Default for FnDeclaration {
+    /// Defaults for a "fn_declarations" object.
+    fn default() -> Self {
+        FnDeclaration {
+            name: String::from(""),
+        }
+    }
+}
+
+impl FnDeclaration {
+    /// Allow sane defaults for `FnDecrlaration::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Represents an individual object in the "zome" "capabilities" array.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Capability {
+    /// The name of this capability.
+    #[serde(default)]
+    pub name: String,
+
+    /// "capability" sub-object
+    #[serde(default)]
+    pub capability: CapabilityType,
+
+    /// "fn_declarations" array
+    #[serde(default)]
+    pub fn_declarations: Vec<FnDeclaration>,
+
+    /// Validation code for this entry_type.
+    #[serde(default)]
+    pub code: DnaWasm,
+}
+
+impl Default for Capability {
+    /// Provide defaults for a "zome"s "capabilities" object.
+    fn default() -> Self {
+        Capability {
+            name: String::from(""),
+            capability: CapabilityType::new(),
+            fn_declarations: Vec::new(),
+            code: DnaWasm::new(),
+        }
+    }
+}
+
+impl Capability {
+    /// Allow sane defaults for `Capability::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_and_compare() {
+        let fixture: Capability = serde_json::from_str(
+            r#"{
+                "name": "test",
+                "capability": {
+                    "membrane": "public"
+                },
+                "fn_declarations": [
+                    {
+                        "name": "test"
+                    }
+                ],
+                "code": {
+                    "code": "AAECAw=="
+                }
+            }"#,
+        ).unwrap();
+
+        let mut cap = Capability::new();
+        cap.name = String::from("test");
+        let mut fn_dec = FnDeclaration::new();
+        fn_dec.name = String::from("test");
+        cap.fn_declarations.push(fn_dec);
+        cap.code.code = vec![0, 1, 2, 3];
+
+        assert_eq!(fixture, cap);
+    }
+}

--- a/hc_dna/src/zome/entry_types.rs
+++ b/hc_dna/src/zome/entry_types.rs
@@ -1,0 +1,146 @@
+/*!
+hc_dna::zome::entry_types is a set of structs for working with holochain dna.
+*/
+
+extern crate serde_json;
+
+use wasm::DnaWasm;
+
+/// Enum for Zome EntryType "sharing" property.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Sharing {
+    #[serde(rename = "public")]
+    Public,
+    #[serde(rename = "private")]
+    Private,
+    #[serde(rename = "encrypted")]
+    Encrypted,
+}
+
+impl Default for Sharing {
+    /// Default zome entry_type sharing is "public"
+    fn default() -> Self {
+        Sharing::Public
+    }
+}
+
+/// An individual object in a "links_to" array.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct LinksTo {
+    /// The target_type of this links_to entry
+    #[serde(default)]
+    pub target_type: String,
+
+    /// The tag of this links_to entry
+    #[serde(default)]
+    pub tag: String,
+
+    /// Validation code for this links_to.
+    #[serde(default)]
+    pub validation: DnaWasm,
+}
+
+impl Default for LinksTo {
+    /// Provide defaults for a "links_to" object.
+    fn default() -> Self {
+        LinksTo {
+            target_type: String::from(""),
+            tag: String::from(""),
+            validation: DnaWasm::new(),
+        }
+    }
+}
+
+impl LinksTo {
+    /// Allow sane defaults for `LinksTo::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Represents an individual object in the "zome" "entry_types" array.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct EntryType {
+    /// The name of this entry type.
+    #[serde(default)]
+    pub name: String,
+
+    /// A description of this entry type.
+    #[serde(default)]
+    pub description: String,
+
+    /// The sharing model of this entry type (public, private, encrypted).
+    #[serde(default)]
+    pub sharing: Sharing,
+
+    /// Validation code for this entry_type.
+    #[serde(default)]
+    pub validation: DnaWasm,
+
+    /// An array of entry_types associated with this zome.
+    #[serde(default)]
+    pub links_to: Vec<LinksTo>,
+}
+
+impl Default for EntryType {
+    /// Provide defaults for a "zome"s "entry_types" object.
+    fn default() -> Self {
+        EntryType {
+            name: String::from(""),
+            description: String::from(""),
+            sharing: Sharing::Public,
+            validation: DnaWasm::new(),
+            links_to: Vec::new(),
+        }
+    }
+}
+
+impl EntryType {
+    /// Allow sane defaults for `EntryType::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_and_compare() {
+        let fixture: EntryType = serde_json::from_str(
+            r#"{
+                "name": "test",
+                "description": "test",
+                "validation": {
+                    "code": "AAECAw=="
+                },
+                "sharing": "public",
+                "links_to": [
+                    {
+                        "target_type": "test",
+                        "tag": "test",
+                        "validation": {
+                            "code": "AAECAw=="
+                        }
+                    }
+                ]
+            }"#,
+        ).unwrap();
+
+        let mut entry = EntryType::new();
+        entry.name = String::from("test");
+        entry.description = String::from("test");
+        entry.validation.code = vec![0, 1, 2, 3];
+        entry.sharing = Sharing::Public;
+
+        let mut link = LinksTo::new();
+        link.target_type = String::from("test");
+        link.tag = String::from("test");
+        link.validation.code = vec![0, 1, 2, 3];
+
+        entry.links_to.push(link);
+
+        assert_eq!(fixture, entry);
+    }
+}

--- a/hc_dna/src/zome/mod.rs
+++ b/hc_dna/src/zome/mod.rs
@@ -1,0 +1,117 @@
+/*!
+hc_dna::zome is a set of structs for working with holochain dna.
+*/
+
+extern crate serde_json;
+
+pub mod capabilities;
+pub mod entry_types;
+
+/// Enum for "zome" "config" "error_handling" property.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum ErrorHandling {
+    #[serde(rename = "throw-errors")]
+    ThrowErrors,
+}
+
+impl Default for ErrorHandling {
+    /// Default zome config error_handling is "throw-errors"
+    fn default() -> Self {
+        ErrorHandling::ThrowErrors
+    }
+}
+
+/// Represents the "config" object on a "zome".
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Config {
+    /// How errors should be handled within this zome.
+    #[serde(default)]
+    pub error_handling: ErrorHandling,
+}
+
+impl Default for Config {
+    /// Provide defaults for the "zome" "config" object.
+    fn default() -> Self {
+        Config {
+            error_handling: ErrorHandling::ThrowErrors,
+        }
+    }
+}
+
+impl Config {
+    /// Allow sane defaults for `Config::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+/// Represents an individual "zome".
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct Zome {
+    /// The name of this zome.
+    #[serde(default)]
+    pub name: String,
+
+    /// A description of this zome.
+    #[serde(default)]
+    pub description: String,
+
+    /// Configuration associated with this zome.
+    #[serde(default)]
+    pub config: Config,
+
+    /// An array of entry_types associated with this zome.
+    #[serde(default)]
+    pub entry_types: Vec<entry_types::EntryType>,
+
+    /// An array of capabilities associated with this zome.
+    #[serde(default)]
+    pub capabilities: Vec<capabilities::Capability>,
+}
+
+impl Default for Zome {
+    /// Provide defaults for an individual "zome".
+    fn default() -> Self {
+        Zome {
+            name: String::from(""),
+            description: String::from(""),
+            config: Config::new(),
+            entry_types: Vec::new(),
+            capabilities: Vec::new(),
+        }
+    }
+}
+
+impl Zome {
+    /// Allow sane defaults for `Zome::new()`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_and_compare() {
+        let fixture: Zome = serde_json::from_str(
+            r#"{
+                "name": "test",
+                "description": "test",
+                "config": {
+                    "error_handling": "throw-errors"
+                },
+                "entry_types": [],
+                "capabilities": []
+            }"#,
+        ).unwrap();
+
+        let mut zome = Zome::new();
+        zome.name = String::from("test");
+        zome.description = String::from("test");
+        zome.config.error_handling = ErrorHandling::ThrowErrors;
+
+        assert_eq!(fixture, zome);
+    }
+}

--- a/hc_dna/src/zome/mod.rs
+++ b/hc_dna/src/zome/mod.rs
@@ -56,7 +56,11 @@ pub struct Zome {
     #[serde(default)]
     pub description: String,
 
-    /// Configuration associated with this zome.
+    /**
+    Configuration associated with this zome.
+    Note, this should perhaps be a more free-form serde_json::Value,
+    "throw-errors" may not make sense for wasm, or other ribosome types.
+    */
     #[serde(default)]
     pub config: Config,
 

--- a/hc_dna_c_binding/include/hc_dna_c_binding.h
+++ b/hc_dna_c_binding/include/hc_dna_c_binding.h
@@ -13,7 +13,21 @@ extern Dna *hc_dna_create_from_json(const char *buf);
 extern void hc_dna_free(Dna *ptr);
 extern char *hc_dna_to_json(const Dna *ptr);
 extern void hc_dna_string_free(char *s);
+
+extern char *hc_dna_get_name(const Dna *ptr);
+extern void hc_dna_set_name(const Dna *ptr, const char *val);
+
+extern char *hc_dna_get_description(const Dna *ptr);
+extern void hc_dna_set_description(const Dna *ptr, const char *val);
+
+extern char *hc_dna_get_version(const Dna *ptr);
+extern void hc_dna_set_version(const Dna *ptr, const char *val);
+
+extern char *hc_dna_get_uuid(const Dna *ptr);
+extern void hc_dna_set_uuid(const Dna *ptr, const char *val);
+
 extern char *hc_dna_get_dna_spec_version(const Dna *ptr);
+extern void hc_dna_set_dna_spec_version(const Dna *ptr, const char *val);
 
 #ifdef __cplusplus
 }

--- a/hc_dna_c_binding/src/lib.rs
+++ b/hc_dna_c_binding/src/lib.rs
@@ -1,8 +1,10 @@
-//! This crate is an ffi wrapper to provide a c-compatible dna library.
-//!
-//! Remember to free all dna objects and returned strings.
-//!
-//! See the associated Qt unit tests in the c_binding_tests directory.
+/*!
+This crate is an ffi wrapper to provide a c-compatible dna library.
+
+Remember to free all dna objects and returned strings.
+
+See the associated Qt unit tests in the c_binding_tests directory.
+*/
 
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -24,6 +26,7 @@ pub extern "C" fn hc_dna_create() -> *mut Dna {
 pub extern "C" fn hc_dna_create_from_json(buf: *const c_char) -> *mut Dna {
     match catch_unwind(|| {
         let json = unsafe { CStr::from_ptr(buf).to_string_lossy().into_owned() };
+
         let dna = match Dna::new_from_json(&json) {
             Ok(d) => d,
             Err(_) => return std::ptr::null_mut(),
@@ -85,30 +88,78 @@ pub extern "C" fn hc_dna_string_free(s: *mut c_char) {
     }).unwrap_or(());
 }
 
-#[no_mangle]
-pub extern "C" fn hc_dna_get_dna_spec_version(ptr: *const Dna) -> *mut c_char {
-    match catch_unwind(|| {
-        let dna = unsafe {
-            assert!(!ptr.is_null());
-            &*ptr
-        };
-        let version = dna.dna_spec_version.clone();
+/**
+This macro takes care boilerplate for getting string accessors over ffi.
+This is not exported, it is only meant to be used internally.
+*/
+macro_rules! _xa_str {
+    ($struct:ident, $prop:ident, $getname:ident, $setname:ident) => {
+        #[no_mangle]
+        pub extern "C" fn $getname(ptr: *const $struct) -> *mut c_char {
+            match catch_unwind(|| {
+                let arg = unsafe {
+                    if ptr.is_null() {
+                        return std::ptr::null_mut();
+                    }
+                    &*ptr
+                };
 
-        let res = match CString::new(version) {
-            Ok(s) => s,
-            Err(_) => return std::ptr::null_mut(),
-        };
+                let res = arg.$prop.clone();
 
-        res.into_raw()
-    }) {
-        Ok(r) => r,
-        Err(_) => std::ptr::null_mut(),
-    }
+                let res = match CString::new(res) {
+                    Ok(s) => s,
+                    Err(_) => return std::ptr::null_mut(),
+                };
+
+                res.into_raw()
+            }) {
+                Ok(r) => r,
+                Err(_) => std::ptr::null_mut(),
+            }
+        }
+
+        #[no_mangle]
+        pub extern "C" fn $setname(ptr: *mut $struct, val: *const c_char) {
+            catch_unwind(|| {
+                let arg = unsafe {
+                    if ptr.is_null() {
+                        return;
+                    }
+                    &mut *ptr
+                };
+                let val = unsafe { CStr::from_ptr(val).to_string_lossy().into_owned() };
+                arg.$prop = val;
+            }).unwrap_or(());
+        }
+    };
 }
+
+_xa_str!(Dna, name, hc_dna_get_name, hc_dna_set_name);
+
+_xa_str!(
+    Dna,
+    description,
+    hc_dna_get_description,
+    hc_dna_set_description
+);
+
+_xa_str!(Dna, version, hc_dna_get_version, hc_dna_set_version);
+
+_xa_str!(Dna, uuid, hc_dna_get_uuid, hc_dna_set_uuid);
+
+_xa_str!(
+    Dna,
+    dna_spec_version,
+    hc_dna_get_dna_spec_version,
+    hc_dna_set_dna_spec_version
+);
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // comprehensive tests are handled in the C++ Qt unit test framework
+    // there are a couple here to make iterating within this file faster
 
     #[test]
     fn serialize_and_deserialize() {
@@ -125,5 +176,22 @@ mod tests {
         hc_dna_string_free(version_raw);
 
         hc_dna_free(dna2);
+    }
+
+    #[test]
+    fn can_set_and_get_value() {
+        let val = CString::new("test").unwrap();
+
+        let dna = hc_dna_create();
+
+        hc_dna_set_name(dna, val.as_ptr());
+
+        let res_raw = hc_dna_get_name(dna);
+        let res_str = unsafe { CStr::from_ptr(res_raw).to_string_lossy().into_owned() };
+
+        assert_eq!(val.to_string_lossy(), res_str);
+
+        hc_dna_string_free(res_raw);
+        hc_dna_free(dna);
     }
 }


### PR DESCRIPTION
RESOLVES https://github.com/holochain/org/issues/58

- More complete dna representation
- Deserialization defaults to streamline json parsing
- Entry-Order preserving json objects for consistency
- Better modularization
- WebAssembly serialization (Vec<u8> in memory, base64 string in json)
- Much more complete testing

The c_binding is still mostly just a stub, but I got a boilerplate macro working to make defining accessors far more DRY.