### PR TITLE
mdbook automation - multiple concurrent travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,23 @@
-language: rust
-
-cache: cargo
-
 services:
   - docker
 
 dist: trusty
 
-install:
-  - docker pull holochain/holochain-rust:develop
+jobs:
+  include:
+    - stage: "All"
+      name: "Tests"
+      install: docker pull holochain/holochain-rust:develop
+      script: . docker/run-test
+      after_success:
+        - . docker/run-cov
+        - bash <(curl -s https://codecov.io/bash)
+    - name: "Mdbook Build"
+      language: rust
+      cache: cargo
+      install: cargo install mdbook --vers "^0.1.0" || echo "Mdbook already installed"
+      script: ./travis-update-book.sh
+      env:
+        - ENCRYPTION_LABEL: "30dd9296640e"
+        - COMMIT_AUTHOR_EMAIL: "connor.turland@holo.host"
 
-script:
-  - . docker/run-test
-
-env:
-  global:
-  - ENCRYPTION_LABEL: "30dd9296640e"
-  - COMMIT_AUTHOR_EMAIL: "connor.turland@holo.host"
-
-after_success:
-  - . docker/run-cov
-  - bash <(curl -s https://codecov.io/bash)
-  - bash ./travis-update-book.sh


### PR DESCRIPTION
so because of the long deploy times, David and I came up with a solution of doing multiple concurrent travis jobs, so that's what this PR is.
This PR also completes a fully tested version of the automated deploy script, which I tested fully by forking to Connoropolous/holochain-rust and setting up the full travis deploy stack, see:
https://connoropolous.github.io/holochain-rust/agent.html

Other background: 
- I removed `language: rust` from the main script execution, because it was just installing rust to travis, then re-installing it inside docker, also removed `cache: cargo` for the same reason.
- I made it so that the mdbook command executes directly on the travis machine, not in docker, because then it can utilize the cargo caching and make for quicker mdbook build stages