### PR TITLE
Transition to use more common rust idioms

### DIFF
--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -14,10 +14,8 @@ impl Agent {
         Agent { identity: id }
     }
 
-    pub fn from_string(text: &str) -> Self {
-        Agent::new(Identity {
-            content: text.to_string(),
-        })
+    pub fn from_string(text: String) -> Self {
+        Agent::new(Identity { content: text })
     }
 
     pub fn to_string(&self) -> String {
@@ -36,7 +34,7 @@ mod tests {
         });
         assert_eq!(agent.identity.content, "bob".to_string());
 
-        let agent = Agent::from_string("jane");
+        let agent = Agent::from_string("jane".to_string());
         assert_eq!(agent.identity.content, "jane".to_string());
 
         assert_eq!(agent.to_string(), "jane".to_string());

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -90,6 +90,8 @@ pub enum Action {
 }
 
 /// function signature for action handler functions
+// @TODO merge these into a single signature
+// @see https://github.com/holochain/holochain-rust/issues/194
 pub type AgentReduceFn = ReduceFn<AgentState>;
 pub type NucleusReduceFn = ReduceFn<NucleusState>;
 pub type ReduceFn<S> =

--- a/core/src/agent/keys.rs
+++ b/core/src/agent/keys.rs
@@ -91,13 +91,13 @@ pub mod tests {
     #[test]
     /// tests keys.public_key()
     fn keys_public_key() {
-        assert_eq!(test_keys().public_key(), test_public_key(),);
+        assert_eq!(test_keys().public_key(), test_public_key());
     }
 
     #[test]
     /// tests keys.private_key()
     fn keys_private_key() {
-        assert_eq!(test_keys().private_key(), test_private_key(),);
+        assert_eq!(test_keys().private_key(), test_private_key());
     }
 
 }

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -134,12 +134,14 @@ fn reduce_get(
     // drop in a dummy entry for testing
     let mut chain = Chain::new(Rc::new(MemTable::new()));
     let e = Entry::new("testEntryType", "test entry content");
-    chain.push(&e).unwrap();
+    chain.push(&e).expect("test entry should be valid");
 
     // @TODO if the get fails local, do a network get
     // @see https://github.com/holochain/holochain-rust/issues/167
 
-    let result = chain.get_entry(&key).unwrap();
+    let result = chain
+        .get_entry(&key)
+        .expect("should be able to get entry that we just added");
     state
         .actions
         .insert(action_wrapper.clone(), ActionResponse::Get(result.clone()));
@@ -287,6 +289,6 @@ pub mod tests {
             "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"type_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
             ActionResponse::Get(Some(test_pair())).to_json(),
         );
-        assert_eq!("", ActionResponse::Get(None).to_json(),);
+        assert_eq!("", ActionResponse::Get(None).to_json());
     }
 }

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -179,7 +179,10 @@ impl<T: HashTable> Chain<T> {
 
     /// restore canonical JSON chain
     ///
-    /// panics if string isn't valid JSON or pairs fail to validate
+    /// # Panics
+    ///
+    /// Panics if the string passed isn't valid JSON or pairs fail to validate
+    ///
     /// @TODO accept canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn from_json(table: Rc<T>, s: &str) -> Self {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -15,13 +15,8 @@ pub struct Context {
 impl Context {
     // helper function to make it easier to call the logger
     pub fn log(&self, msg: &str) -> Result<(), HolochainError> {
-        let result = self.logger.lock();
-        match result {
-            Err(_) => return Err(HolochainError::LoggingError),
-            Ok(mut logger) => {
-                logger.log(msg.to_string());
-            }
-        }
+        let mut logger = self.logger.lock().or(Err(HolochainError::LoggingError))?;
+        logger.log(msg.to_string());
         Ok(())
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -105,6 +105,6 @@ mod tests {
     fn can_return_result() {
         let result = raises_holochain_error(false);
 
-        assert_eq!(result, Ok(()))
+        assert!(result.is_ok());
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,3 +1,4 @@
+use self::HolochainError::*;
 use std::{error::Error, fmt};
 
 /// module for holding Holochain specific errors
@@ -38,8 +39,6 @@ impl fmt::Display for HolochainError {
     }
 }
 
-use self::HolochainError::*;
-
 impl Error for HolochainError {
     fn description(&self) -> &str {
         match self {
@@ -72,37 +71,32 @@ mod tests {
     /// test that we can convert an error to a string
     fn to_string() {
         let err = HolochainError::new("foo");
-        assert_eq!("ErrorGeneric(\"foo\")", err.to_string(),);
+        assert_eq!(r#"ErrorGeneric("foo")"#, err.to_string());
     }
 
     #[test]
     /// test that we can convert an error to valid JSON
     fn test_to_json() {
         let err = HolochainError::new("foo");
-        assert_eq!("{\"error\":\"foo\"}", err.to_json());
+        assert_eq!(r#"{"error":"foo"}"#, err.to_json());
     }
 
     #[test]
     /// smoke test new errors
     fn can_instantiate() {
         let err = HolochainError::new("borked");
-        if let HolochainError::ErrorGeneric(err_msg) = err {
-            assert_eq!(err_msg, "borked")
-        } else {
-            assert!(false)
-        }
+
+        assert_eq!(HolochainError::ErrorGeneric("borked".to_string()), err);
     }
 
     #[test]
     /// test errors as a result and destructuring
     fn can_raise_holochain_error() {
-        let result = raises_holochain_error(true);
-        match result {
-            Ok(_) => assert!(false),
-            Err(err) => match err {
-                HolochainError::ErrorGeneric(msg) => assert_eq!(msg, "borked"),
-                _ => assert!(false),
-            },
+        let err = raises_holochain_error(true).expect_err("should return an error when yes=true");
+
+        match err {
+            HolochainError::ErrorGeneric(msg) => assert_eq!(msg, "borked"),
+            _ => panic!("raises_holochain_error should return an ErrorGeneric"),
         };
     }
 
@@ -110,10 +104,7 @@ mod tests {
     /// test errors as a returned result
     fn can_return_result() {
         let result = raises_holochain_error(false);
-        let result = match result {
-            Ok(x) => x,
-            Err(_) => panic!(),
-        };
-        assert_eq!(result, ())
+
+        assert_eq!(result, Ok(()))
     }
 }

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -21,6 +21,7 @@ pub fn serializable_to_b58_hash<S: Serialize>(s: S, hash_type: Hash) -> String {
 
 #[cfg(test)]
 pub mod tests {
+    use super::*;
     use hash_table::entry::tests::test_entry;
     use multihash::Hash;
 
@@ -33,7 +34,7 @@ pub mod tests {
     /// mimics tests from legacy golang holochain core hashing bytes
     fn bytes_to_b58_known_golang() {
         assert_eq!(
-            super::bytes_to_b58_hash(b"test data", Hash::SHA2256),
+            bytes_to_b58_hash(b"test data", Hash::SHA2256),
             "QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqh2"
         )
     }
@@ -42,14 +43,14 @@ pub mod tests {
     /// mimics tests from legacy golang holochain core hashing strings
     fn str_to_b58_hash_known_golang() {
         assert_eq!(
-            super::str_to_b58_hash("test data", Hash::SHA2256),
+            str_to_b58_hash("test data", Hash::SHA2256),
             "QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqh2"
         );
     }
 
     #[test]
     /// known hash for a serializable something
-    fn serializable_to_b58_hash() {
+    fn can_serialize_to_b58_hash() {
         #[derive(Serialize)]
         struct Foo {
             foo: u8,
@@ -57,7 +58,7 @@ pub mod tests {
 
         assert_eq!(
             "Qme7Bu4NVYMtpsRtb7e4yyhcbE1zdB9PsrKTdosaqF3Bu3",
-            super::serializable_to_b58_hash(Foo { foo: 5 }, Hash::SHA2256),
+            serializable_to_b58_hash(Foo { foo: 5 }, Hash::SHA2256),
         );
     }
 }

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -65,7 +65,7 @@ impl Entry {
         self.entry_type.clone()
     }
 
-    /// returns true if the entry is valid
+    /// returns true iff the entry is valid
     pub fn validate(&self) -> bool {
         // always valid if immutable and new() enforces validity
         true
@@ -79,7 +79,6 @@ impl Entry {
 
     /// serialize the Entry to a canonical JSON string
     ///
-    /// panics if it fails to serialize
     /// @TODO return canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn to_json(&self) -> String {
@@ -90,7 +89,9 @@ impl Entry {
 
     /// deserialize an Entry from a canonical JSON string
     ///
-    /// panics if string isn't valid JSON
+    /// # Panics
+    ///
+    /// Panics if the string passed isn't valid JSON.
     /// @TODO accept canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     /// @TODO don't return invalid entries

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -48,11 +48,11 @@ impl Entry {
     pub fn hash(&self) -> String {
         // @TODO - this is the wrong string being hashed
         // @see https://github.com/holochain/holochain-rust/issues/103
-        let string_to_hash = self.content.clone();
+        let string_to_hash = &self.content;
 
         // @TODO the hashing algo should not be hardcoded
         // @see https://github.com/holochain/holochain-rust/issues/104
-        hash::str_to_b58_hash(&string_to_hash, Hash::SHA2256)
+        hash::str_to_b58_hash(string_to_hash, Hash::SHA2256)
     }
 
     /// content getter
@@ -67,7 +67,7 @@ impl Entry {
 
     /// returns true if the entry is valid
     pub fn validate(&self) -> bool {
-        // always valid iff immutable and new() enforces validity
+        // always valid if immutable and new() enforces validity
         true
     }
 
@@ -78,19 +78,24 @@ impl Entry {
     }
 
     /// serialize the Entry to a canonical JSON string
+    ///
+    /// panics if it fails to serialize
     /// @TODO return canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn to_json(&self) -> String {
         // @TODO error handling
         // @see https://github.com/holochain/holochain-rust/issues/168
-        serde_json::to_string(&self).unwrap()
+        serde_json::to_string(&self).expect("should serialize without error")
     }
 
-    /// deserialize a Entry from a canonical JSON string
+    /// deserialize an Entry from a canonical JSON string
+    ///
+    /// panics if string isn't valid JSON
     /// @TODO accept canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
+    /// @TODO don't return invalid entries
     pub fn from_json(s: &str) -> Entry {
-        let entry: Entry = serde_json::from_str(s).unwrap();
+        let entry: Entry = serde_json::from_str(s).expect("JSON should be valid");
         entry
     }
 }
@@ -180,17 +185,17 @@ pub mod tests {
         let t2 = "b";
 
         // same type and content is equal
-        assert_eq!(Entry::new(t1, c1).hash(), Entry::new(t1, c1).hash(),);
+        assert_eq!(Entry::new(t1, c1).hash(), Entry::new(t1, c1).hash());
 
         // same type different content is not equal
-        assert_ne!(Entry::new(t1, c1).hash(), Entry::new(t1, c2).hash(),);
+        assert_ne!(Entry::new(t1, c1).hash(), Entry::new(t1, c2).hash());
 
         // same content different type is equal
         // @see https://github.com/holochain/holochain-rust/issues/85
-        assert_eq!(Entry::new(t1, c1).hash(), Entry::new(t2, c1).hash(),);
+        assert_eq!(Entry::new(t1, c1).hash(), Entry::new(t2, c1).hash());
 
         // different content different type is not equal
-        assert_ne!(Entry::new(t1, c1).hash(), Entry::new(t2, c2).hash(),);
+        assert_ne!(Entry::new(t1, c1).hash(), Entry::new(t2, c2).hash());
     }
 
     #[test]
@@ -282,7 +287,7 @@ pub mod tests {
     /// test that we can round trip through JSON
     fn json_round_trip() {
         let e = test_entry_a();
-        let expected = "{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}";
+        let expected = r#"{"content":"test entry content","entry_type":"testEntryType"}"#;
         assert_eq!(expected, e.to_json());
         assert_eq!(e, Entry::from_json(expected));
         assert_eq!(e, Entry::from_json(&e.to_json()));

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -40,7 +40,7 @@ impl HashTable for MemTable {
     }
 
     fn get(&self, key: &str) -> Result<Option<Pair>, HolochainError> {
-        Ok(self.pairs.get(key).and_then(|p| Some(p.clone())))
+        Ok(self.pairs.get(key).cloned())
     }
 
     fn modify(
@@ -49,30 +49,24 @@ impl HashTable for MemTable {
         old_pair: &Pair,
         new_pair: &Pair,
     ) -> Result<(), HolochainError> {
-        let result = self.commit(new_pair);
-        if result.is_err() {
-            return result;
-        }
+        self.commit(new_pair)?;
 
         // @TODO what if meta fails when commit succeeds?
         // @see https://github.com/holochain/holochain-rust/issues/142
-        let result = self.assert_meta(&PairMeta::new(
+        self.assert_meta(PairMeta::new(
             keys,
             &old_pair,
             STATUS_NAME,
             &CRUDStatus::MODIFIED.bits().to_string(),
-        ));
-        if result.is_err() {
-            return result;
-        }
+        ))?;
 
         // @TODO what if meta fails when commit succeeds?
         // @see https://github.com/holochain/holochain-rust/issues/142
-        self.assert_meta(&PairMeta::new(keys, &old_pair, LINK_NAME, &new_pair.key()))
+        self.assert_meta(PairMeta::new(keys, &old_pair, LINK_NAME, &new_pair.key()))
     }
 
     fn retract(&mut self, keys: &Keys, pair: &Pair) -> Result<(), HolochainError> {
-        self.assert_meta(&PairMeta::new(
+        self.assert_meta(PairMeta::new(
             keys,
             &pair,
             STATUS_NAME,
@@ -80,13 +74,13 @@ impl HashTable for MemTable {
         ))
     }
 
-    fn assert_meta(&mut self, meta: &PairMeta) -> Result<(), HolochainError> {
-        self.meta.insert(meta.key(), meta.clone());
+    fn assert_meta(&mut self, meta: PairMeta) -> Result<(), HolochainError> {
+        self.meta.insert(meta.key(), meta);
         Ok(())
     }
 
     fn get_meta(&mut self, key: &str) -> Result<Option<PairMeta>, HolochainError> {
-        Ok(self.meta.get(key).and_then(|m| Some(m.clone())))
+        Ok(self.meta.get(key).cloned())
     }
 
     fn get_pair_meta(&mut self, pair: &Pair) -> Result<Vec<PairMeta>, HolochainError> {
@@ -147,7 +141,7 @@ pub mod tests {
     fn pair_round_trip() {
         let mut ht = test_table();
         let p = test_pair();
-        ht.commit(&p).unwrap();
+        ht.commit(&p).expect("should be able to commit valid pair");
         assert_eq!(ht.get(&p.key()), Ok(Some(p)));
     }
 
@@ -158,8 +152,9 @@ pub mod tests {
         let p1 = test_pair_a();
         let p2 = test_pair_b();
 
-        ht.commit(&p1).unwrap();
-        ht.modify(&test_keys(), &p1, &p2).unwrap();
+        ht.commit(&p1).expect("should be able to commit valid pair");
+        ht.modify(&test_keys(), &p1, &p2)
+            .expect("should be able to edit with valid pair");
 
         assert_eq!(
             vec![
@@ -171,11 +166,16 @@ pub mod tests {
                     &CRUDStatus::MODIFIED.bits().to_string(),
                 ),
             ],
-            ht.get_pair_meta(&p1).unwrap()
+            ht.get_pair_meta(&p1)
+                .expect("getting the metadata on a pair shouldn't fail")
         );
 
         let empty_vec: Vec<PairMeta> = Vec::new();
-        assert_eq!(empty_vec, ht.get_pair_meta(&p2).unwrap());
+        assert_eq!(
+            empty_vec,
+            ht.get_pair_meta(&p2)
+                .expect("getting the metadata on a pair shouldn't fail")
+        );
     }
 
     #[test]
@@ -185,10 +185,15 @@ pub mod tests {
         let p = test_pair();
         let empty_vec: Vec<PairMeta> = Vec::new();
 
-        ht.commit(&p).unwrap();
-        assert_eq!(empty_vec, ht.get_pair_meta(&p).unwrap());
+        ht.commit(&p).expect("should be able to commit valid pair");
+        assert_eq!(
+            empty_vec,
+            ht.get_pair_meta(&p)
+                .expect("getting the metadata on a pair shouldn't fail")
+        );
 
-        ht.retract(&test_keys(), &p).unwrap();
+        ht.retract(&test_keys(), &p)
+            .expect("should be able to retract");
         assert_eq!(
             vec![PairMeta::new(
                 &test_keys(),
@@ -196,7 +201,8 @@ pub mod tests {
                 STATUS_NAME,
                 &CRUDStatus::DELETED.bits().to_string(),
             )],
-            ht.get_pair_meta(&p).unwrap(),
+            ht.get_pair_meta(&p)
+                .expect("getting the metadata on a pair shouldn't fail"),
         );
     }
 
@@ -206,10 +212,20 @@ pub mod tests {
         let mut ht = test_table();
         let m = test_pair_meta();
 
-        assert_eq!(None, ht.get_meta(&m.key()).unwrap());
+        assert_eq!(
+            None,
+            ht.get_meta(&m.key())
+                .expect("getting the metadata on a pair shouldn't fail")
+        );
 
-        ht.assert_meta(&m).unwrap();
-        assert_eq!(Some(m.clone()), ht.get_meta(&m.key()).unwrap());
+        ht.assert_meta(m.clone())
+            .expect("asserting metadata shouldn't fail");
+        assert_eq!(
+            Some(&m),
+            ht.get_meta(&m.key())
+                .expect("getting the metadata on a pair shouldn't fail")
+                .as_ref()
+        );
     }
 
     #[test]
@@ -221,12 +237,26 @@ pub mod tests {
         let m2 = test_pair_meta_b();
         let empty_vec: Vec<PairMeta> = Vec::new();
 
-        assert_eq!(empty_vec, ht.get_pair_meta(&p).unwrap());
+        assert_eq!(
+            empty_vec,
+            ht.get_pair_meta(&p)
+                .expect("getting the metadata on a pair shouldn't fail")
+        );
 
-        ht.assert_meta(&m1).unwrap();
-        assert_eq!(vec![m1.clone()], ht.get_pair_meta(&p).unwrap());
+        ht.assert_meta(m1.clone())
+            .expect("asserting metadata shouldn't fail");
+        assert_eq!(
+            vec![m1.clone()],
+            ht.get_pair_meta(&p)
+                .expect("getting the metadata on a pair shouldn't fail")
+        );
 
-        ht.assert_meta(&m2).unwrap();
-        assert_eq!(vec![m2.clone(), m1.clone()], ht.get_pair_meta(&p).unwrap());
+        ht.assert_meta(m2.clone())
+            .expect("asserting metadata shouldn't fail");
+        assert_eq!(
+            vec![m2, m1],
+            ht.get_pair_meta(&p)
+                .expect("getting the metadata on a pair shouldn't fail")
+        );
     }
 }

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -31,7 +31,7 @@ pub trait HashTable {
 
     // meta
     /// assert a given PairMeta in the HashTable
-    fn assert_meta(&mut self, meta: &PairMeta) -> Result<(), HolochainError>;
+    fn assert_meta(&mut self, meta: PairMeta) -> Result<(), HolochainError>;
     /// lookup a PairMeta from the HashTable by key
     fn get_meta(&mut self, key: &str) -> Result<Option<PairMeta>, HolochainError>;
     /// lookup all PairMeta for a given Pair

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -21,7 +21,9 @@ impl Pair {
     /// need to include X. Pair Y can be regenerated with the same parameters as Y' and will be
     /// now be valid, the new Y' will include correct headers pointing to X.
     ///
-    /// panics if entry is somehow invalid
+    /// # Panics
+    ///
+    /// Panics if entry is somehow invalid
     ///
     /// @see chain::entry::Entry
     /// @see chain::header::Header
@@ -68,7 +70,6 @@ impl Pair {
 
     /// serialize the Pair to a canonical JSON string
     ///
-    /// panics if it fails to serialize
     /// @TODO return canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn to_json(&self) -> String {
@@ -79,7 +80,9 @@ impl Pair {
 
     /// deserialize a Pair from a canonical JSON string
     ///
-    /// panics if string isn't valid JSON
+    /// # Panics
+    ///
+    /// Panics if the string given isn't valid JSON.
     /// @TODO accept canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn from_json(s: &str) -> Pair {

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -2,6 +2,7 @@ use chain::Chain;
 use hash_table::{entry::Entry, header::Header, HashTable};
 use serde_json;
 
+/// Pairs are entries with their headers
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Pair {
     header: Header,
@@ -10,40 +11,44 @@ pub struct Pair {
 
 impl Pair {
     /// build a new Pair from a chain and entry
+    ///
     /// Header is generated automatically
+    ///
     /// a Pair is immutable, but the chain is mutable if chain.push() is used.
+    ///
     /// this means that if two Pairs X and Y are generated for chain C then Pair X is pushed onto
     /// C to create chain C' (containing X), then Pair Y is no longer valid as the headers would
     /// need to include X. Pair Y can be regenerated with the same parameters as Y' and will be
     /// now be valid, the new Y' will include correct headers pointing to X.
+    ///
+    /// panics if entry is somehow invalid
+    ///
     /// @see chain::entry::Entry
     /// @see chain::header::Header
-    pub fn new<T: HashTable>(chain: &Chain<T>, entry: &Entry) -> Pair {
-        let header = Header::new(chain, entry);
+    pub fn new<T: HashTable>(chain: &Chain<T>, entry: Entry) -> Pair {
+        let header = Header::new(chain, &entry);
 
         let p = Pair {
-            header: header.clone(),
-            entry: entry.clone(),
+            header: header,
+            entry: entry,
         };
 
-        if !p.validate() {
-            // we panic as no code path should attempt to create invalid pairs
-            // creating a Pair is an internal process of chain.push() and is deterministic based on
-            // an immutable Entry (that itself cannot be invalid), so this should never happen.
-            panic!("attempted to create an invalid pair");
-        };
+        // we panic as no code path should attempt to create invalid pairs
+        // creating a Pair is an internal process of chain.push() and is deterministic based on
+        // an immutable Entry (that itself cannot be invalid), so this should never happen.
+        assert!(p.validate(), "attempted to create an invalid pair");
 
         p
     }
 
     /// header getter
-    pub fn header(&self) -> Header {
-        self.header.clone()
+    pub fn header(&self) -> &Header {
+        &self.header
     }
 
     /// entry getter
-    pub fn entry(&self) -> Entry {
-        self.entry.clone()
+    pub fn entry(&self) -> &Entry {
+        &self.entry
     }
 
     /// key used in hash table lookups and other references
@@ -62,19 +67,23 @@ impl Pair {
     }
 
     /// serialize the Pair to a canonical JSON string
+    ///
+    /// panics if it fails to serialize
     /// @TODO return canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn to_json(&self) -> String {
         // @TODO error handling
         // @see https://github.com/holochain/holochain-rust/issues/168
-        serde_json::to_string(&self).unwrap()
+        serde_json::to_string(&self).expect("should serialize without error")
     }
 
     /// deserialize a Pair from a canonical JSON string
+    ///
+    /// panics if string isn't valid JSON
     /// @TODO accept canonical JSON
     /// @see https://github.com/holochain/holochain-rust/issues/75
     pub fn from_json(s: &str) -> Pair {
-        let pair: Pair = serde_json::from_str(s).unwrap();
+        let pair: Pair = serde_json::from_str(s).expect("json should be valid");
         pair
     }
 }
@@ -93,7 +102,7 @@ pub mod tests {
 
     /// dummy pair
     pub fn test_pair() -> Pair {
-        Pair::new(&test_chain(), &test_entry())
+        Pair::new(&test_chain(), test_entry())
     }
 
     /// dummy pair, same as test_pair()
@@ -103,7 +112,7 @@ pub mod tests {
 
     /// dummy pair, differs from test_pair()
     pub fn test_pair_b() -> Pair {
-        Pair::new(&test_chain(), &test_entry_b())
+        Pair::new(&test_chain(), test_entry_b())
     }
 
     #[test]
@@ -117,9 +126,9 @@ pub mod tests {
         assert_eq!(h1.entry(), e1.hash());
         assert_eq!(h1.next(), None);
 
-        let p1 = Pair::new(&chain, &e1);
-        assert_eq!(e1, p1.entry());
-        assert_eq!(h1, p1.header());
+        let p1 = Pair::new(&chain, e1.clone());
+        assert_eq!(&e1, p1.entry());
+        assert_eq!(&h1, p1.header());
     }
 
     #[test]
@@ -130,9 +139,9 @@ pub mod tests {
         let c = "bar";
         let e = Entry::new(t, c);
         let h = Header::new(&chain, &e);
-        let p = Pair::new(&chain, &e);
+        let p = Pair::new(&chain, e);
 
-        assert_eq!(h, p.header());
+        assert_eq!(&h, p.header());
     }
 
     #[test]
@@ -141,9 +150,11 @@ pub mod tests {
         let mut chain = test_chain();
         let t = "foo";
         let e = Entry::new(t, "");
-        let p = chain.push(&e).unwrap();
+        let p = chain
+            .push(&e)
+            .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
 
-        assert_eq!(e, p.entry());
+        assert_eq!(&e, p.entry());
     }
 
     #[test]
@@ -153,7 +164,7 @@ pub mod tests {
         let t = "fooType";
 
         let e1 = Entry::new(t, "bar");
-        let p1 = Pair::new(&chain, &e1);
+        let p1 = Pair::new(&chain, e1);
 
         assert!(p1.validate());
     }
@@ -161,12 +172,12 @@ pub mod tests {
     #[test]
     /// test JSON roundtrip for pairs
     fn json_roundtrip() {
-        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"type_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}";
+        let json = r#"{"header":{"entry_type":"testEntryType","time":"","next":null,"entry":"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT","type_next":null,"signature":""},"entry":{"content":"test entry content","entry_type":"testEntryType"}}"#;
 
-        assert_eq!(json, test_pair().to_json(),);
+        assert_eq!(json, test_pair().to_json());
 
-        assert_eq!(test_pair(), Pair::from_json(&json),);
+        assert_eq!(test_pair(), Pair::from_json(&json));
 
-        assert_eq!(test_pair(), Pair::from_json(&test_pair().to_json()),);
+        assert_eq!(test_pair(), Pair::from_json(&test_pair().to_json()));
     }
 }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -298,7 +298,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::InitApplication(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for InitApplication");
             sleep(Duration::from_millis(10))
@@ -311,7 +312,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ExecuteZomeFunction(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for ExecuteZomeFunction for genesis");
             sleep(Duration::from_millis(10))
@@ -324,7 +326,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnZomeFunctionResult(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for ReturnZomeFunctionResult from genesis");
             sleep(Duration::from_millis(10))
@@ -337,7 +340,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnInitializationResult(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for ReturnInitializationResult");
             sleep(Duration::from_millis(10))

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -1,14 +1,15 @@
 //use error::HolochainError;
 use action::ActionWrapper;
 use context::Context;
-use state::*;
+use state::State;
 use std::{
-    sync::{mpsc::*, Arc, RwLock, RwLockReadGuard},
+    sync::{
+        mpsc::{channel, Sender},
+        Arc, RwLock, RwLockReadGuard,
+    },
     thread,
-    time::Duration,
 };
 
-pub const REDUX_LOOP_TIMEOUT_MS: u64 = 400;
 pub const REDUX_DEFAULT_TIMEOUT_MS: u64 = 2000;
 
 /// Object representing a Holochain app instance.
@@ -25,13 +26,6 @@ type ClosureType = Box<FnMut(&State) -> bool + Send>;
 /// State Observer that executes a closure everytime the State changes.
 pub struct Observer {
     pub sensor: ClosureType,
-    pub done: bool,
-}
-
-impl Observer {
-    fn check(&mut self, state: &State) {
-        self.done = (self.sensor)(state);
-    }
 }
 
 pub static DISPATCH_WITHOUT_CHANNELS: &str = "dispatch called without channels open";
@@ -53,12 +47,8 @@ impl Instance {
     }
 
     /// Stack an Action in the Event Queue and block until is has been processed.
-    pub fn dispatch_and_wait(&mut self, action_wrapper: &ActionWrapper) {
-        dispatch_action_and_wait(
-            &self.action_channel,
-            &self.observer_channel,
-            &action_wrapper,
-        );
+    pub fn dispatch_and_wait(&mut self, action_wrapper: ActionWrapper) {
+        dispatch_action_and_wait(&self.action_channel, &self.observer_channel, action_wrapper);
     }
 
     /// Stack an action in the Event Queue and create an Observer on it with the specified closure
@@ -81,47 +71,44 @@ impl Instance {
         self.action_channel = tx_action.clone();
         self.observer_channel = tx_observer.clone();
 
-        let state_mutex = self.state.clone();
+        let state_mutex = Arc::clone(&self.state);
 
         thread::spawn(move || {
-            let mut state_observers: Vec<Box<Observer>> = Vec::new();
+            let mut state_observers: Vec<Observer> = Vec::new();
 
             // @TODO this should all be callable outside the loop so that deterministic tests that
             // don't rely on time can be written
             // @see https://github.com/holochain/holochain-rust/issues/169
-            loop {
-                match rx_action.recv_timeout(Duration::from_millis(REDUX_LOOP_TIMEOUT_MS)) {
-                    Ok(action_wrapper) => {
-                        // Mutate state
-                        {
-                            let mut state = state_mutex.write().unwrap();
-                            *state = state.reduce(
-                                context.clone(),
-                                action_wrapper,
-                                &tx_action,
-                                &tx_observer,
-                            );
-                        }
+            for action_wrapper in rx_action {
+                // Mutate state
+                {
+                    let mut state = state_mutex
+                        .write()
+                        .expect("owners of the state RwLock shouldn't panic");
+                    *state = state.reduce(
+                        Arc::clone(&context),
+                        action_wrapper,
+                        &tx_action,
+                        &tx_observer,
+                    );
+                }
 
-                        // Add new observers
-                        while let Ok(observer) = rx_observer.try_recv() {
-                            state_observers.push(Box::new(observer));
-                        }
+                // Add new observers
+                state_observers.extend(rx_observer.try_iter());
 
-                        // Run all observer closures
-                        {
-                            let state = state_mutex.read().unwrap();
-                            state_observers = state_observers
-                                .into_iter()
-                                .map(|mut observer| {
-                                    observer.check(&state);
-                                    observer
-                                })
-                                .filter(|observer| !observer.done)
-                                .collect::<Vec<_>>();
+                // Run all observer closures
+                {
+                    let state = state_mutex
+                        .read()
+                        .expect("owners of the state RwLock shouldn't panic");
+                    let mut i = 0;
+                    while i != state_observers.len() {
+                        if (&mut state_observers[i].sensor)(&state) {
+                            state_observers.remove(i);
+                        } else {
+                            i += 1;
                         }
                     }
-                    Err(ref _recv_error) => {}
                 }
             }
         });
@@ -138,7 +125,9 @@ impl Instance {
     }
 
     pub fn state(&self) -> RwLockReadGuard<State> {
-        self.state.read().unwrap()
+        self.state
+            .read()
+            .expect("owners of the state RwLock shouldn't panic")
     }
 }
 
@@ -149,21 +138,25 @@ impl Default for Instance {
 }
 
 /// Send Action to Instance's Event Queue and block until is has been processed.
+///
+/// panics if called before start_action_loop
 pub fn dispatch_action_and_wait(
     action_channel: &Sender<ActionWrapper>,
     observer_channel: &Sender<Observer>,
-    action_wrapper: &ActionWrapper,
+    action_wrapper: ActionWrapper,
 ) {
     // Create blocking channel
-    let (sender, receiver) = channel::<bool>();
+    let (sender, receiver) = channel::<()>();
 
     // Create blocking observer
     let observer_action_wrapper = action_wrapper.clone();
     let closure = move |state: &State| {
         if state.history.contains(&observer_action_wrapper) {
             sender
-                .send(true)
-                .unwrap_or_else(|_| panic!(DISPATCH_WITHOUT_CHANNELS));
+                .send(())
+                // the channel stays connected until the first message has been sent
+                // if this fails that means that it was called after having returned done=true
+                .expect("observer called after done");
             true
         } else {
             false
@@ -171,23 +164,20 @@ pub fn dispatch_action_and_wait(
     };
     let observer = Observer {
         sensor: Box::new(closure),
-        done: false,
     };
 
     // Send observer to instance
     observer_channel
         .send(observer)
-        .unwrap_or_else(|_| panic!(DISPATCH_WITHOUT_CHANNELS));
+        .expect(DISPATCH_WITHOUT_CHANNELS);
 
     // Send action to instance
     action_channel
         .send(action_wrapper.clone())
-        .unwrap_or_else(|_| panic!(DISPATCH_WITHOUT_CHANNELS));
+        .expect(DISPATCH_WITHOUT_CHANNELS);
 
     // Block until Observer has sensed the completion of the Action
-    receiver
-        .recv()
-        .unwrap_or_else(|_| panic!(DISPATCH_WITHOUT_CHANNELS));
+    receiver.recv().expect(DISPATCH_WITHOUT_CHANNELS);
 }
 
 /// Send Action to the Event Queue and create an Observer for it with the specified closure
@@ -201,12 +191,11 @@ pub fn dispatch_action_with_observer<F>(
 {
     let observer = Observer {
         sensor: Box::new(closure),
-        done: false,
     };
 
     observer_channel
         .send(observer)
-        .expect("observer channel to be open");
+        .expect(DISPATCH_WITHOUT_CHANNELS);
     dispatch_action(action_channel, &action_wrapper);
 }
 
@@ -217,7 +206,7 @@ pub fn dispatch_action(
 ) -> ActionWrapper {
     action_channel
         .send(action_wrapper.clone())
-        .unwrap_or_else(|_| panic!(DISPATCH_WITHOUT_CHANNELS));
+        .expect(DISPATCH_WITHOUT_CHANNELS);
     action_wrapper.clone()
 }
 
@@ -257,7 +246,7 @@ pub mod tests {
 
     /// create a test context and TestLogger pair so we can use the logger in assertions
     pub fn test_context_and_logger(agent_name: &str) -> (Arc<Context>, Arc<Mutex<TestLogger>>) {
-        let agent = Agent::from_string(agent_name);
+        let agent = Agent::from_string(agent_name.to_string());
         let logger = test_logger();
         (
             Arc::new(Context {
@@ -281,8 +270,8 @@ pub mod tests {
         let mut instance = Instance::new();
         instance.start_action_loop(test_context("jane"));
 
-        let action_wrapper = ActionWrapper::new(&Action::InitApplication(dna.clone()));
-        instance.dispatch_and_wait(&action_wrapper);
+        let action_wrapper = ActionWrapper::new(Action::InitApplication(dna.clone()));
+        instance.dispatch_and_wait(action_wrapper);
 
         assert_eq!(instance.state().nucleus().dna(), Some(dna.clone()));
 
@@ -301,7 +290,7 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::InitApplication(_) => true,
                 _ => false,
-            }) == None
+            }).is_none()
         {
             println!("Waiting for InitApplication");
             sleep(Duration::from_millis(10))
@@ -314,7 +303,7 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ExecuteZomeFunction(_) => true,
                 _ => false,
-            }) == None
+            }).is_none()
         {
             println!("Waiting for ExecuteZomeFunction for genesis");
             sleep(Duration::from_millis(10))
@@ -327,7 +316,7 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnZomeFunctionResult(_) => true,
                 _ => false,
-            }) == None
+            }).is_none()
         {
             println!("Waiting for ReturnZomeFunctionResult from genesis");
             sleep(Duration::from_millis(10))
@@ -338,9 +327,9 @@ pub mod tests {
             .history
             .iter()
             .find(|aw| match aw.action() {
-                Action::ReturnZomeFunctionResult(_) => true,
+                Action::ReturnInitializationResult(_) => true,
                 _ => false,
-            }) == None
+            }).is_none()
         {
             println!("Waiting for ReturnInitializationResult");
             sleep(Duration::from_millis(10))
@@ -373,17 +362,21 @@ pub mod tests {
         let dna = Dna::new();
         let (sender, receiver) = channel();
         instance.dispatch_with_observer(
-            &ActionWrapper::new(&Action::InitApplication(dna.clone())),
+            &ActionWrapper::new(Action::InitApplication(dna.clone())),
             move |state: &State| match state.nucleus().dna() {
                 Some(dna) => {
-                    sender.send(dna).expect("test channel must be open");
-                    return true;
+                    sender
+                        .send(dna)
+                        // the channel stays connected until the first message has been sent
+                        // if this fails that means that it was called after having returned done=true
+                        .expect("observer called after done");
+                    true
                 }
-                None => return false,
+                None => false,
             },
         );
 
-        let stored_dna = receiver.recv().unwrap();
+        let stored_dna = receiver.recv().expect("observer dropped before done");
 
         assert_eq!(dna, stored_dna);
     }
@@ -400,13 +393,13 @@ pub mod tests {
 
         let dna = Dna::new();
 
-        let action = ActionWrapper::new(&Action::InitApplication(dna.clone()));
+        let action = ActionWrapper::new(Action::InitApplication(dna.clone()));
         instance.start_action_loop(test_context("jane"));
 
         // the initial state is not intialized
         assert!(instance.state().nucleus().has_initialized() == false);
 
-        instance.dispatch_and_wait(&action);
+        instance.dispatch_and_wait(action);
         assert_eq!(instance.state().nucleus().dna(), Some(dna));
 
         // Wait for Init to finish

--- a/core/src/logger.rs
+++ b/core/src/logger.rs
@@ -3,10 +3,9 @@
 //! gets emitted globaly from the container.
 
 use chrono::Local;
-use std::fmt;
 
 /// trait that defines the logging functionality that holochain_core requires
-pub trait Logger: fmt::Debug + Send {
+pub trait Logger: Send {
     fn log(&mut self, msg: String);
 }
 
@@ -23,10 +22,4 @@ impl Logger for SimpleLogger {
     // fn new() -> SimpleLogger {
     //      SimpleLogger {}
     // }
-}
-
-impl fmt::Debug for SimpleLogger {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "<empty>")
-    }
 }

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -66,7 +66,7 @@ pub fn call_zome_and_wait_for_result(
     action_channel: &Sender<ActionWrapper>,
     observer_channel: &Sender<Observer>,
 ) -> Result<String, HolochainError> {
-    let call_action_wrapper = ActionWrapper::new(&Action::ExecuteZomeFunction(call.clone()));
+    let call_action_wrapper = ActionWrapper::new(Action::ExecuteZomeFunction(call.clone()));
 
     // Dispatch action with observer closure that waits for a result in the state
     let (sender, receiver) = channel();
@@ -95,7 +95,7 @@ pub fn call_and_wait_for_result(
     call: FunctionCall,
     instance: &mut super::instance::Instance,
 ) -> Result<String, HolochainError> {
-    let call_action = ActionWrapper::new(&Action::ExecuteZomeFunction(call.clone()));
+    let call_action = ActionWrapper::new(Action::ExecuteZomeFunction(call.clone()));
 
     // Dispatch action with observer closure that waits for a result in the state
     let (sender, receiver) = channel();
@@ -165,10 +165,9 @@ fn reduce_rir(
 /// Helper
 fn return_initialization_result(result: Option<String>, action_channel: &Sender<ActionWrapper>) {
     action_channel
-        .send(ActionWrapper::new(&Action::ReturnInitializationResult(
+        .send(ActionWrapper::new(Action::ReturnInitializationResult(
             result,
-        )))
-        .expect("action channel to be open in reducer");
+        ))).expect("action channel to be open in reducer");
 }
 
 /// Reduce InitApplication Action
@@ -211,8 +210,7 @@ fn reduce_ia(
                             &zome.name(),
                             &CallbackParams::Genesis,
                         )
-                    })
-                    .collect();
+                    }).collect();
 
                 // pad out a single pass if there are no zome results
                 // @TODO is this really OK?
@@ -261,7 +259,7 @@ fn reduce_ezf(
     action_channel: &Sender<ActionWrapper>,
     observer_channel: &Sender<Observer>,
 ) {
-    let function_call = match action_wrapper.action() {
+    let function_call = match action_wrapper.action().clone() {
         Action::ExecuteZomeFunction(call) => call,
         _ => unreachable!(),
     };
@@ -309,9 +307,7 @@ fn reduce_ezf(
 
                     // Send ReturnResult Action
                     action_channel
-                        .send(ActionWrapper::new(&Action::ReturnZomeFunctionResult(
-                            result,
-                        )))
+                        .send(ActionWrapper::new(Action::ReturnZomeFunctionResult(result)))
                         .expect("action channel to be open in reducer");
                 });
             } else {
@@ -340,9 +336,7 @@ fn reduce_ezf(
     }
     if has_error {
         action_channel
-            .send(ActionWrapper::new(&Action::ReturnZomeFunctionResult(
-                result,
-            )))
+            .send(ActionWrapper::new(Action::ReturnZomeFunctionResult(result)))
             .expect("action channel to be open in reducer");
     }
 }
@@ -540,7 +534,7 @@ pub mod tests {
     /// smoke test the init of a nucleus reduction
     fn can_reduce_initialize_action() {
         let dna = Dna::new();
-        let action_wrapper = ActionWrapper::new(&Action::InitApplication(dna));
+        let action_wrapper = ActionWrapper::new(Action::InitApplication(dna));
         let nucleus = Arc::new(NucleusState::new()); // initialize to bogus value
         let (sender, receiver) = channel::<ActionWrapper>();
         let (tx_observer, _observer) = channel::<Observer>();
@@ -553,7 +547,7 @@ pub mod tests {
             &sender.clone(),
             &tx_observer.clone(),
         );
-        receiver.recv().unwrap_or_else(|_| panic!("channel failed"));
+        receiver.recv().expect("channel failed");
 
         assert_eq!(reduced_nucleus.has_initialized(), false);
         assert_eq!(reduced_nucleus.has_initialization_failed(), false);
@@ -564,7 +558,7 @@ pub mod tests {
     /// test that we can initialize and send/receive result values from a nucleus
     fn can_reduce_return_init_result_action() {
         let dna = Dna::new();
-        let action_wrapper = ActionWrapper::new(&Action::InitApplication(dna));
+        let action_wrapper = ActionWrapper::new(Action::InitApplication(dna));
         let nucleus = Arc::new(NucleusState::new()); // initialize to bogus value
         let (sender, receiver) = channel::<ActionWrapper>();
         let (tx_observer, _observer) = channel::<Observer>();
@@ -577,14 +571,14 @@ pub mod tests {
             &sender.clone(),
             &tx_observer.clone(),
         );
-        receiver.recv().unwrap_or_else(|_| panic!("receiver fail"));
+        receiver.recv().expect("receiver fail");
 
         assert_eq!(initializing_nucleus.has_initialized(), false);
         assert_eq!(initializing_nucleus.has_initialization_failed(), false);
         assert_eq!(initializing_nucleus.status(), NucleusStatus::Initializing);
 
         // Send ReturnInit(false) ActionWrapper
-        let return_action_wrapper = ActionWrapper::new(&Action::ReturnInitializationResult(Some(
+        let return_action_wrapper = ActionWrapper::new(Action::ReturnInitializationResult(Some(
             "init failed".to_string(),
         )));
         let reduced_nucleus = reduce(
@@ -610,7 +604,7 @@ pub mod tests {
             &sender.clone(),
             &tx_observer.clone(),
         );
-        receiver.recv().unwrap_or_else(|_| panic!("receiver fail"));
+        receiver.recv().expect("receiver shouldn't fail");
 
         assert_eq!(
             reduced_nucleus.status(),
@@ -618,7 +612,7 @@ pub mod tests {
         );
 
         // Send ReturnInit(None) ActionWrapper
-        let return_action_wrapper = ActionWrapper::new(&Action::ReturnInitializationResult(None));
+        let return_action_wrapper = ActionWrapper::new(Action::ReturnInitializationResult(None));
         let reduced_nucleus = reduce(
             test_context("jimmy"),
             initializing_nucleus.clone(),
@@ -637,7 +631,7 @@ pub mod tests {
     fn can_reduce_execfn_action() {
         let call = FunctionCall::new("myZome", "public", "bogusfn", "");
 
-        let action_wrapper = ActionWrapper::new(&Action::ExecuteZomeFunction(call));
+        let action_wrapper = ActionWrapper::new(Action::ExecuteZomeFunction(call));
         let nucleus = Arc::new(NucleusState::new()); // initialize to bogus value
         let (sender, _receiver) = channel::<ActionWrapper>();
         let (tx_observer, _observer) = channel::<Observer>();

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -167,7 +167,8 @@ fn return_initialization_result(result: Option<String>, action_channel: &Sender<
     action_channel
         .send(ActionWrapper::new(Action::ReturnInitializationResult(
             result,
-        ))).expect("action channel to be open in reducer");
+        )))
+        .expect("action channel to be open in reducer");
 }
 
 /// Reduce InitApplication Action
@@ -210,7 +211,8 @@ fn reduce_ia(
                             &zome.name(),
                             &CallbackParams::Genesis,
                         )
-                    }).collect();
+                    })
+                    .collect();
 
                 // pad out a single pass if there are no zome results
                 // @TODO is this really OK?

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -73,7 +73,7 @@ pub fn call_zome_and_wait_for_result(
     ::instance::dispatch_action_with_observer(
         action_channel,
         observer_channel,
-        &call_action_wrapper,
+        call_action_wrapper,
         move |state: &super::state::State| {
             if let Some(result) = state.nucleus().ribosome_call_result(&call) {
                 sender
@@ -99,7 +99,7 @@ pub fn call_and_wait_for_result(
 
     // Dispatch action with observer closure that waits for a result in the state
     let (sender, receiver) = channel();
-    instance.dispatch_with_observer(&call_action, move |state: &super::state::State| {
+    instance.dispatch_with_observer(call_action, move |state: &super::state::State| {
         if let Some(result) = state.nucleus().ribosome_call_result(&call) {
             sender
                 .send(result.clone())

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -25,71 +25,74 @@ pub fn invoke_commit(
 ) -> Result<Option<RuntimeValue>, Trap> {
     // deserialize args
     let args_str = runtime_args_to_utf8(&runtime, &args);
-    let res_entry: Result<CommitArgs, _> = serde_json::from_str(&args_str);
-    // Exit on error
-    if res_entry.is_err() {
-        // Return Error code in i32 format
-        return Ok(Some(RuntimeValue::I32(
-            HcApiReturnCode::ErrorSerdeJson as i32,
-        )));
-    }
+    let entry_input: CommitArgs = match serde_json::from_str(&args_str) {
+        Ok(entry_input) => entry_input,
+        // Exit on error
+        Err(_) => {
+            // Return Error code in i32 format
+            return Ok(Some(RuntimeValue::I32(
+                HcApiReturnCode::ErrorSerdeJson as i32,
+            )));
+        }
+    };
 
     // Create Chain Entry
-    let entry_input = res_entry.unwrap();
     let entry =
         ::hash_table::entry::Entry::new(&entry_input.entry_type_name, &entry_input.entry_content);
 
-    let validate_result = validate_commit(
+    // @TODO test that failing validation prevents commits happening
+    // @see https://github.com/holochain/holochain-rust/issues/206
+    if let CallbackResult::Fail(_) = validate_commit(
         &runtime.action_channel,
         &runtime.observer_channel,
         &runtime.function_call.zome,
         &CallbackParams::ValidateCommit(entry.clone()),
-    );
-
-    // @TODO test that failing validation prevents commits happening
-    // @see https://github.com/holochain/holochain-rust/issues/206
-    match validate_result {
-        CallbackResult::Fail(_) => Ok(Some(RuntimeValue::I32(
+    ) {
+        return Ok(Some(RuntimeValue::I32(
             HcApiReturnCode::ErrorCallbackResult as i32,
-        ))),
-        // anything other than a fail means we should commit the entry
-        _ => {
-            // Create Commit Action
-            let action_wrapper = ActionWrapper::new(&Action::Commit(entry));
-            // Send Action and block for result
-            let (sender, receiver) = channel();
-            ::instance::dispatch_action_with_observer(
-                &runtime.action_channel,
-                &runtime.observer_channel,
-                &action_wrapper.clone(),
-                move |state: &::state::State| {
-                    let actions = state.agent().actions().clone();
-                    if actions.contains_key(&action_wrapper) {
-                        // @TODO never panic in wasm
-                        // @see https://github.com/holochain/holochain-rust/issues/159
-                        let v = &actions[&action_wrapper];
-                        sender.send(v.clone()).expect("local channel to be open");
-                        true
-                    } else {
-                        false
-                    }
-                },
-            );
-            // TODO #97 - Return error if timeout or something failed
-            // return Err(_);
+        )));
+    }
+    // anything other than a fail means we should commit the entry
 
-            let action_result = receiver.recv().expect("local channel to work");
+    // Create Commit Action
+    let action_wrapper = ActionWrapper::new(Action::Commit(entry));
+    // Send Action and block for result
+    let (sender, receiver) = channel();
+    ::instance::dispatch_action_with_observer(
+        &runtime.action_channel,
+        &runtime.observer_channel,
+        &action_wrapper.clone(),
+        move |state: &::state::State| {
+            let mut actions_copy = state.agent().actions();
+            match actions_copy.remove(&action_wrapper) {
+                Some(v) => {
+                    // @TODO never panic in wasm
+                    // @see https://github.com/holochain/holochain-rust/issues/159
+                    sender
+                        .send(v)
+                        // the channel stays connected until the first message has been sent
+                        // if this fails that means that it was called after having returned done=true
+                        .expect("observer called after done");
 
-            match action_result {
-                ActionResponse::Commit(_) => {
-                    // serialize, allocate and encode result
-                    runtime_allocate_encode_str(runtime, &action_result.to_json())
+                    true
                 }
-                _ => Ok(Some(RuntimeValue::I32(
-                    HcApiReturnCode::ErrorActionResult as i32,
-                ))),
+                None => false,
             }
+        },
+    );
+    // TODO #97 - Return error if timeout or something failed
+    // return Err(_);
+
+    let action_result = receiver.recv().expect("observer dropped before done");
+
+    match action_result {
+        ActionResponse::Commit(_) => {
+            // serialize, allocate and encode result
+            runtime_allocate_encode_str(runtime, &action_result.to_json())
         }
+        _ => Ok(Some(RuntimeValue::I32(
+            HcApiReturnCode::ErrorActionResult as i32,
+        ))),
     }
 }
 
@@ -110,7 +113,9 @@ mod tests {
             entry_type_name: e.entry_type().into(),
             entry_content: e.content().into(),
         };
-        serde_json::to_string(&args).unwrap().into_bytes()
+        serde_json::to_string(&args)
+            .expect("args should serialize")
+            .into_bytes()
     }
 
     #[test]

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -61,7 +61,7 @@ pub fn invoke_commit(
     ::instance::dispatch_action_with_observer(
         &runtime.action_channel,
         &runtime.observer_channel,
-        &action_wrapper.clone(),
+        action_wrapper.clone(),
         move |state: &::state::State| {
             let mut actions_copy = state.agent().actions();
             match actions_copy.remove(&action_wrapper) {

--- a/core/src/nucleus/ribosome/api/get.rs
+++ b/core/src/nucleus/ribosome/api/get.rs
@@ -32,7 +32,7 @@ pub fn invoke_get(runtime: &mut Runtime, args: &RuntimeArgs) -> Result<Option<Ru
     ::instance::dispatch_action_with_observer(
         &runtime.action_channel,
         &runtime.observer_channel,
-        &action_wrapper.clone(),
+        action_wrapper.clone(),
         move |state: &::state::State| {
             let mut actions_copy = state.agent().actions();
             match actions_copy.remove(&action_wrapper) {

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -43,11 +43,11 @@ pub enum ZomeAPIFunction {
     /// Zome API
 
     /// send debug information to the log
-    /// debug(s : String)
+    /// debug(s: String)
     Debug,
 
     /// Commit an entry to source chain
-    /// commit(entry_type : String, entry_content : String) -> Hash
+    /// commit(entry_type: String, entry_content: String) -> Hash
     Commit,
 
     /// Get an entry from source chain by key (header hash)
@@ -186,6 +186,8 @@ pub fn runtime_allocate_encode_str(
 }
 
 /// Executes an exposed function in a wasm binary
+///
+/// panics if wasm isn't valid
 pub fn call(
     context: Arc<Context>,
     action_channel: &Sender<ActionWrapper>,
@@ -195,7 +197,7 @@ pub fn call(
     parameters: Option<Vec<u8>>,
 ) -> Result<Runtime, InterpreterError> {
     // Create wasm module from wasm binary
-    let module = wasmi::Module::from_buffer(wasm).unwrap();
+    let module = wasmi::Module::from_buffer(wasm).expect("wasm should be valid");
 
     // Describe invokable functions from within Zome
     impl Externals for Runtime {
@@ -279,8 +281,7 @@ pub fn call(
                 format!("{}_dispatch", function_call.function.clone()).as_str(),
                 &[RuntimeValue::I32(encoded_allocation_of_input as i32)],
                 mut_runtime,
-            )?
-            .unwrap()
+            )?.unwrap()
             .try_into()
             .unwrap();
     }
@@ -395,8 +396,7 @@ pub mod tests {
                 "#,
                     canonical_name
                 ),
-            )
-            .unwrap()
+            ).unwrap()
             .as_ref()
             .to_vec()
     }

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -281,7 +281,8 @@ pub fn call(
                 format!("{}_dispatch", function_call.function.clone()).as_str(),
                 &[RuntimeValue::I32(encoded_allocation_of_input as i32)],
                 mut_runtime,
-            )?.unwrap()
+            )?
+            .unwrap()
             .try_into()
             .unwrap();
     }
@@ -396,7 +397,8 @@ pub mod tests {
                 "#,
                     canonical_name
                 ),
-            ).unwrap()
+            )
+            .unwrap()
             .as_ref()
             .to_vec()
     }

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -39,7 +39,7 @@ pub enum Callback {
 
     /// Communication Capability
 
-    /// receive(from : String, message : String) -> String
+    /// receive(from: String, message: String) -> String
     Receive,
 }
 
@@ -272,8 +272,7 @@ pub mod tests {
                 "#,
                     canonical_name, result,
                 ),
-            )
-            .unwrap()
+            ).expect("string literal should be valid WAT")
             .as_ref()
             .to_vec()
     }
@@ -282,7 +281,7 @@ pub mod tests {
         let dna = test_utils::create_test_dna_with_wasm(
             zome,
             Callback::from_str(canonical_name)
-                .unwrap()
+                .expect("string argument canonical_name should be valid callback")
                 .capability()
                 .as_str(),
             test_callback_wasm(canonical_name, result),
@@ -294,16 +293,22 @@ pub mod tests {
     #[test]
     /// test the FromStr implementation for LifecycleFunction
     fn test_from_str() {
-        assert_eq!(Callback::Genesis, Callback::from_str("genesis").unwrap(),);
+        assert_eq!(
+            Callback::Genesis,
+            Callback::from_str("genesis").expect("string literal should be valid callback")
+        );
         assert_eq!(
             Callback::ValidateCommit,
-            Callback::from_str("validate_commit").unwrap(),
+            Callback::from_str("validate_commit").expect("string literal should be valid callback"),
         );
-        assert_eq!(Callback::Receive, Callback::from_str("receive").unwrap(),);
+        assert_eq!(
+            Callback::Receive,
+            Callback::from_str("receive").expect("string literal should be valid callback")
+        );
 
         assert_eq!(
             "Cannot convert string to Callback",
-            Callback::from_str("foo").unwrap_err(),
+            Callback::from_str("foo").expect_err("string literal shouldn't be valid callback"),
         );
     }
 

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -272,7 +272,8 @@ pub mod tests {
                 "#,
                     canonical_name, result,
                 ),
-            ).expect("string literal should be valid WAT")
+            )
+            .expect("string literal should be valid WAT")
             .as_ref()
             .to_vec()
     }

--- a/core/src/persister.rs
+++ b/core/src/persister.rs
@@ -7,7 +7,7 @@ pub trait Persister: Send {
     // snowflake is only unique across a single process, not a reboot save/load round trip
     // we'd need real UUIDs for persistant uniqueness
     // @see https://github.com/holochain/holochain-rust/issues/203
-    fn save(&mut self, state: &State);
+    fn save(&mut self, state: State);
     fn load(&self) -> Result<Option<State>, HolochainError>;
 }
 
@@ -17,8 +17,8 @@ pub struct SimplePersister {
 }
 
 impl Persister for SimplePersister {
-    fn save(&mut self, state: &State) {
-        self.state = Some(state.clone());
+    fn save(&mut self, state: State) {
+        self.state = Some(state);
     }
     fn load(&self) -> Result<Option<State>, HolochainError> {
         Ok(self.state.clone())
@@ -41,13 +41,8 @@ mod tests {
     #[test]
     fn can_instantiate() {
         let store = SimplePersister::new();
-        match store.load() {
-            Err(_) => assert!(false),
-            Ok(state) => match state {
-                None => assert!(true),
-                _ => assert!(false),
-            },
-        }
+
+        assert_eq!(store.load(), Ok(None));
     }
 
     #[test]
@@ -67,8 +62,8 @@ mod tests {
             &tx_observer,
         );
 
-        store.save(&new_state);
+        store.save(new_state.clone());
 
-        assert_eq!(store.load().unwrap().unwrap(), new_state);
+        assert_eq!(store.load(), Ok(Some(new_state)));
     }
 }

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -35,14 +35,14 @@ impl State {
     ) -> Self {
         let mut new_state = State {
             nucleus: ::nucleus::reduce(
-                context.clone(),
+                Arc::clone(&context),
                 Arc::clone(&self.nucleus),
                 &action_wrapper,
                 action_channel,
                 observer_channel,
             ),
             agent: ::agent::state::reduce(
-                context.clone(),
+                Arc::clone(&context),
                 Arc::clone(&self.agent),
                 &action_wrapper,
                 action_channel,

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! // but for now:
 //! let dna = Dna::new();
-//! let agent = Agent::from_string("bob");
+//! let agent = Agent::from_string("bob".to_string());
 //! let context = Context {
 //!     agent: agent,
 //!     logger: Arc::new(Mutex::new(SimpleLogger {})),
@@ -83,7 +83,7 @@ impl Holochain {
         let mut instance = Instance::new();
         let name = dna.name.clone();
 
-        let action = ActionWrapper::new(&Action::InitApplication(dna));
+        let action = ActionWrapper::new(Action::InitApplication(dna));
         instance.start_action_loop(context.clone());
 
         let (sender, receiver) = channel();
@@ -184,7 +184,7 @@ mod tests {
     // doesn't work.
     // @see https://github.com/holochain/holochain-rust/issues/185
     fn test_context(agent_name: &str) -> (Arc<Context>, Arc<Mutex<test_utils::TestLogger>>) {
-        let agent = holochain_agent::Agent::from_string(agent_name);
+        let agent = holochain_agent::Agent::from_string(agent_name.to_string());
         let logger = test_utils::test_logger();
         (
             Arc::new(Context {

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -88,7 +88,7 @@ impl Holochain {
 
         let (sender, receiver) = channel();
 
-        instance.dispatch_with_observer(&action, move |state: &State| {
+        instance.dispatch_with_observer(action, move |state: &State| {
             let nucleus_state = state.nucleus();
             if nucleus_state.has_initialized() || nucleus_state.has_initialization_failed() {
                 sender

--- a/core_api/wasm-test/commit/src/lib.rs
+++ b/core_api/wasm-test/commit/src/lib.rs
@@ -26,7 +26,7 @@ struct CommitOutputStruct {
 
 /// Call HC API COMMIT function with proper input struct
 /// return hash of entry added source chain
-fn hc_commit(mem_stack: &mut SinglePageStack, entry_type_name: &str, entry_content : &str)
+fn hc_commit(mem_stack: &mut SinglePageStack, entry_type_name: &str, entry_content: &str)
   -> Result<String, HcApiReturnCode>
 {
   // Put args in struct and serialize into memory
@@ -48,7 +48,7 @@ fn hc_commit(mem_stack: &mut SinglePageStack, entry_type_name: &str, entry_conte
   }
 
   // Deserialize complex result stored in memory
-  let output : CommitOutputStruct = result.unwrap();
+  let output: CommitOutputStruct = result.unwrap();
 
   // Free result & input allocations and all allocations made inside commit()
   mem_stack.deallocate(allocation_of_input).expect("deallocate failed");
@@ -104,7 +104,7 @@ fn hc_commit_fail(mem_stack: &mut SinglePageStack)
   }
 
   // Deserialize complex result stored in memory
-  let output : CommitOutputStruct = result.unwrap();
+  let output: CommitOutputStruct = result.unwrap();
   // Free result & input allocations and all allocations made inside commit()
   mem_stack.deallocate(allocation_of_input).expect("deallocate failed");
 

--- a/core_api_c_binding/src/lib.rs
+++ b/core_api_c_binding/src/lib.rs
@@ -25,7 +25,7 @@ impl Logger for NullLogger {
 
 #[no_mangle]
 pub unsafe extern "C" fn holochain_new(ptr: *mut Dna) -> *mut Holochain {
-    let agent = Agent::from_string("c_bob");
+    let agent = Agent::from_string("c_bob".to_string());
 
     let context = Arc::new(Context {
         agent,

--- a/dna/src/lib.rs
+++ b/dna/src/lib.rs
@@ -13,7 +13,7 @@
 //! let mut dna = Dna::new();
 //! dna.name = name.clone();
 //!
-//! let json = dna.to_json().unwrap();
+//! let json = dna.to_json();
 //!
 //! let dna2 = Dna::new_from_json(&json).unwrap();
 //! assert_eq!(name, dna2.name);
@@ -116,7 +116,7 @@ impl Dna {
     ///
     /// let dna = Dna::new_from_json(r#"{
     ///     "name": "MyTestApp"
-    /// }"#).unwrap();
+    /// }"#).expect("DNA should be valid");
     ///
     /// assert_eq!("MyTestApp", dna.name);
     /// ```
@@ -132,11 +132,11 @@ impl Dna {
     /// use holochain_dna::Dna;
     ///
     /// let dna = Dna::new();
-    /// println!("json: {}", dna.to_json().unwrap());
+    /// println!("json: {}", dna.to_json());
     ///
     /// ```
-    pub fn to_json(&self) -> serde_json::Result<String> {
-        serde_json::to_string(self)
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("DNA should serialize")
     }
 
     /// Generate a pretty-printed json string from an in-memory dna struct.
@@ -147,7 +147,7 @@ impl Dna {
     /// use holochain_dna::Dna;
     ///
     /// let dna = Dna::new();
-    /// println!("json: {}", dna.to_json_pretty().unwrap());
+    /// println!("json: {}", dna.to_json_pretty().expect("DNA should serialize"));
     ///
     /// ```
     pub fn to_json_pretty(&self) -> serde_json::Result<String> {
@@ -165,11 +165,10 @@ impl Dna {
         zome: &'a zome::Zome,
         capability_name: &str,
     ) -> Option<&'a wasm::DnaWasm> {
-        let capability = zome
-            .capabilities
+        zome.capabilities
             .iter()
-            .find(|c| c.name == capability_name)?;
-        Some(&capability.code)
+            .find(|c| c.name == capability_name)
+            .map(|capability| &capability.code)
     }
 
     /// Return a Zome's WASM bytecode for a specified Capability
@@ -181,12 +180,10 @@ impl Dna {
         let zome_name = zome_name.into();
         let capability_name = capability_name.into();
 
-        let zome = self.zomes.iter().find(|z| z.name() == zome_name)?;
-        let capability = zome
-            .capabilities
+        self.zomes
             .iter()
-            .find(|c| c.name == capability_name)?;
-        Some(&capability.code)
+            .find(|z| z.name() == zome_name)
+            .and_then(|zome| self.get_capability(&zome, &capability_name))
     }
 
     /// Return a Zome's WASM bytecode for the validation of an entry
@@ -206,7 +203,7 @@ impl Dna {
 
 impl Hash for Dna {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let s = self.to_json().unwrap();
+        let s = self.to_json();
         s.hash(state);
     }
 }
@@ -214,7 +211,7 @@ impl Hash for Dna {
 impl PartialEq for Dna {
     fn eq(&self, other: &Dna) -> bool {
         // need to guarantee that PartialEq and Hash always agree
-        self.to_json().unwrap() == other.to_json().unwrap()
+        self.to_json() == other.to_json()
     }
 }
 
@@ -244,7 +241,7 @@ pub mod tests {
     fn can_parse_and_output_json_helpers() {
         let dna = test_dna();
 
-        let serialized = dna.to_json().unwrap();
+        let serialized = dna.to_json();
 
         let deserialized = Dna::new_from_json(&serialized).unwrap();
 
@@ -318,7 +315,7 @@ pub mod tests {
 
         println!("{}", dna.to_json_pretty().unwrap());
 
-        let serialized = dna.to_json().unwrap().replace(char::is_whitespace, "");
+        let serialized = dna.to_json().replace(char::is_whitespace, "");
 
         assert_eq!(fixture, serialized);
     }

--- a/dna/src/lib.rs
+++ b/dna/src/lib.rs
@@ -165,13 +165,14 @@ impl Dna {
         zome: &'a zome::Zome,
         capability_name: &str,
     ) -> Option<&'a wasm::DnaWasm> {
-        zome.capabilities
+        let capability = zome
+            .capabilities
             .iter()
-            .find(|c| c.name == capability_name)
-            .map(|capability| &capability.code)
+            .find(|c| c.name == capability_name)?;
+        Some(&capability.code)
     }
 
-    /// Return a Zome's WASM bytecode for a specified Capability
+    /// Find a Zome and return it's WASM bytecode for a specified Capability
     pub fn get_wasm_for_capability<T: Into<String>>(
         &self,
         zome_name: T,
@@ -179,11 +180,9 @@ impl Dna {
     ) -> Option<&wasm::DnaWasm> {
         let zome_name = zome_name.into();
         let capability_name = capability_name.into();
-
-        self.zomes
-            .iter()
-            .find(|z| z.name() == zome_name)
-            .and_then(|zome| self.get_capability(&zome, &capability_name))
+        let zome = self.get_zome(&zome_name)?;
+        let capability = self.get_capability(&zome, &capability_name)?;
+        Some(capability)
     }
 
     /// Return a Zome's WASM bytecode for the validation of an entry

--- a/dna/src/zome/capabilities.rs
+++ b/dna/src/zome/capabilities.rs
@@ -208,7 +208,7 @@ mod tests {
     #[test]
     /// test that a canonical string can be created from ReservedCapabilityNames
     fn test_capabilities_as_str() {
-        assert_eq!(ReservedCapabilityNames::LifeCycle.as_str(), "hc_lifecycle",);
+        assert_eq!(ReservedCapabilityNames::LifeCycle.as_str(), "hc_lifecycle");
         assert_eq!(
             ReservedCapabilityNames::Communication.as_str(),
             "hc_web_gateway",
@@ -226,15 +226,15 @@ mod tests {
                 "fn_declarations": [
                     {
                         "name": "test",
-                        "signature" :
+                        "signature":
                         {
-                            "inputs" : [
+                            "inputs": [
                                 {
                                     "name": "post",
                                     "type": "string"
                                 }
                             ],
-                            "outputs" : [
+                            "outputs": [
                                 {
                                     "name": "hash",
                                     "type": "string"

--- a/dna_c_binding/src/lib.rs
+++ b/dna_c_binding/src/lib.rs
@@ -58,10 +58,7 @@ pub extern "C" fn holochain_dna_to_json(ptr: *const Dna) -> *mut c_char {
             &*ptr
         };
 
-        let json = match dna.to_json() {
-            Ok(s) => s,
-            Err(_) => return std::ptr::null_mut(),
-        };
+        let json = dna.to_json();
 
         let json = match CString::new(json) {
             Ok(s) => s,
@@ -186,8 +183,7 @@ fn zome_names_as_vec(dna: &Dna) -> Option<Vec<*const c_char>> {
                     Err(_) => std::ptr::null(),
                 };
                 raw as *const c_char
-            })
-            .collect::<Vec<*const c_char>>(),
+            }).collect::<Vec<*const c_char>>(),
     )
 }
 
@@ -224,8 +220,7 @@ fn capabilities_as_vec(dna: &Dna, zome_name: &str) -> Option<Vec<*const c_char>>
                 Err(_) => std::ptr::null(),
             };
             raw as *const c_char
-        })
-        .collect::<Vec<*const c_char>>();
+        }).collect::<Vec<*const c_char>>();
     Some(result)
 }
 
@@ -261,8 +256,7 @@ fn fn_names_as_vec(
                 Err(_) => std::ptr::null(),
             };
             raw as *const c_char
-        })
-        .collect::<Vec<*const c_char>>();
+        }).collect::<Vec<*const c_char>>();
     Some(result)
 }
 
@@ -307,8 +301,7 @@ fn fn_parameters_as_vec(
                 Err(_) => std::ptr::null(),
             };
             raw as *const c_char
-        })
-        .collect::<Vec<*const c_char>>();
+        }).collect::<Vec<*const c_char>>();
     Some(result)
 }
 

--- a/dna_c_binding/src/lib.rs
+++ b/dna_c_binding/src/lib.rs
@@ -183,7 +183,8 @@ fn zome_names_as_vec(dna: &Dna) -> Option<Vec<*const c_char>> {
                     Err(_) => std::ptr::null(),
                 };
                 raw as *const c_char
-            }).collect::<Vec<*const c_char>>(),
+            })
+            .collect::<Vec<*const c_char>>(),
     )
 }
 
@@ -220,7 +221,8 @@ fn capabilities_as_vec(dna: &Dna, zome_name: &str) -> Option<Vec<*const c_char>>
                 Err(_) => std::ptr::null(),
             };
             raw as *const c_char
-        }).collect::<Vec<*const c_char>>();
+        })
+        .collect::<Vec<*const c_char>>();
     Some(result)
 }
 
@@ -256,7 +258,8 @@ fn fn_names_as_vec(
                 Err(_) => std::ptr::null(),
             };
             raw as *const c_char
-        }).collect::<Vec<*const c_char>>();
+        })
+        .collect::<Vec<*const c_char>>();
     Some(result)
 }
 
@@ -301,7 +304,8 @@ fn fn_parameters_as_vec(
                 Err(_) => std::ptr::null(),
             };
             raw as *const c_char
-        }).collect::<Vec<*const c_char>>();
+        })
+        .collect::<Vec<*const c_char>>();
     Some(result)
 }
 

--- a/doc/specs/dna.md
+++ b/doc/specs/dna.md
@@ -138,15 +138,15 @@ They are available in keyword specific Capabilities and function names
           "functions": [
             {
               "name": "newPost",
-              "signature" :
+              "signature":
               {
-                  "inputs" : [
+                  "inputs": [
                       {
                           "name": "post",
                           "type": "string"
                       }
                   ],
-                  "outputs" : [
+                  "outputs": [
                       {
                           "name": "hash",
                           "type": "string"

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
 
     //let dna = holochain_dna::from_package_file("mydna.hcpkg");
     let dna = Dna::new();
-    let agent = Agent::from_string(identity);
+    let agent = Agent::from_string(identity.to_string());
     let context = Context {
         agent,
         logger: Arc::new(Mutex::new(SimpleLogger {})),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -103,7 +103,7 @@ pub fn test_logger() -> Arc<Mutex<TestLogger>> {
 }
 
 pub fn test_context_and_logger(agent_name: &str) -> (Arc<Context>, Arc<Mutex<TestLogger>>) {
-    let agent = Agent::from_string(agent_name);
+    let agent = Agent::from_string(agent_name.to_string());
     let logger = test_logger();
     (
         Arc::new(Context {

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -22,7 +22,7 @@ pub enum HcApiReturnCode {
     ErrorCallbackResult = 5 << 16,
 }
 
-//pub fn decode_error(encoded_allocation : u32) -> HcApiReturnCode {
+//pub fn decode_error(encoded_allocation: u32) -> HcApiReturnCode {
 //
 //}
 
@@ -223,15 +223,15 @@ pub mod tests {
     #[test]
     /// tests that encoding integers for errors returns the correct return code
     fn encode_error() {
-        assert_eq!(super::encode_error(0), HcApiReturnCode::Success,);
+        assert_eq!(super::encode_error(0), HcApiReturnCode::Success);
 
-        assert_eq!(super::encode_error(1), HcApiReturnCode::Error,);
+        assert_eq!(super::encode_error(1), HcApiReturnCode::Error);
 
-        assert_eq!(super::encode_error(2), HcApiReturnCode::ErrorSerdeJson,);
+        assert_eq!(super::encode_error(2), HcApiReturnCode::ErrorSerdeJson);
 
-        assert_eq!(super::encode_error(3), HcApiReturnCode::ErrorPageOverflow,);
+        assert_eq!(super::encode_error(3), HcApiReturnCode::ErrorPageOverflow);
 
-        assert_eq!(super::encode_error(4), HcApiReturnCode::ErrorActionResult,);
+        assert_eq!(super::encode_error(4), HcApiReturnCode::ErrorActionResult);
     }
 
     #[test]
@@ -240,9 +240,9 @@ pub mod tests {
         let i = 0b1010101010101010_0101010101010101;
         let spa = SinglePageAllocation::new(i).unwrap();
 
-        assert_eq!(0b1010101010101010, spa.offset,);
+        assert_eq!(0b1010101010101010, spa.offset);
 
-        assert_eq!(0b0101010101010101, spa.length,);
+        assert_eq!(0b0101010101010101, spa.length);
     }
 
     #[test]
@@ -292,7 +292,7 @@ pub mod tests {
         let i = 0b1010101010101010_0101010101010101;
         let spa = SinglePageAllocation::new(i).unwrap();
 
-        assert_eq!(i, spa.encode(),);
+        assert_eq!(i, spa.encode());
     }
 
     #[test]


### PR DESCRIPTION
This is a pretty big changelog. I'm open to feedback and I hope this doesn't come across as critical. I love this code.

***Once I submit this PR, I'm going to write a review explaining each change that's not a pure formatting change.***

**REVIEW IN PROGRESS. MAY BE DELAYED IF I LOSE INTERNET ON MY PLANE**

Here are some 
## General themes:

### Transition `unwrap()` -> `expect("how it should be")`

This change is pretty pedantic.

The benefit of it is that if one of these `expect`s panics you'll get a descriptive error message that could be the difference between breaking your flow or not.

I figure that if I'm going to do all the work to convert these unwraps then we may as well convert them.

### Make functions own the arguments that they'd otherwise clone

Cloning takes resources and if the caller can choose whether to clone or just to move ownership to the function, that can be more efficient.

For example
```rust
#[derive(Clone, Debug)]
struct MyStruct(pub u64);

fn clones_and_prints(arg: &MyStruct) {
    println!("{:?}", arg.clone());
}

fn takes_and_prints(arg: MyStruct) {
    println!("{:?}", arg)
}

fn worse_main() {
    let to_print = MyStruct(4);
    clones_and_prints(&to_print); // 1 clone
}

fn better_main() {
    let to_print = MyStruct(4);
    takes_and_prints(to_print); // no clones
}
```

### Make functions return references to the objects that they'd otherwise clone

This is similar to above, gives the caller the choice of whether or not to clone. This helps in cases where cloning is unnecessary.

### Formatting differences done by `cargo fmt`

OOPS! I wish I hadn't run that command. :P Now the changes list is diluted.

### Shifting certain patterns to their more common counterparts

Examples:

```rust
// old way
get_some_option().and_then(|v| Some(v+1))
// new way
get_some_option().map(|v| v+1)

// old way
get_some_result().or_else(|e| panic!("some message"))
// new way
get_some_result().expect("some message")

// old way
let result = get_some_result();
if result.is_err() {
    return Err("some error")
}
let value = result.unwrap();
// new way
let value = get_some_result().or(Err("some error"))?;
```