### PR TITLE
Upgraded docker and Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 dist: trusty
 
 install:
-  - docker pull sphinxc0re/holochain-rust:develop
+  - docker pull holochain/holochain-rust:develop
 
 script:
   . docker/run-test

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ C_BINDING_CLEAN = $(foreach dir,$(C_BINDING_DIRS),$(dir)Makefile $(dir).qmake.st
 # apply formatting / style guidelines, and build the rust project
 main:
 	$(CARGO) +$(TOOLS_NIGHTLY) fmt -- --check
-	$(CARGO) +$(TOOLS_NIGHTLY) clippy
+	$(CARGO) +$(TOOLS_NIGHTLY) clippy -- -A needless_return
 	$(CARGO) build --all
 
 # list all our found "C" binding tests

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 all: main
 
-PINNED_NIGHTLY ?= nightly-2018-06-01
+CARGO = cargo $(CARGO_ARGS)
 
 # list all the "C" binding tests that have been written
 C_BINDING_DIRS = $(sort $(dir $(wildcard c_binding_tests/*/)))
@@ -28,9 +28,9 @@ C_BINDING_CLEAN = $(foreach dir,$(C_BINDING_DIRS),$(dir)Makefile $(dir).qmake.st
 
 # apply formatting / style guidelines, and build the rust project
 main:
-	cargo +$(PINNED_NIGHTLY) fmt -- --check
-	cargo +$(PINNED_NIGHTLY) clippy -- -A needless_return
-	cargo build --verbose --all
+	$(CARGO) +$(TOOLS_NIGHTLY) fmt -- --check
+	$(CARGO) +$(TOOLS_NIGHTLY) clippy
+	$(CARGO) build --all
 
 # list all our found "C" binding tests
 c_binding_tests: ${C_BINDING_DIRS}
@@ -44,16 +44,16 @@ ${C_BINDING_DIRS}:
 test: test_non_c c_binding_tests ${C_BINDING_TESTS}
 
 test_non_c: main
-	cd core/src/nucleus/wasm-test && cargo +$(PINNED_NIGHTLY) build --target wasm32-unknown-unknown
-	cd core_api/wasm-test/round_trip && cargo +$(PINNED_NIGHTLY) build --target wasm32-unknown-unknown
-	cd core_api/wasm-test/commit && cargo +$(PINNED_NIGHTLY) build --target wasm32-unknown-unknown
-	RUSTFLAGS="-D warnings" cargo test
+	cd core/src/nucleus/wasm-test && $(CARGO) +$(WASM_NIGHTLY) build --target wasm32-unknown-unknown
+	cd core_api/wasm-test/round_trip && $(CARGO) +$(WASM_NIGHTLY) build --target wasm32-unknown-unknown
+	cd core_api/wasm-test/commit && $(CARGO) +$(WASM_NIGHTLY) build --target wasm32-unknown-unknown
+	RUSTFLAGS="-D warnings" $(CARGO) test
 
 cov:
-	cargo tarpaulin --all --out Xml
+	$(CARGO) tarpaulin --all --out Xml
 
 fmt:
-	cargo +$(PINNED_NIGHTLY) fmt
+	$(CARGO) +$(TOOLS_NIGHTLY) fmt
 
 # execute all the found "C" binding tests
 ${C_BINDING_TESTS}:

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -5,7 +5,8 @@ use chain::Chain;
 use hash_table::{entry::Entry, memory::MemTable, pair::Pair};
 use state;
 use std::{
-    rc::Rc, sync::{mpsc::Sender, Arc},
+    rc::Rc,
+    sync::{mpsc::Sender, Arc},
 };
 
 #[derive(Clone, Debug, PartialEq, Default)]

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -191,7 +191,9 @@ pub mod tests {
     use super::Chain;
     use hash_table::{
         entry::tests::{test_entry, test_entry_a, test_entry_b, test_type_a, test_type_b},
-        memory::{tests::test_table, MemTable}, pair::Pair, HashTable,
+        memory::{tests::test_table, MemTable},
+        pair::Pair,
+        HashTable,
     };
     use std::rc::Rc;
 

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -4,7 +4,10 @@ use error::HolochainError;
 
 use agent::keys::Keys;
 use hash_table::{
-    pair::Pair, pair_meta::PairMeta, status::{CRUDStatus, LINK_NAME, STATUS_NAME}, HashTable,
+    pair::Pair,
+    pair_meta::PairMeta,
+    status::{CRUDStatus, LINK_NAME, STATUS_NAME},
+    HashTable,
 };
 
 #[derive(Serialize, Debug, Clone, PartialEq)]
@@ -105,11 +108,14 @@ pub mod tests {
 
     use agent::keys::tests::test_keys;
     use hash_table::{
-        memory::MemTable, pair::tests::{test_pair, test_pair_a, test_pair_b},
+        memory::MemTable,
+        pair::tests::{test_pair, test_pair_a, test_pair_b},
         pair_meta::{
-            tests::{test_pair_meta, test_pair_meta_a, test_pair_meta_b}, PairMeta,
+            tests::{test_pair_meta, test_pair_meta_a, test_pair_meta_b},
+            PairMeta,
         },
-        status::{CRUDStatus, LINK_NAME, STATUS_NAME}, HashTable,
+        status::{CRUDStatus, LINK_NAME, STATUS_NAME},
+        HashTable,
     };
 
     pub fn test_table() -> MemTable {

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -67,8 +67,10 @@ pub mod tests {
     use chain::tests::test_chain;
     use hash_table::{
         entry::{
-            tests::{test_entry, test_entry_b}, Entry,
-        }, header::Header,
+            tests::{test_entry, test_entry_b},
+            Entry,
+        },
+        header::Header,
     };
 
     /// dummy pair

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -1,7 +1,9 @@
 //use error::HolochainError;
 use state::*;
 use std::{
-    sync::{mpsc::*, Arc, RwLock, RwLockReadGuard}, thread, time::Duration,
+    sync::{mpsc::*, Arc, RwLock, RwLockReadGuard},
+    thread,
+    time::Duration,
 };
 
 pub const REDUX_LOOP_TIMEOUT_MS: u64 = 400;

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -2,15 +2,19 @@ pub mod ribosome;
 
 use error::HolochainError;
 use holochain_dna::{
-    zome::capabilities::{ReservedCapabilityNames, ReservedFunctionNames}, Dna,
+    zome::capabilities::{ReservedCapabilityNames, ReservedFunctionNames},
+    Dna,
 };
 use instance::Observer;
 use snowflake;
 use state;
 use std::{
-    collections::HashMap, sync::{
-        mpsc::{channel, Sender}, Arc,
-    }, thread,
+    collections::HashMap,
+    sync::{
+        mpsc::{channel, Sender},
+        Arc,
+    },
+    thread,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -460,7 +464,8 @@ pub fn reduce(
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{nucleus::Action::*, state::Action::*}, *,
+        super::{nucleus::Action::*, state::Action::*},
+        *,
     };
     use std::sync::mpsc::channel;
 

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -3,7 +3,9 @@ use instance::Observer;
 use nucleus::NucleusState;
 use snowflake;
 use std::{
-    collections::HashSet, hash::{Hash, Hasher}, sync::{mpsc::Sender, Arc},
+    collections::HashSet,
+    hash::{Hash, Hasher},
+    sync::{mpsc::Sender, Arc},
 };
 
 #[derive(Clone, Debug, PartialEq)]

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -57,13 +57,16 @@ extern crate holochain_dna;
 extern crate test_utils;
 
 use holochain_core::{
-    context::Context, error::HolochainError, instance::Instance,
+    context::Context,
+    error::HolochainError,
+    instance::Instance,
     nucleus::{call_and_wait_for_result, Action::*, FunctionCall, NucleusStatus},
     state::{Action::*, State},
 };
 use holochain_dna::Dna;
 use std::{
-    sync::{mpsc::channel, Arc}, time::Duration,
+    sync::{mpsc::channel, Arc},
+    time::Duration,
 };
 
 /// contains a Holochain application instance
@@ -170,7 +173,8 @@ mod tests {
     use holochain_core::{context::Context, logger::Logger, persister::SimplePersister};
     use holochain_dna::zome::capabilities::ReservedCapabilityNames;
     use std::{
-        fmt, sync::{Arc, Mutex},
+        fmt,
+        sync::{Arc, Mutex},
     };
     use test_utils::{create_test_dna_with_wasm, create_test_dna_with_wat, create_wasm_from_file};
 

--- a/core_api_c_binding/src/lib.rs
+++ b/core_api_c_binding/src/lib.rs
@@ -11,7 +11,9 @@ use std::sync::Arc;
 use holochain_agent::Agent;
 use holochain_core::{logger::Logger, persister::SimplePersister};
 use std::{
-    ffi::{CStr, CString}, os::raw::c_char, sync::Mutex,
+    ffi::{CStr, CString},
+    os::raw::c_char,
+    sync::Mutex,
 };
 
 #[derive(Clone, Debug)]

--- a/dna/src/wasm.rs
+++ b/dna/src/wasm.rs
@@ -4,7 +4,9 @@
 
 use base64;
 use serde::{
-    self, de::{Deserializer, Visitor}, ser::Serializer,
+    self,
+    de::{Deserializer, Visitor},
+    ser::Serializer,
 };
 
 /// Private helper for converting binary WebAssembly into base64 serialized string.
@@ -51,7 +53,10 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct DnaWasm {
     /// The actual binary WebAssembly bytecode goes here.
-    #[serde(serialize_with = "_vec_u8_to_b64_str", deserialize_with = "_b64_str_to_vec_u8")]
+    #[serde(
+        serialize_with = "_vec_u8_to_b64_str",
+        deserialize_with = "_b64_str_to_vec_u8"
+    )]
     pub code: Vec<u8>,
     // using a struct gives us the flexibility to extend it later
     // should we need additional properties, like:

--- a/dna_c_binding/src/lib.rs
+++ b/dna_c_binding/src/lib.rs
@@ -8,7 +8,9 @@ extern crate holochain_dna;
 
 use holochain_dna::Dna;
 use std::{
-    ffi::{CStr, CString}, os::raw::c_char, panic::catch_unwind,
+    ffi::{CStr, CString},
+    os::raw::c_char,
+    panic::catch_unwind,
 };
 
 #[no_mangle]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -2,9 +2,12 @@ FROM ubuntu
 
 # This removes some warning when installing packages when there is no X
 ENV DEBIAN_FRONTEND noninteractive
-ENV PINNED_NIGHTLY nightly-2018-06-01
-ENV CLIPPY_VERSION 0.0.206
-ENV RUST_VERSION stable
+
+ENV WASM_NIGHTLY nightly-2018-06-01
+
+ENV TOOLS_NIGHTLY nightly-2018-07-17
+
+ENV CORE_RUST_VERSION stable
 
 RUN apt-get update && apt-get install --yes\
   libssl-dev \
@@ -15,13 +18,18 @@ RUN apt-get update && apt-get install --yes\
   qt5-default \
   python2.7
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${RUST_VERSION} -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${CORE_RUST_VERSION} -y
 ENV PATH /root/.cargo/bin:$PATH
 RUN rustc --version
-RUN rustup toolchain install ${PINNED_NIGHTLY}
-RUN rustup component add rustfmt-preview --toolchain ${PINNED_NIGHTLY}
-RUN cargo +${PINNED_NIGHTLY} install clippy --version ${CLIPPY_VERSION}
-RUN rustup target add wasm32-unknown-unknown --toolchain ${PINNED_NIGHTLY}
+
+RUN rustup toolchain install ${WASM_NIGHTLY}
+RUN rustup toolchain install ${TOOLS_NIGHTLY}
+
+RUN rustup component add rustfmt-preview --toolchain ${TOOLS_NIGHTLY}
+RUN rustup component add clippy-preview --toolchain ${TOOLS_NIGHTLY}
+
+RUN rustup target add wasm32-unknown-unknown --toolchain ${WASM_NIGHTLY}
+
 RUN RUSTFLAGS="--cfg procmacro2_semver_exempt" cargo install cargo-tarpaulin
 
 WORKDIR /holochain

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -3,10 +3,16 @@ FROM ubuntu
 # This removes some warning when installing packages when there is no X
 ENV DEBIAN_FRONTEND noninteractive
 
+# Set the internal user for the docker container (non-root)
+ENV DOCKER_BUILD_USER holochain
+
+# The Rust version used for the Wasm builds
 ENV WASM_NIGHTLY nightly-2018-06-01
 
+# The Rust version used for the tools
 ENV TOOLS_NIGHTLY nightly-2018-07-17
 
+# The Rust version that is used everywhere else
 ENV CORE_RUST_VERSION stable
 
 RUN apt-get update && apt-get install --yes\
@@ -18,8 +24,11 @@ RUN apt-get update && apt-get install --yes\
   qt5-default \
   python2.7
 
+RUN useradd -ms /bin/bash ${DOCKER_BUILD_USER}
+USER ${DOCKER_BUILD_USER}
+
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${CORE_RUST_VERSION} -y
-ENV PATH /root/.cargo/bin:$PATH
+ENV PATH /home/${DOCKER_BUILD_USER}/.cargo/bin:$PATH
 RUN rustc --version
 
 RUN rustup toolchain install ${WASM_NIGHTLY}

--- a/docker/build-ubuntu
+++ b/docker/build-ubuntu
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -f docker/Dockerfile.ubuntu -t sphinxc0re/holochain-rust:develop "$@" .
+docker build -f docker/Dockerfile.ubuntu -t holochain/holochain-rust:develop "$@" .

--- a/docker/entry
+++ b/docker/entry
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ -n "$HOST_UID" ]; then
+  OLDID=`id -u holochain`
+  if [ $$OLDID != "$HOST_UID" ]; then
+    usermod -u "$HOST_UID" holochain
+    groupmod -g "$HOST_UID" holochain
+    find /home/holochain -user $$OLDID -exec chown -h $HOST_UID:$HOST_UID {} \;
+    usermod -g "$HOST_UID" holochain
+  fi
+fi
+
+$@

--- a/docker/run
+++ b/docker/run
@@ -11,4 +11,4 @@ else
   HOST_UID=
 fi
 
-docker run -v `pwd`:/holochain --rm -it sphinxc0re/holochain-rust:develop ./docker/entry "$@"
+docker run -v `pwd`:/holochain --rm -it holochain/holochain-rust:develop ./docker/entry "$@"

--- a/docker/run
+++ b/docker/run
@@ -1,2 +1,14 @@
 #!/bin/bash
-docker run -v `pwd`:/holochain --rm -p 3141:3141 -it sphinxc0re/holochain-rust:develop bash
+
+# Detect whether we are on a OSX host, determine host user ID
+# This gives a warning on linux that must be ignored.
+if [ "$(uname)" = "Linux" ]; then
+  # linux detected
+  HOST_UID=$$
+else
+  # There is nothing we need to do in this case. For the holochain user, everything below app/
+  # appears to belong to him. This is a quirk of Docker for Mac.
+  HOST_UID=
+fi
+
+docker run -v `pwd`:/holochain --rm -it sphinxc0re/holochain-rust:develop ./docker/entry "$@"

--- a/docker/run-cov
+++ b/docker/run-cov
@@ -11,4 +11,4 @@ else
   HOST_UID=
 fi
 
-docker run -v `pwd`:/holochain --rm --security-opt seccomp=unconfined -it sphinxc0re/holochain-rust:develop ./docker/entry make cov
+docker run -v `pwd`:/holochain --rm --security-opt seccomp=unconfined -it holochain/holochain-rust:develop ./docker/entry make cov

--- a/docker/run-cov
+++ b/docker/run-cov
@@ -1,2 +1,14 @@
 #!/bin/bash
-docker run -v `pwd`:/holochain --rm --security-opt seccomp=unconfined sphinxc0re/holochain-rust:develop make cov
+
+# Detect whether we are on a OSX host, determine host user ID
+# This gives a warning on linux that must be ignored.
+if [ "$(uname)" = "Linux" ]; then
+  # linux detected
+  HOST_UID=$$
+else
+  # There is nothing we need to do in this case. For the holochain user, everything below app/
+  # appears to belong to him. This is a quirk of Docker for Mac.
+  HOST_UID=
+fi
+
+docker run -v `pwd`:/holochain --rm --security-opt seccomp=unconfined -it sphinxc0re/holochain-rust:develop ./docker/entry make cov

--- a/docker/run-fmt
+++ b/docker/run-fmt
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker run -v `pwd`:/holochain --rm -it sphinxc0re/holochain-rust:develop make fmt
+./docker/run make fmt

--- a/docker/run-test
+++ b/docker/run-test
@@ -1,2 +1,2 @@
 #!/bin/bash
-RUST_BACKTRACE=full docker run -v `pwd`:/holochain --rm sphinxc0re/holochain-rust:develop make test
+RUST_BACKTRACE=full ./docker/run make test

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -8,7 +8,8 @@ use holochain_core::{context::Context, logger::SimpleLogger, persister::SimplePe
 use holochain_core_api::*;
 use holochain_dna::Dna;
 use std::{
-    env, sync::{Arc, Mutex},
+    env,
+    sync::{Arc, Mutex},
 };
 
 fn usage() {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -4,7 +4,9 @@ extern crate wabt;
 
 use holochain_core::*;
 use holochain_dna::{
-    wasm::DnaWasm, zome::{capabilities::Capability, Zome}, Dna,
+    wasm::DnaWasm,
+    zome::{capabilities::Capability, Zome},
+    Dna,
 };
 use std::{fs::File, io::prelude::*};
 use wabt::Wat2Wasm;


### PR DESCRIPTION
## Summary

While I was moving the docker automated build to the `holochain` org, the build of our Dockerfile errored while installing clippy. It seems like clippy is now officially supported by the rust core team and inside the component collection of `rustup`. This means better support but also that I had to do some adjustments. As of this update we will be using:

 - `nightly-2018-07-17` for our tools (`rustfmt`, `clippy`)
 - `nightly-2018-06-01` for Wasm compilation
 - `stable` for everything else

The upgrade of `rustfmt` again will result in some reformatting. I intentionally didn't include the changes of that because the changes will still have to go though the docker hub build. Also as I suspected, the resulting reformatting won't be too heavy since it only touches some imports.

I also did some changes to the Makefile. I purposely removed the `--verbose` flag from the regular Rust build to (drum roll) reduce verbosity.

~Another thing I changed was the call to clippy. It now is called without any flags to prevent unwanted behavior. We should always stick to the default community standards and this helps a lot with doing so.~ 

*The CI will probably fail because it will be using the old docker image*

## What reviewers can do
You can check out the branch locally, run the build script (`. docker/build-ubuntu`), run the formatting script (`. docker/run-fmt`) and check whether the tests run using `. docker/run-test`