### PR TITLE
Split `fn start_action_loop` into multiple functions (see #169)

### DIFF
--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -4,7 +4,7 @@ use context::Context;
 use state::State;
 use std::{
     sync::{
-        mpsc::{channel, Sender, Receiver},
+        mpsc::{channel, Receiver, Sender},
         Arc, RwLock, RwLockReadGuard,
     },
     thread,
@@ -120,7 +120,8 @@ impl Instance {
     ) -> Vec<Observer> {
         // Mutate state
         {
-            let mut state = self.state
+            let mut state = self
+                .state
                 .write()
                 .expect("owners of the state RwLock shouldn't panic");
             *state = state.reduce(
@@ -136,7 +137,8 @@ impl Instance {
 
         // Run all observer closures
         {
-            let state = self.state
+            let state = self
+                .state
                 .read()
                 .expect("owners of the state RwLock shouldn't panic");
             let mut i = 0;

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -94,10 +94,6 @@ impl Instance {
 
         thread::spawn(move || {
             let mut state_observers: Vec<Observer> = Vec::new();
-
-            // @TODO this should all be callable outside the loop so that deterministic tests that
-            // don't rely on time can be written
-            // @see https://github.com/holochain/holochain-rust/issues/169
             for action_wrapper in rx_action {
                 state_observers = sync_self.process_action(
                     action_wrapper,


### PR DESCRIPTION
fixes #169 

I think that this resolves #169 although there are some next steps
with this solution that we may want to make:
- Create tests for various actions that use the `fn process_action` API or something better
- Create tests for the action processing code that use a test action type as well a test state type (requires state trait)

I'm just giving this a shot. Totally open to feedback or suggestions. It's possible I misunderstood something and this is a negative change. I figure it's better for me to put something out there and get feedback than for me to stew on a pull request asking a lot of questions until I feel sure it's good.

One thing I'm not sure about is why `#[derive(Clone)]` was
commented out and if there is some flaw with using it.