### PR TITLE
174 coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ linker = "<your $HOME value here>/NDK/arm/bin/arm-linux-androideabi-clang"
 [target.i686-linux-android]
 ar = "<your $HOME value here>/NDK/x86/bin/i686-linux-android-ar"
 linker = "<your $HOME value here>/NDK/x86/bin/i686-linux-android-clang"
-
 ```
+
 (this toml file needs absolute paths, so you need to prefix the path with your home dir).
 
 4. Now you can add those targets to your rust installation with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,7 @@
 coverage:
   round: up
   range: 85..100
+  status:
+    project:
+      default:
+        target: 85

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+# Repository Yaml
+coverage:
+  round: up
+  range: 85..100

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -12,11 +12,13 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[cfg_attr(tarpaulin, skip)]
 fn usage() {
     println!("Usage: holochain_test_bin <identity>");
     std::process::exit(1);
 }
 
+#[cfg_attr(tarpaulin, skip)]
 fn main() {
     let args: Vec<String> = env::args().collect();
 

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -12,12 +12,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+// this is all debug code, no need to track code test coverage
 #[cfg_attr(tarpaulin, skip)]
 fn usage() {
     println!("Usage: holochain_test_bin <identity>");
     std::process::exit(1);
 }
 
+// this is all debug code, no need to track code test coverage
 #[cfg_attr(tarpaulin, skip)]
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -71,7 +71,6 @@ pub struct SinglePageAllocation {
 #[allow(unknown_lints)]
 #[allow(cast_lossless)]
 impl SinglePageAllocation {
-
     /// An Encoded Allocation is a u32 where 'offset' is first 16-bits and 'length' last 16-bits
     /// A valid allocation must not have a length of zero
     /// An Encoded Allocation with an offset but no length is actually an encoding of an ErrorCode
@@ -99,7 +98,6 @@ impl SinglePageAllocation {
     pub fn encode(self) -> u32 {
         u32_merge_bits(self.offset, self.length)
     }
-
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -117,7 +115,9 @@ pub struct SinglePageStack {
 impl SinglePageStack {
     // A stack can be initialized by giving the last know allocation on this stack
     pub fn new(last_allocation: SinglePageAllocation) -> Self {
-        assert!(last_allocation.offset as u32 + last_allocation.length as u32 <= std::u16::MAX as u32);
+        assert!(
+            last_allocation.offset as u32 + last_allocation.length as u32 <= std::u16::MAX as u32
+        );
         SinglePageStack {
             top: last_allocation.offset + last_allocation.length,
         }
@@ -127,7 +127,9 @@ impl SinglePageStack {
         let last_allocation = SinglePageAllocation::new(encoded_last_allocation as u32);
         let last_allocation =
             last_allocation.expect("received error instead of valid encoded allocation");
-        assert!(last_allocation.offset as u32 + last_allocation.length as u32 <= std::u16::MAX as u32);
+        assert!(
+            last_allocation.offset as u32 + last_allocation.length as u32 <= std::u16::MAX as u32
+        );
         return SinglePageStack::new(last_allocation);
     }
 
@@ -215,55 +217,31 @@ pub fn serialize_into_encoded_allocation<T: Serialize>(
 #[cfg(test)]
 pub mod tests {
 
-    use super::HcApiReturnCode;
-    use super::SinglePageAllocation;
+    use super::{HcApiReturnCode, SinglePageAllocation};
 
     #[test]
     /// tests that encoding integers for errors returns the correct return code
     fn encode_error() {
-        assert_eq!(
-            super::encode_error(0),
-            HcApiReturnCode::Success,
-        );
+        assert_eq!(super::encode_error(0), HcApiReturnCode::Success,);
 
-        assert_eq!(
-            super::encode_error(1),
-            HcApiReturnCode::Error,
-        );
+        assert_eq!(super::encode_error(1), HcApiReturnCode::Error,);
 
-        assert_eq!(
-            super::encode_error(2),
-            HcApiReturnCode::ErrorSerdeJson,
-        );
+        assert_eq!(super::encode_error(2), HcApiReturnCode::ErrorSerdeJson,);
 
-        assert_eq!(
-            super::encode_error(3),
-            HcApiReturnCode::ErrorPageOverflow,
-        );
+        assert_eq!(super::encode_error(3), HcApiReturnCode::ErrorPageOverflow,);
 
-        assert_eq!(
-            super::encode_error(4),
-            HcApiReturnCode::ErrorActionResult,
-        );
+        assert_eq!(super::encode_error(4), HcApiReturnCode::ErrorActionResult,);
     }
 
     #[test]
     /// tests construction and encoding in a new single page allocation
     fn new_spa() {
-
         let i = 0b1010101010101010_0101010101010101;
         let spa = SinglePageAllocation::new(i).unwrap();
 
-        assert_eq!(
-            0b1010101010101010,
-            spa.offset,
-        );
+        assert_eq!(0b1010101010101010, spa.offset,);
 
-        assert_eq!(
-            0b0101010101010101,
-            spa.length,
-        );
-
+        assert_eq!(0b0101010101010101, spa.length,);
     }
 
     #[test]
@@ -310,59 +288,46 @@ pub mod tests {
     #[test]
     /// tests that a SinglePageAllocation returns its encoded offset/length pair as u32
     fn spa_encode() {
-
         let i = 0b1010101010101010_0101010101010101;
         let spa = SinglePageAllocation::new(i).unwrap();
 
-        assert_eq!(
-            i,
-            spa.encode(),
-        );
-
+        assert_eq!(i, spa.encode(),);
     }
 
     #[test]
     /// tests that we can extract the high bits from a u32 into the correct u16
     fn u32_high_bits() {
-
         assert_eq!(
             0b1010101010101010,
             super::u32_high_bits(0b1010101010101010_0101010101010101),
         );
-
     }
 
     #[test]
     /// tests that we can extract the high bits from a u32 into the correct u16
     fn u32_low_bits() {
-
         assert_eq!(
             0b0101010101010101,
             super::u32_low_bits(0b1010101010101010_0101010101010101),
         );
-
     }
 
     #[test]
     /// tests that we can split a u32 into a tuple of high/low bits
     fn u32_split_bits() {
-
         assert_eq!(
             (0b1010101010101010, 0b0101010101010101),
             super::u32_split_bits(0b1010101010101010_0101010101010101),
         );
-
     }
 
     #[test]
     /// tests that we can merge a u16 tuple into a u32
     fn u32_merge_bits() {
-
         assert_eq!(
             0b1010101010101010_0101010101010101,
             super::u32_merge_bits(0b1010101010101010, 0b0101010101010101),
         );
-
     }
 
 }

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -54,7 +54,7 @@ pub fn u32_split_bits(i: u32) -> (u16, u16) {
 
 /// merges 2x u16 into a single u32
 pub fn u32_merge_bits(high: u16, low: u16) -> u32 {
-    ((high as u32) << 16) + low as u32
+    (u32::from(high) << 16) + u32::from(low)
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -54,7 +54,7 @@ pub fn u32_split_bits(i: u32) -> (u16, u16) {
 
 /// merges 2x u16 into a single u32
 pub fn u32_merge_bits(high: u16, low: u16) -> u32 {
-    (u32::from(high) << 16) + u32::from(low)
+    (u32::from(high) << 16) | u32::from(low)
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -82,6 +82,7 @@ impl SinglePageAllocation {
         // zero length allocation = encoding an error api return code
         if allocation.length == 0 {
             // @TODO is it right to return success as Err for 0? what is a "success" error?
+            // @see https://github.com/holochain/holochain-rust/issues/181
             return Err(encode_error(allocation.offset));
         }
 

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -9,8 +9,10 @@ use std::{ffi::CStr, os::raw::c_char, slice};
 //--------------------------------------------------------------------------------------------------
 
 /// Enumeration of all possible return codes that an HC API function can return
+/// represents a zero length offset in SinglePageAllocation
+/// @see SinglePageAllocation
 #[repr(u32)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum HcApiReturnCode {
     Success = 0,
     Error = 1 << 16,
@@ -25,12 +27,34 @@ pub enum HcApiReturnCode {
 
 pub fn encode_error(offset: u16) -> HcApiReturnCode {
     match offset {
+        // @TODO what is a success error?
+        // @see https://github.com/holochain/holochain-rust/issues/181
         0 => HcApiReturnCode::Success,
         2 => HcApiReturnCode::ErrorSerdeJson,
         3 => HcApiReturnCode::ErrorPageOverflow,
         4 => HcApiReturnCode::ErrorActionResult,
         1 | _ => HcApiReturnCode::Error,
     }
+}
+
+/// returns the u16 high bits from a u32
+pub fn u32_high_bits(i: u32) -> u16 {
+    (i >> 16) as u16
+}
+
+/// returns the u16 low bits from a u32
+pub fn u32_low_bits(i: u32) -> u16 {
+    (i as u16 % std::u16::MAX)
+}
+
+/// splits the high and low bits of u32 into a tuple of u16, for destructuring convenience
+pub fn u32_split_bits(i: u32) -> (u16, u16) {
+    (u32_high_bits(i), u32_low_bits(i))
+}
+
+/// merges 2x u16 into a single u32
+pub fn u32_merge_bits(high: u16, low: u16) -> u32 {
+    ((high as u32) << 16) + low as u32
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -47,26 +71,34 @@ pub struct SinglePageAllocation {
 #[allow(unknown_lints)]
 #[allow(cast_lossless)]
 impl SinglePageAllocation {
+
     /// An Encoded Allocation is a u32 where 'offset' is first 16-bits and 'length' last 16-bits
     /// A valid allocation must not have a length of zero
     /// An Encoded Allocation with an offset but no length is actually an encoding of an ErrorCode
     pub fn new(encoded_allocation: u32) -> Result<Self, HcApiReturnCode> {
-        let allocation = SinglePageAllocation {
-            offset: (encoded_allocation >> 16) as u16,
-            length: (encoded_allocation % 65536) as u16,
-        };
+        let (offset, length) = u32_split_bits(encoded_allocation);
+        let allocation = SinglePageAllocation { offset, length };
+
+        // zero length allocation = encoding an error api return code
         if allocation.length == 0 {
+            // @TODO is it right to return success as Err for 0? what is a "success" error?
             return Err(encode_error(allocation.offset));
         }
-        if (allocation.offset as u32 + allocation.length as u32) > 65535 {
+
+        // should never happen
+        // we don't panic because this needs to work with wasm, which doesn't support panic
+        if (allocation.offset as u32 + allocation.length as u32) > std::u16::MAX as u32 {
             return Err(HcApiReturnCode::ErrorPageOverflow);
         }
+
         Ok(allocation)
     }
 
+    /// returns a single u32 value encoding both the u16 offset and length values
     pub fn encode(self) -> u32 {
-        ((self.offset as u32) << 16) + self.length as u32
+        u32_merge_bits(self.offset, self.length)
     }
+
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -84,7 +116,7 @@ pub struct SinglePageStack {
 impl SinglePageStack {
     // A stack can be initialized by giving the last know allocation on this stack
     pub fn new(last_allocation: SinglePageAllocation) -> Self {
-        assert!(last_allocation.offset as u32 + last_allocation.length as u32 <= 65535);
+        assert!(last_allocation.offset as u32 + last_allocation.length as u32 <= std::u16::MAX as u32);
         SinglePageStack {
             top: last_allocation.offset + last_allocation.length,
         }
@@ -94,12 +126,12 @@ impl SinglePageStack {
         let last_allocation = SinglePageAllocation::new(encoded_last_allocation as u32);
         let last_allocation =
             last_allocation.expect("received error instead of valid encoded allocation");
-        assert!(last_allocation.offset as u32 + last_allocation.length as u32 <= 65535);
+        assert!(last_allocation.offset as u32 + last_allocation.length as u32 <= std::u16::MAX as u32);
         return SinglePageStack::new(last_allocation);
     }
 
     pub fn allocate(&mut self, size: u16) -> u16 {
-        assert!(self.top as u32 + size as u32 <= 65535);
+        assert!(self.top as u32 + size as u32 <= std::u16::MAX as u32);
         let offset = self.top;
         self.top += size;
         offset
@@ -154,7 +186,7 @@ pub fn try_deserialize_allocation<'s, T: Deserialize<'s>>(
 pub fn serialize<T: Serialize>(stack: &mut SinglePageStack, internal: T) -> SinglePageAllocation {
     let json_bytes = serde_json::to_vec(&internal).unwrap();
     let json_bytes_len = json_bytes.len();
-    assert!(json_bytes_len < 65536);
+    assert!(json_bytes_len < std::u16::MAX as usize);
 
     let ptr = stack.allocate(json_bytes_len as u16) as *mut c_char;
 
@@ -177,4 +209,159 @@ pub fn serialize_into_encoded_allocation<T: Serialize>(
 ) -> i32 {
     let allocation_of_output = serialize(stack, internal);
     return allocation_of_output.encode() as i32;
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use super::HcApiReturnCode;
+    use super::SinglePageAllocation;
+
+    #[test]
+    /// tests that encoding integers for errors returns the correct return code
+    fn encode_error() {
+        assert_eq!(
+            super::encode_error(0),
+            HcApiReturnCode::Success,
+        );
+
+        assert_eq!(
+            super::encode_error(1),
+            HcApiReturnCode::Error,
+        );
+
+        assert_eq!(
+            super::encode_error(2),
+            HcApiReturnCode::ErrorSerdeJson,
+        );
+
+        assert_eq!(
+            super::encode_error(3),
+            HcApiReturnCode::ErrorPageOverflow,
+        );
+
+        assert_eq!(
+            super::encode_error(4),
+            HcApiReturnCode::ErrorActionResult,
+        );
+    }
+
+    #[test]
+    /// tests construction and encoding in a new single page allocation
+    fn new_spa() {
+
+        let i = 0b1010101010101010_0101010101010101;
+        let spa = SinglePageAllocation::new(i).unwrap();
+
+        assert_eq!(
+            0b1010101010101010,
+            spa.offset,
+        );
+
+        assert_eq!(
+            0b0101010101010101,
+            spa.length,
+        );
+
+    }
+
+    #[test]
+    /// tests that we can encode error return codes (zero length allocation)
+    fn new_spa_error() {
+        assert_eq!(
+            // offset 0 = success?
+            // @see https://github.com/holochain/holochain-rust/issues/181
+            SinglePageAllocation::new(0b0000000000000000_0000000000000000).unwrap_err(),
+            HcApiReturnCode::Success,
+        );
+
+        assert_eq!(
+            // offset 1 = generic error
+            SinglePageAllocation::new(0b0000000000000001_0000000000000000).unwrap_err(),
+            HcApiReturnCode::Error,
+        );
+
+        assert_eq!(
+            // offset 2 = serde json error
+            SinglePageAllocation::new(0b0000000000000010_0000000000000000).unwrap_err(),
+            HcApiReturnCode::ErrorSerdeJson,
+        );
+
+        assert_eq!(
+            // offset 3 = page overflow error
+            SinglePageAllocation::new(0b0000000000000011_0000000000000000).unwrap_err(),
+            HcApiReturnCode::ErrorPageOverflow,
+        );
+
+        assert_eq!(
+            // offset 4 = page overflow error
+            SinglePageAllocation::new(0b0000000000000100_0000000000000000).unwrap_err(),
+            HcApiReturnCode::ErrorActionResult,
+        );
+
+        assert_eq!(
+            // nonsense offset = generic error
+            SinglePageAllocation::new(0b1010101010101010_0000000000000000).unwrap_err(),
+            HcApiReturnCode::Error,
+        );
+    }
+
+    #[test]
+    /// tests that a SinglePageAllocation returns its encoded offset/length pair as u32
+    fn spa_encode() {
+
+        let i = 0b1010101010101010_0101010101010101;
+        let spa = SinglePageAllocation::new(i).unwrap();
+
+        assert_eq!(
+            i,
+            spa.encode(),
+        );
+
+    }
+
+    #[test]
+    /// tests that we can extract the high bits from a u32 into the correct u16
+    fn u32_high_bits() {
+
+        assert_eq!(
+            0b1010101010101010,
+            super::u32_high_bits(0b1010101010101010_0101010101010101),
+        );
+
+    }
+
+    #[test]
+    /// tests that we can extract the high bits from a u32 into the correct u16
+    fn u32_low_bits() {
+
+        assert_eq!(
+            0b0101010101010101,
+            super::u32_low_bits(0b1010101010101010_0101010101010101),
+        );
+
+    }
+
+    #[test]
+    /// tests that we can split a u32 into a tuple of high/low bits
+    fn u32_split_bits() {
+
+        assert_eq!(
+            (0b1010101010101010, 0b0101010101010101),
+            super::u32_split_bits(0b1010101010101010_0101010101010101),
+        );
+
+    }
+
+    #[test]
+    /// tests that we can merge a u16 tuple into a u32
+    fn u32_merge_bits() {
+
+        assert_eq!(
+            0b1010101010101010_0101010101010101,
+            super::u32_merge_bits(0b1010101010101010, 0b0101010101010101),
+        );
+
+    }
+
 }


### PR DESCRIPTION
fixes #174 

hitting thriveboard goals!

changes:

- ignore debug code in test_bin for coverage reports
- configure codecov to treat 85% as the minimum coverage for reports
- configure codecov to provide a commit status for PRs
- added some tests to memory allocation as low hanging fruit to bump the project % up

followup:

- err success? #181 