### PR TITLE
validate pushes and support hash lookups in source chain

### DIFF
--- a/hc_core/src/common/entry.rs
+++ b/hc_core/src/common/entry.rs
@@ -88,3 +88,31 @@ impl Header {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Hash {}
+
+#[cfg(test)]
+mod tests {
+    use super::Entry;
+    use super::Header;
+
+    #[test]
+    fn new_entry() {
+        let c = String::from("foo");
+        let e = Entry::new(&c);
+
+        assert_eq!(e.content(), c);
+        assert_ne!(e.hash(), 0);
+        assert!(e.validate());
+    }
+
+    #[test]
+    fn new_header() {
+        let e = Entry::new(&String::from("foo"));
+        let h = Header::new(None, &e);
+
+        assert_eq!(h.entry(), e.hash());
+        assert_eq!(h.previous(), None);
+        assert_ne!(h.hash(), 0);
+        assert!(h.validate());
+    }
+
+}

--- a/hc_core/src/common/entry.rs
+++ b/hc_core/src/common/entry.rs
@@ -32,6 +32,10 @@ impl Entry {
     pub fn content(&self) -> String {
         self.content.clone()
     }
+
+    pub fn validate(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -73,6 +77,10 @@ impl Header {
 
     pub fn hash(&self) -> u64 {
         self.hash
+    }
+
+    pub fn validate(&self) -> bool {
+        true
     }
 }
 

--- a/hc_core/src/common/entry.rs
+++ b/hc_core/src/common/entry.rs
@@ -34,6 +34,7 @@ impl Entry {
     }
 
     pub fn validate(&self) -> bool {
+        // always valid iff immutable and new() enforces validity
         true
     }
 }
@@ -80,6 +81,7 @@ impl Header {
     }
 
     pub fn validate(&self) -> bool {
+        // always valid iff immutable and new() enforces validity
         true
     }
 }

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -39,8 +39,10 @@ impl super::SourceChain for SourceChain {
     // @see https://github.com/holochain/holochain-rust/issues/31
     fn push(&mut self, pair: &super::Pair) {
 
+        let previous_hash_lookup = pair.header.previous().and_then(|h| self.get(h));
+
         // smoke test this pair in isolation, and check the hash reference against the top pair
-        if !(pair.validate() && self.pairs.first() == pair.header.previous().and_then(|h| self.get(h)).as_ref()) {
+        if !(pair.validate() && self.pairs.first() == previous_hash_lookup.as_ref()) {
             // we panic because no code path should attempt to append an invalid pair
             panic!("attempted to push an invalid pair for this source chain");
         }

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -41,9 +41,18 @@ impl super::SourceChain for SourceChain {
             None => None,
         };
 
+        // smoke test this pair in isolation, and check the hash reference against the top pair
         if !(pair.validate() && self.pairs.first() == previous_pair.as_ref()) {
             // we panic because no code path should attempt to append an invalid pair
             panic!("attempted to push an invalid pair for this source chain");
+        }
+
+        // dry run an insertion against a clone and validate the outcome
+        let mut validation_chain = self.clone();
+        validation_chain.pairs.insert(0, pair.clone());
+        if !validation_chain.validate() {
+            // we panic because no code path should ever invalidate the chain
+            panic!("adding this pair would invalidate the source chain");
         }
 
         // @TODO - inserting at the start of a vector is O(n), some other collection could be O(1)

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -15,6 +15,7 @@ impl SourceChain {
 impl IntoIterator for SourceChain {
     type Item = super::Pair;
     type IntoIter = std::vec::IntoIter<super::Pair>;
+    
     fn into_iter(self) -> Self::IntoIter {
         self.pairs.into_iter()
     }
@@ -32,6 +33,7 @@ impl<'a> IntoIterator for &'a SourceChain {
 
 // basic SouceChain trait
 impl super::SourceChain for SourceChain {
+
     // appends the current pair to the top of the chain
     // @TODO - appending pairs should fail if hashes do not line up
     // @see https://github.com/holochain/holochain-rust/issues/31
@@ -56,23 +58,28 @@ impl super::SourceChain for SourceChain {
         self.pairs.insert(0, pair.clone())
 
     }
+
     // returns an iterator referencing pairs from top (most recent) to bottom (genesis)
     fn iter(&self) -> std::slice::Iter<super::Pair> {
         self.pairs.iter()
     }
+
     fn validate(&self) -> bool {
         self.pairs.iter().all(|p| p.validate())
     }
+
     fn get(&self, header_hash: u64) -> Option<super::Pair> {
         // @TODO - this is a slow way to do a lookup
         // @see https://github.com/holochain/holochain-rust/issues/50
         self.pairs.clone().into_iter().find(|p| p.header.hash() == header_hash)
     }
+
     fn get_entry(&self, entry_hash: u64) -> Option<super::Pair> {
         // @TODO - this is a slow way to do a lookup
         // @see https://github.com/holochain/holochain-rust/issues/50
         self.pairs.clone().into_iter().find(|p| p.entry.hash() == entry_hash)
     }
+
 }
 
 #[cfg(test)]

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -15,7 +15,7 @@ impl SourceChain {
 impl IntoIterator for SourceChain {
     type Item = super::Pair;
     type IntoIter = std::vec::IntoIter<super::Pair>;
-    
+
     fn into_iter(self) -> Self::IntoIter {
         self.pairs.into_iter()
     }
@@ -59,7 +59,6 @@ impl super::SourceChain for SourceChain {
 
     }
 
-    // returns an iterator referencing pairs from top (most recent) to bottom (genesis)
     fn iter(&self) -> std::slice::Iter<super::Pair> {
         self.pairs.iter()
     }

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -36,13 +36,9 @@ impl super::SourceChain for SourceChain {
     // @TODO - appending pairs should fail if hashes do not line up
     // @see https://github.com/holochain/holochain-rust/issues/31
     fn push(&mut self, pair: &super::Pair) {
-        let previous_pair = match pair.header.previous() {
-            Some(h) => self.get(h),
-            None => None,
-        };
 
         // smoke test this pair in isolation, and check the hash reference against the top pair
-        if !(pair.validate() && self.pairs.first() == previous_pair.as_ref()) {
+        if !(pair.validate() && self.pairs.first() == pair.header.previous().and_then(|h| self.get(h)).as_ref()) {
             // we panic because no code path should attempt to append an invalid pair
             panic!("attempted to push an invalid pair for this source chain");
         }
@@ -58,6 +54,7 @@ impl super::SourceChain for SourceChain {
         // @TODO - inserting at the start of a vector is O(n), some other collection could be O(1)
         // @see https://github.com/holochain/holochain-rust/issues/35
         self.pairs.insert(0, pair.clone())
+
     }
     // returns an iterator referencing pairs from top (most recent) to bottom (genesis)
     fn iter(&self) -> std::slice::Iter<super::Pair> {

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -103,6 +103,7 @@ mod tests {
         let p1 = test_pair(None, "foo");
         let p2 = test_pair(Some(&p1), "bar");
 
+        // for valid pairs its truetles all the way down...
         let mut chain = super::SourceChain::new();
         assert!(chain.validate());
         chain.push(&p1);

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -57,7 +57,7 @@ impl super::SourceChain for SourceChain {
 
         // @TODO - inserting at the start of a vector is O(n), some other collection could be O(1)
         // @see https://github.com/holochain/holochain-rust/issues/35
-        self.pairs.insert(0, pair.clone());
+        self.pairs.insert(0, pair.clone())
     }
     // returns an iterator referencing pairs from top (most recent) to bottom (genesis)
     fn iter(&self) -> std::slice::Iter<super::Pair> {

--- a/hc_core/src/source_chain/memory/mod.rs
+++ b/hc_core/src/source_chain/memory/mod.rs
@@ -64,17 +64,17 @@ impl super::SourceChain for SourceChain {
         self.pairs.iter()
     }
     fn validate(&self) -> bool {
-        self.pairs.iter().fold(true, |acc, p| acc && p.validate())
+        self.pairs.iter().all(|p| p.validate())
     }
     fn get(&self, header_hash: u64) -> Option<super::Pair> {
         // @TODO - this is a slow way to do a lookup
         // @see https://github.com/holochain/holochain-rust/issues/50
-        self.pairs.clone().into_iter().filter(|p| p.header.hash() == header_hash).next()
+        self.pairs.clone().into_iter().find(|p| p.header.hash() == header_hash)
     }
     fn get_entry(&self, entry_hash: u64) -> Option<super::Pair> {
         // @TODO - this is a slow way to do a lookup
         // @see https://github.com/holochain/holochain-rust/issues/50
-        self.pairs.clone().into_iter().filter(|p| p.entry.hash() == entry_hash).next()
+        self.pairs.clone().into_iter().find(|p| p.entry.hash() == entry_hash)
     }
 }
 

--- a/hc_core/src/source_chain/mod.rs
+++ b/hc_core/src/source_chain/mod.rs
@@ -25,15 +25,19 @@ impl Pair {
     pub fn entry(&self) -> Entry {
         self.entry.clone()
     }
+
+    pub fn validate(&self) -> bool {
+        self.header.validate() && self.entry.validate()
+    }
 }
 
-pub trait SourceChain: IntoIterator + std::ops::Index<u64> {
+pub trait SourceChain: IntoIterator {
     // appends the given pair to the source chain, if doing so results in a new valid chain
-    // assumes the chain is currently valid
     // returns the potentially updated chain
-    fn push(&mut self, &Pair) -> &Self;
+    fn push(&mut self, &Pair);
     fn iter(&self) -> std::slice::Iter<Pair>;
     fn validate(&self) -> bool;
+    fn get(&self, k: u64) -> Option<Pair>;
 }
 
 #[cfg(test)]

--- a/hc_core/src/source_chain/mod.rs
+++ b/hc_core/src/source_chain/mod.rs
@@ -38,6 +38,7 @@ pub trait SourceChain: IntoIterator {
     fn iter(&self) -> std::slice::Iter<Pair>;
     fn validate(&self) -> bool;
     fn get(&self, k: u64) -> Option<Pair>;
+    fn get_entry(&self, k:u64) -> Option<Pair>;
 }
 
 #[cfg(test)]

--- a/hc_core/src/source_chain/mod.rs
+++ b/hc_core/src/source_chain/mod.rs
@@ -43,15 +43,19 @@ impl Pair {
 
 pub trait SourceChain: IntoIterator {
 
-    // append a pair to the source chain if the pair and new chain are both valid, else panic
+    /// append a pair to the source chain if the pair and new chain are both valid, else panic
     fn push(&mut self, &Pair);
 
+    /// returns an iterator referencing pairs from top (most recent) to bottom (genesis)
     fn iter(&self) -> std::slice::Iter<Pair>;
 
+    /// returns true if system and dApp validation is successful
     fn validate(&self) -> bool;
-    
+
+    /// returns a pair for a given header hash
     fn get(&self, k: u64) -> Option<Pair>;
 
+    /// returns a pair for a given entry hash
     fn get_entry(&self, k:u64) -> Option<Pair>;
 
 }

--- a/hc_core/src/source_chain/mod.rs
+++ b/hc_core/src/source_chain/mod.rs
@@ -27,9 +27,13 @@ impl Pair {
     }
 }
 
-pub trait SourceChain: IntoIterator {
-    fn push(&mut self, &Pair);
+pub trait SourceChain: IntoIterator + std::ops::Index<u64> {
+    // appends the given pair to the source chain, if doing so results in a new valid chain
+    // assumes the chain is currently valid
+    // returns the potentially updated chain
+    fn push(&mut self, &Pair) -> &Self;
     fn iter(&self) -> std::slice::Iter<Pair>;
+    fn validate(&self) -> bool;
 }
 
 #[cfg(test)]

--- a/hc_core/src/source_chain/mod.rs
+++ b/hc_core/src/source_chain/mod.rs
@@ -11,6 +11,7 @@ pub struct Pair {
 }
 
 impl Pair {
+
     pub fn new(header: &Header, entry: &Entry) -> Pair {
         let p = Pair {
             header: header.clone(),
@@ -37,15 +38,22 @@ impl Pair {
         self.header.validate() && self.entry.validate() &&
         self.header.entry() == self.entry.hash()
     }
+
 }
 
 pub trait SourceChain: IntoIterator {
+
     // append a pair to the source chain if the pair and new chain are both valid, else panic
     fn push(&mut self, &Pair);
+
     fn iter(&self) -> std::slice::Iter<Pair>;
+
     fn validate(&self) -> bool;
+    
     fn get(&self, k: u64) -> Option<Pair>;
+
     fn get_entry(&self, k:u64) -> Option<Pair>;
+
 }
 
 #[cfg(test)]

--- a/hc_core/src/source_chain/mod.rs
+++ b/hc_core/src/source_chain/mod.rs
@@ -12,10 +12,17 @@ pub struct Pair {
 
 impl Pair {
     pub fn new(header: &Header, entry: &Entry) -> Pair {
-        Pair {
+        let p = Pair {
             header: header.clone(),
             entry: entry.clone(),
-        }
+        };
+
+        if !p.validate() {
+            // we panic as no code path should attempt to create invalid pairs
+            panic!("attempted to create an invalid pair");
+        };
+
+        p
     }
 
     pub fn header(&self) -> Header {
@@ -27,13 +34,13 @@ impl Pair {
     }
 
     pub fn validate(&self) -> bool {
-        self.header.validate() && self.entry.validate()
+        self.header.validate() && self.entry.validate() &&
+        self.header.entry() == self.entry.hash()
     }
 }
 
 pub trait SourceChain: IntoIterator {
-    // appends the given pair to the source chain, if doing so results in a new valid chain
-    // returns the potentially updated chain
+    // append a pair to the source chain if the pair and new chain are both valid, else panic
     fn push(&mut self, &Pair);
     fn iter(&self) -> std::slice::Iter<Pair>;
     fn validate(&self) -> bool;
@@ -57,5 +64,43 @@ mod tests {
         let p1 = Pair::new(&h1, &e1);
         assert_eq!(e1, p1.entry());
         assert_eq!(h1, p1.header());
+    }
+
+    #[test]
+    fn header() {
+        let e1 = Entry::new(&String::from("foo"));
+        let h1 = Header::new(None, &e1);
+        let p1 = Pair::new(&h1, &e1);
+
+        assert_eq!(h1, p1.header());
+    }
+
+    #[test]
+    fn entry() {
+        let e1 = Entry::new(&String::from("bar"));
+        let h1 = Header::new(None, &e1);
+        let p1 = Pair::new(&h1, &e1);
+
+        assert_eq!(e1, p1.entry());
+    }
+
+    #[test]
+    fn validate() {
+        let e1 = Entry::new(&String::from("bar"));
+        let h1 = Header::new(None, &e1);
+        let p1 = Pair::new(&h1, &e1);
+
+        assert!(p1.validate());
+    }
+
+    #[test]
+    #[should_panic(expected = "attempted to create an invalid pair")]
+    fn invalidate() {
+        let e1 = Entry::new(&String::from("foo"));
+        let e2 = Entry::new(&String::from("bar"));
+        let h1 = Header::new(None, &e1);
+
+        // header/entry mismatch, must panic!
+        Pair::new(&h1, &e2);
     }
 }


### PR DESCRIPTION
fixes #30 
fixes #31 

changes:

- validation for headers/entries is simply `true` atm, to be revisited in #32
- `push` to a source chain now validates the pair, that the header references the old top pair, and the whole proposed new chain passes validation
- added `validate` fn for chains, pairs, entries, headers
- added `get` and `get_entry` to chain to lookup pairs by header/entry hash respectively
- tests
- pairs now validate that the header entry hash references the hash of the entry in the pair
- pairs now validate that their headers and entries are valid

followup:

- #52