### PR TITLE
mdbook automation - set default rustup toolchain

### DIFF
--- a/docker/Dockerfile.mdbook
+++ b/docker/Dockerfile.mdbook
@@ -1,5 +1,6 @@
 FROM holochain/holochain-rust:develop
 
+RUN rustup default stable
 RUN cargo install mdbook --vers "^0.1.0"
 
 WORKDIR /holochain/doc/holochain_101


### PR DESCRIPTION
brutal feedback loops with travis, since it has like a 30 min build time. But I forked the repo completely so that I could test it faster with tighter feedback. 