### PR TITLE
186 system entry types abstraction

### DIFF
--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -11,7 +11,6 @@ impl Identity {
     }
 }
 
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct Agent {
     identity: Identity,

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -7,7 +7,7 @@ pub struct Identity {
 
 impl Identity {
     pub fn new(content: String) -> Self {
-        Identity { content: content }
+        Identity { content }
     }
 }
 

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -4,6 +4,14 @@
 pub struct Identity {
     content: String,
 }
+
+impl Identity {
+    pub fn new(content: String) -> Self {
+        Identity { content: content }
+    }
+}
+
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Agent {
     identity: Identity,

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -284,7 +284,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"same_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
+            "{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
             ActionResponse::Get(Some(test_pair())).to_json(),
         );
         assert_eq!("", ActionResponse::Get(None).to_json(),);

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -140,7 +140,7 @@ fn reduce_get(
     // @see https://github.com/holochain/holochain-rust/issues/167
 
     let result = chain
-        .get_entry(&key)
+        .entry(&key)
         .expect("should be able to get entry that we just added");
     state
         .actions
@@ -286,7 +286,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            "{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
+            "{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"link\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
             ActionResponse::Get(Some(test_pair())).to_json(),
         );
         assert_eq!("", ActionResponse::Get(None).to_json());

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -108,7 +108,7 @@ fn reduce_commit(
 
     state.actions.insert(
         action_wrapper.clone(),
-        ActionResponse::Commit(chain.push(&entry)),
+        ActionResponse::Commit(chain.push_entry(&entry)),
     );
 }
 
@@ -134,7 +134,7 @@ fn reduce_get(
     // drop in a dummy entry for testing
     let mut chain = Chain::new(Rc::new(MemTable::new()));
     let e = Entry::new("testEntryType", "test entry content");
-    chain.push(&e).unwrap();
+    chain.push_entry(&e).unwrap();
 
     // @TODO if the get fails local, do a network get
     // @see https://github.com/holochain/holochain-rust/issues/167
@@ -284,7 +284,7 @@ pub mod tests {
         );
 
         assert_eq!(
-            "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"type_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
+            "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"same_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}",
             ActionResponse::Get(Some(test_pair())).to_json(),
         );
         assert_eq!("", ActionResponse::Get(None).to_json(),);

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -34,7 +34,7 @@ impl<T: HashTable> Iterator for ChainIterator<T> {
     fn next(&mut self) -> Option<Pair> {
         let previous = self.current.take();
         self.current = previous.as_ref()
-                        .and_then(|p| p.header().prev())
+                        .and_then(|p| p.header().link())
                         // @TODO should this panic?
                         // @see https://github.com/holochain/holochain-rust/issues/146
                         .and_then(|h| self.table.get(&h).expect("getting from a table shouldn't fail"));
@@ -112,7 +112,7 @@ impl<T: HashTable> Chain<T> {
         }
 
         let top_pair = self.top().as_ref().map(|p| p.key());
-        let next_pair = pair.header().prev();
+        let next_pair = pair.header().link();
 
         if top_pair != next_pair {
             return Err(HolochainError::new(&format!(
@@ -151,12 +151,12 @@ impl<T: HashTable> Chain<T> {
     }
 
     /// get a Pair by Pair/Header key from the HashTable if it exists
-    pub fn get_pair(&self, k: &str) -> Result<Option<Pair>, HolochainError> {
+    pub fn pair(&self, k: &str) -> Result<Option<Pair>, HolochainError> {
         self.table.get(k)
     }
 
     /// get an Entry by Entry key from the HashTable if it exists
-    pub fn get_entry(&self, entry_hash: &str) -> Result<Option<Pair>, HolochainError> {
+    pub fn entry(&self, entry_hash: &str) -> Result<Option<Pair>, HolochainError> {
         // @TODO - this is a slow way to do a lookup
         // @see https://github.com/holochain/holochain-rust/issues/50
         Ok(self
@@ -349,7 +349,7 @@ pub mod tests {
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
         assert_eq!(
             Some(&p),
-            c.get_pair(&p.key())
+            c.pair(&p.key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
@@ -422,27 +422,27 @@ pub mod tests {
         assert_eq!(
             None,
             chain
-                .get_pair("")
+                .pair("")
                 .expect("getting an entry from a chain shouldn't fail")
         );
         assert_eq!(
             Some(&p1),
             chain
-                .get_pair(&p1.key())
+                .pair(&p1.key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
         assert_eq!(
             Some(&p2),
             chain
-                .get_pair(&p2.key())
+                .pair(&p2.key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
         assert_eq!(
             Some(&p3),
             chain
-                .get_pair(&p3.key())
+                .pair(&p3.key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
@@ -450,21 +450,21 @@ pub mod tests {
         assert_eq!(
             Some(&p1),
             chain
-                .get_pair(&p1.header().key())
+                .pair(&p1.header().key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
         assert_eq!(
             Some(&p2),
             chain
-                .get_pair(&p2.header().key())
+                .pair(&p2.header().key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
         assert_eq!(
             Some(&p3),
             chain
-                .get_pair(&p3.header().key())
+                .pair(&p3.header().key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
@@ -492,28 +492,28 @@ pub mod tests {
         assert_eq!(
             None,
             chain
-                .get_entry("")
+                .entry("")
                 .expect("getting an entry from a chain shouldn't fail")
         );
         // @TODO at this point we have p3 with the same entry key as p1...
         assert_eq!(
             Some(&p3),
             chain
-                .get_entry(&p1.entry().key())
+                .entry(&p1.entry().key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
         assert_eq!(
             Some(&p2),
             chain
-                .get_entry(&p2.entry().key())
+                .entry(&p2.entry().key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
         assert_eq!(
             Some(&p3),
             chain
-                .get_entry(&p3.entry().key())
+                .entry(&p3.entry().key())
                 .expect("getting an entry from a chain shouldn't fail")
                 .as_ref()
         );
@@ -644,7 +644,7 @@ pub mod tests {
             .push_entry(&e3)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
 
-        let expected_json = "[{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":\"QmPT5HXvyv54Dg36YSK1A2rYvoPCNWoqpLzzZnHnQBcU6x\",\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}},{\"header\":{\"entry_type\":\"testEntryTypeB\",\"timestamp\":\"\",\"prev\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\",\"entry_hash\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"other test entry content\",\"entry_type\":\"testEntryTypeB\"}},{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}]"
+        let expected_json = "[{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"link\":\"QmPT5HXvyv54Dg36YSK1A2rYvoPCNWoqpLzzZnHnQBcU6x\",\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}},{\"header\":{\"entry_type\":\"testEntryTypeB\",\"timestamp\":\"\",\"link\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\",\"entry_hash\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":{\"content\":\"other test entry content\",\"entry_type\":\"testEntryTypeB\"}},{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"link\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}]"
         ;
         assert_eq!(
             expected_json,

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -127,7 +127,7 @@ impl<T: HashTable> Chain<T> {
             "attempted to push while table is already borrowed",
         ))?;
         table.commit(&pair)?;
-            self.top = Some(pair.clone());
+        self.top = Some(pair.clone());
         Ok(pair)
     }
 
@@ -646,7 +646,7 @@ pub mod tests {
 
         let expected_json = "[{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":\"QmPT5HXvyv54Dg36YSK1A2rYvoPCNWoqpLzzZnHnQBcU6x\",\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}},{\"header\":{\"entry_type\":\"testEntryTypeB\",\"timestamp\":\"\",\"prev\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\",\"entry_hash\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"other test entry content\",\"entry_type\":\"testEntryTypeB\"}},{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}]"
         ;
-                assert_eq!(
+        assert_eq!(
             expected_json,
             chain.to_json().expect("chain shouldn't fail to serialize")
         );

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -375,9 +375,18 @@ pub mod tests {
         assert_eq!(Some(p1.clone()), chain.get_pair(&p1.key()).unwrap());
         assert_eq!(Some(p2.clone()), chain.get_pair(&p2.key()).unwrap());
         assert_eq!(Some(p3.clone()), chain.get_pair(&p3.key()).unwrap());
-        assert_eq!(Some(p1.clone()), chain.get_pair(&p1.header().key()).unwrap());
-        assert_eq!(Some(p2.clone()), chain.get_pair(&p2.header().key()).unwrap());
-        assert_eq!(Some(p3.clone()), chain.get_pair(&p3.header().key()).unwrap());
+        assert_eq!(
+            Some(p1.clone()),
+            chain.get_pair(&p1.header().key()).unwrap()
+        );
+        assert_eq!(
+            Some(p2.clone()),
+            chain.get_pair(&p2.header().key()).unwrap()
+        );
+        assert_eq!(
+            Some(p3.clone()),
+            chain.get_pair(&p3.header().key()).unwrap()
+        );
     }
 
     #[test]

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -36,7 +36,7 @@ impl<T: HashTable> Iterator for ChainIterator<T> {
     fn next(&mut self) -> Option<Pair> {
         let ret = self.current();
         self.current = ret.clone()
-                        .and_then(|p| p.header().next())
+                        .and_then(|p| p.header().prev())
                         // @TODO should this panic?
                         // @see https://github.com/holochain/holochain-rust/issues/146
                         .and_then(|h| self.table.get(&h).unwrap());
@@ -112,7 +112,7 @@ impl<T: HashTable> Chain<T> {
         }
 
         let top_pair = self.top().and_then(|p| Some(p.key()));
-        let next_pair = pair.header().next();
+        let next_pair = pair.header().prev();
 
         if top_pair != next_pair {
             return Err(HolochainError::new(&format!(
@@ -475,38 +475,8 @@ pub mod tests {
         chain.push_entry(&e2).unwrap();
         chain.push_entry(&e3).unwrap();
 
-        let expected_json = "[{\
-        \"header\":{\
-            \"entry_type\":\"testEntryType\",\
-            \"time\":\"\",\
-            \"next\":\"QmPT5HXvyv54Dg36YSK1A2rYvoPCNWoqpLzzZnHnQBcU6x\",\
-            \"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\
-            \"same_next\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\",\
-            \"signature\":\"\"},\
-        \"entry\":{\
-            \"content\":\"test entry content\",\
-            \"entry_type\":\"testEntryType\"}},\
-        {\"header\":{\
-            \"entry_type\":\"testEntryTypeB\",\
-            \"time\":\"\",\
-            \"next\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\",\
-            \"entry_hash\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\
-            \"same_next\":null,\
-            \"signature\":\"\"},\
-        \"entry\":{\
-            \"content\":\"other test entry content\",\
-            \"entry_type\":\"testEntryTypeB\"}},\
-        {\"header\":{\
-            \"entry_type\":\"testEntryType\",\
-            \"time\":\"\",\
-            \"next\":null,\
-            \"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\
-            \"same_next\":null,\
-            \"signature\":\"\"},\
-        \"entry\":{\
-            \"content\":\"test entry content\",\
-            \"entry_type\":\"testEntryType\"}\
-        }]";
+        let expected_json = "[{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":\"QmPT5HXvyv54Dg36YSK1A2rYvoPCNWoqpLzzZnHnQBcU6x\",\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}},{\"header\":{\"entry_type\":\"testEntryTypeB\",\"timestamp\":\"\",\"prev\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\",\"entry_hash\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"other test entry content\",\"entry_type\":\"testEntryTypeB\"}},{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}]"
+        ;
         assert_eq!(expected_json, chain.to_json().unwrap());
 
         let table = test_table();

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -3,7 +3,6 @@ use multihash::Hash;
 use serde_json;
 use std::hash::{Hash as StdHash, Hasher};
 
-
 /// Structure holding actual data in a source chain "Item"
 /// data is stored as a JSON string
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -3,6 +3,9 @@ use multihash::Hash;
 use serde_json;
 use std::hash::{Hash as StdHash, Hasher};
 
+
+/// Structure holding actual data in a source chain "Item"
+/// data is stored as a JSON string
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Entry {
     content: String,

--- a/core/src/hash_table/header.rs
+++ b/core/src/hash_table/header.rs
@@ -62,24 +62,29 @@ impl Header {
         }
     }
 
-    /// getters
-    pub fn entry_type(&self) -> String {
-        self.entry_type.clone()
+    /// entry_type getter
+    pub fn entry_type(&self) -> &str {
+        &self.entry_type
     }
-    pub fn timestamp(&self) -> String {
-        self.timestamp.clone()
+    /// timestamp getter
+    pub fn timestamp(&self) -> &str {
+        &self.timestamp
     }
+    /// prev getter
     pub fn prev(&self) -> Option<String> {
         self.prev.clone()
     }
-    pub fn entry_hash(&self) -> String {
-        self.entry_hash.clone()
+    /// entry_hash getter
+    pub fn entry_hash(&self) -> &str {
+        &self.entry_hash
     }
+    /// prev_same getter
     pub fn prev_same(&self) -> Option<String> {
         self.prev_same.clone()
     }
-    pub fn entry_signature(&self) -> String {
-        self.entry_signature.clone()
+    /// entry_signature getter
+    pub fn entry_signature(&self) -> &str {
+        &self.entry_signature
     }
 
     /// hashes the header

--- a/core/src/hash_table/header.rs
+++ b/core/src/hash_table/header.rs
@@ -1,6 +1,6 @@
 use chain::Chain;
 use hash;
-use hash_table::{entry::Entry, HashTable, HashString};
+use hash_table::{entry::Entry, HashString, HashTable};
 use multihash::Hash;
 
 /// Header of a source chain "Item"

--- a/core/src/hash_table/header.rs
+++ b/core/src/hash_table/header.rs
@@ -1,6 +1,6 @@
 use chain::Chain;
 use hash;
-use hash_table::{entry::Entry, HashTable, /*entry::EntryKind,*/ HashString};
+use hash_table::{entry::Entry, HashTable, HashString};
 use multihash::Hash;
 
 /// Header of a source chain "Item"
@@ -16,7 +16,7 @@ pub struct Header {
     entry_type: String,
     /// ISO8601 time stamp
     timestamp: String,
-    /// Key to the immediately preceding header. Only the genesis ChainLink can have None as valid
+    /// Key to the immediately preceding header. Only the genesis Pair can have None as valid
     prev: Option<HashString>,
     /// Key to the entry of this header
     entry_hash: HashString,
@@ -61,32 +61,22 @@ impl Header {
         }
     }
 
-    /// entry_type getter
+    /// getters
     pub fn entry_type(&self) -> String {
         self.entry_type.clone()
     }
-
-    /// time getter
     pub fn timestamp(&self) -> String {
         self.timestamp.clone()
     }
-
-    /// next getter
     pub fn prev(&self) -> Option<String> {
         self.prev.clone()
     }
-
-    /// entry getter
     pub fn entry_hash(&self) -> String {
         self.entry_hash.clone()
     }
-
-    /// type_next getter
     pub fn prev_same(&self) -> Option<String> {
         self.prev_same.clone()
     }
-
-    /// signature getter
     pub fn entry_signature(&self) -> String {
         self.entry_signature.clone()
     }

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -10,6 +10,7 @@ use hash_table::{
     HashTable,
 };
 
+/// Struct Implemenating the HashTable Trait which stores the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 pub struct MemTable {
     pairs: HashMap<String, Pair>,
@@ -93,7 +94,7 @@ impl HashTable for MemTable {
         let mut metas = self
             .meta
             .values()
-            .filter(|&m| m.pair() == pair.key())
+            .filter(|&m| m.pair_hash() == pair.key())
             .cloned()
             .collect::<Vec<PairMeta>>();
         // @TODO should this be sorted at all at this point?

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -10,7 +10,7 @@ use hash_table::{
     HashTable,
 };
 
-/// Struct Implemenating the HashTable Trait which stores the HashTable in memory
+/// Struct implementing the HashTable Trait by storing the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 pub struct MemTable {
     pairs: HashMap<String, Pair>,

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -12,8 +12,6 @@ use hash_table::{pair::Pair, pair_meta::PairMeta};
 
 pub type HashString = String;
 
-pub type EntryString = String;
-
 /// Trait of the data structure storing the source chain
 /// source chain is stored as a hash table of Pairs.
 /// Pair is a pair holding an Entry and its Header

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -9,6 +9,10 @@ use agent::keys::Keys;
 use error::HolochainError;
 use hash_table::{pair::Pair, pair_meta::PairMeta};
 
+
+/// Trait of the data structure storing the source chain
+/// source chain is stored as a hash table of Pairs.
+/// Pair is a pair holding an Entry and its Header
 pub trait HashTable {
     // internal state management
     fn setup(&mut self) -> Result<(), HolochainError>;

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -4,11 +4,15 @@ pub mod memory;
 pub mod pair;
 pub mod pair_meta;
 pub mod status;
+pub mod sys_entry;
 
 use agent::keys::Keys;
 use error::HolochainError;
 use hash_table::{pair::Pair, pair_meta::PairMeta};
 
+pub type HashString = String;
+
+pub type EntryString = String;
 
 /// Trait of the data structure storing the source chain
 /// source chain is stored as a hash table of Pairs.

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -118,7 +118,7 @@ pub mod tests {
         let h1 = Header::new(&chain, &e1);
 
         assert_eq!(h1.entry_hash(), e1.hash());
-        assert_eq!(h1.next(), None);
+        assert_eq!(h1.prev(), None);
 
         let p1 = Pair::new(&chain, &e1);
         assert_eq!(e1, p1.entry());
@@ -164,7 +164,8 @@ pub mod tests {
     #[test]
     /// test JSON roundtrip for pairs
     fn json_roundtrip() {
-        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"same_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}";
+        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}"
+        ;
 
         assert_eq!(json, test_pair().to_json(),);
 

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -2,6 +2,9 @@ use chain::Chain;
 use hash_table::{entry::Entry, header::Header, HashTable};
 use serde_json;
 
+/// Struct for holding a source chain "Item"
+/// It is like a pair holding the entry and header separately
+/// The source chain being a hash table, the key of a Pair is the hash of its Header
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Pair {
     header: Header,
@@ -56,7 +59,7 @@ impl Pair {
         // the header and entry must validate independently
         self.header.validate() && self.entry.validate()
         // the header entry hash must be the same as the entry hash
-        && self.header.entry() == self.entry.hash()
+        && self.header.entry_hash() == self.entry.hash()
         // the entry_type must line up across header and entry
         && self.header.entry_type() == self.entry.entry_type()
     }
@@ -114,7 +117,7 @@ pub mod tests {
         let e1 = Entry::new(t, "some content");
         let h1 = Header::new(&chain, &e1);
 
-        assert_eq!(h1.entry(), e1.hash());
+        assert_eq!(h1.entry_hash(), e1.hash());
         assert_eq!(h1.next(), None);
 
         let p1 = Pair::new(&chain, &e1);
@@ -141,7 +144,7 @@ pub mod tests {
         let mut chain = test_chain();
         let t = "foo";
         let e = Entry::new(t, "");
-        let p = chain.push(&e).unwrap();
+        let p = chain.push_entry(&e).unwrap();
 
         assert_eq!(e, p.entry());
     }
@@ -161,7 +164,7 @@ pub mod tests {
     #[test]
     /// test JSON roundtrip for pairs
     fn json_roundtrip() {
-        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"type_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}";
+        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"same_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}";
 
         assert_eq!(json, test_pair().to_json(),);
 

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -37,9 +37,9 @@ impl Pair {
             entry: entry,
         };
 
-            // we panic as no code path should attempt to create invalid pairs
-            // creating a Pair is an internal process of chain.push() and is deterministic based on
-            // an immutable Entry (that itself cannot be invalid), so this should never happen.
+        // we panic as no code path should attempt to create invalid pairs
+        // creating a Pair is an internal process of chain.push() and is deterministic based on
+        // an immutable Entry (that itself cannot be invalid), so this should never happen.
         assert!(p.validate(), "attempted to create an invalid pair");
 
         p

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -129,7 +129,7 @@ pub mod tests {
         let h1 = Header::new(&chain, &e1);
 
         assert_eq!(h1.entry_hash(), e1.hash());
-        assert_eq!(h1.prev(), None);
+        assert_eq!(h1.link(), None);
 
         let p1 = Pair::new(&chain, e1.clone());
         assert_eq!(&e1, p1.entry());
@@ -177,7 +177,7 @@ pub mod tests {
     #[test]
     /// test JSON roundtrip for pairs
     fn json_roundtrip() {
-        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}"
+        let json = "{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"link\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}"
         ;
 
         assert_eq!(json, test_pair().to_json());

--- a/core/src/hash_table/pair_meta.rs
+++ b/core/src/hash_table/pair_meta.rs
@@ -15,7 +15,7 @@ use std::cmp::Ordering;
 /// source = the agent making the meta assertion
 /// signature = the asserting agent's signature of the meta assertion
 pub struct PairMeta {
-    pair: String,
+    pair_hash: String,
     attribute: String,
     value: String,
     // @TODO implement local transaction ordering
@@ -30,7 +30,7 @@ pub struct PairMeta {
 impl Ord for PairMeta {
     fn cmp(&self, other: &PairMeta) -> Ordering {
         // we want to sort by pair hash, then attribute name, then attribute value
-        match self.pair.cmp(&other.pair) {
+        match self.pair_hash.cmp(&other.pair_hash) {
             Ordering::Equal => match self.attribute.cmp(&other.attribute) {
                 Ordering::Equal => self.value.cmp(&other.value),
                 Ordering::Greater => Ordering::Greater,
@@ -54,7 +54,7 @@ impl PairMeta {
     /// @see https://github.com/holochain/holochain-rust/issues/140
     pub fn new(keys: &Keys, pair: &Pair, attribute: &str, value: &str) -> PairMeta {
         PairMeta {
-            pair: pair.key(),
+            pair_hash: pair.key(),
             attribute: attribute.into(),
             value: value.into(),
             source: keys.node_id(),
@@ -62,8 +62,8 @@ impl PairMeta {
     }
 
     /// getter for pair clone
-    pub fn pair(&self) -> String {
-        self.pair.clone()
+    pub fn pair_hash(&self) -> String {
+        self.pair_hash.clone()
     }
 
     /// getter for attribute clone
@@ -154,7 +154,7 @@ pub mod tests {
     #[test]
     /// test meta.pair()
     fn pair() {
-        assert_eq!(test_pair_meta().pair(), test_pair().key());
+        assert_eq!(test_pair_meta().pair_hash(), test_pair().key());
     }
 
     #[test]

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -6,8 +6,7 @@ use std::str::FromStr;
 
 pub trait ToEntry {
     fn to_entry(&self) -> Entry;
-    // FIXME - Maybe change to `new_from_entry` ?
-    fn from_entry(&Entry) -> Self;
+    fn new_from_entry(&Entry) -> Self;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -73,10 +72,11 @@ impl EntryType {
 
 impl ToEntry for Dna {
     fn to_entry(&self) -> Entry {
+        // TODO #239 - Convert Dna to Entry by following DnaEntry schema and not the to_json() dump
         Entry::new(EntryType::Dna.as_str(), &self.to_json().unwrap())
     }
 
-    fn from_entry(entry: &Entry) -> Self {
+    fn new_from_entry(entry: &Entry) -> Self {
         assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::Dna);
         return Dna::new_from_json(&entry.content()).expect("entry is not a valid Dna Entry");
     }
@@ -87,11 +87,12 @@ impl ToEntry for Dna {
 //-------------------------------------------------------------------------------------------------
 
 impl ToEntry for Agent {
+
     fn to_entry(&self) -> Entry {
         Entry::new(EntryType::AgentId.as_str(), &self.to_string())
     }
 
-    fn from_entry(entry: &Entry) -> Self {
+    fn new_from_entry(entry: &Entry) -> Self {
         assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::AgentId);
         let id_content: String =
             serde_json::from_str(&entry.content()).expect("entry is not a valid AgentId Entry");

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -1,17 +1,14 @@
-
-use holochain_dna::Dna;
 use hash_table::entry::Entry;
-use std::str::FromStr;
-use holochain_agent::Agent;
-use holochain_agent::Identity;
+use holochain_agent::{Agent, Identity};
+use holochain_dna::Dna;
 use serde_json;
+use std::str::FromStr;
 
 pub trait ToEntry {
-  fn to_entry(&self) -> Entry;
-  // FIXME - Maybe change to `new_from_entry` ?
-  fn from_entry(&Entry) -> Self;
+    fn to_entry(&self) -> Entry;
+    // FIXME - Maybe change to `new_from_entry` ?
+    fn from_entry(&Entry) -> Self;
 }
-
 
 //-------------------------------------------------------------------------------------------------
 // Entry Type
@@ -19,53 +16,55 @@ pub trait ToEntry {
 
 // Macro for statically concatanating the system entry prefix for entry types of system entries
 macro_rules! sys_prefix {
-    ($s:expr) => ( concat!("%", $s) )
+    ($s:expr) => {
+        concat!("%", $s)
+    };
 }
 
 // Enum for listing all System Entry Types
 // Variant `Data` is for user defined entry types
 #[derive(Debug, Clone, PartialEq)]
 pub enum EntryType {
-  AgentId,
-  Deletion,
-  Data,
-  Dna,
-  Headers,
-  Key,
-  Link,
-  Migration,
+    AgentId,
+    Deletion,
+    Data,
+    Dna,
+    Headers,
+    Key,
+    Link,
+    Migration,
 }
 
 impl FromStr for EntryType {
-  type Err = usize;
-  // Note: Function always return Ok()
-  fn from_str(s: &str) -> Result<Self, Self::Err> {
-    match s {
-      sys_prefix!("agent_id") => Ok(EntryType::AgentId),
-      sys_prefix!("deletion") => Ok(EntryType::Deletion),
-      sys_prefix!("dna") => Ok(EntryType::Dna),
-      sys_prefix!("headers") => Ok(EntryType::Headers),
-      sys_prefix!("key") => Ok(EntryType::Key),
-      sys_prefix!("link") => Ok(EntryType::Link),
-      sys_prefix!("migration") => Ok(EntryType::Migration),
-      _ => Ok(EntryType::Data),
+    type Err = usize;
+    // Note: Function always return Ok()
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            sys_prefix!("agent_id") => Ok(EntryType::AgentId),
+            sys_prefix!("deletion") => Ok(EntryType::Deletion),
+            sys_prefix!("dna") => Ok(EntryType::Dna),
+            sys_prefix!("headers") => Ok(EntryType::Headers),
+            sys_prefix!("key") => Ok(EntryType::Key),
+            sys_prefix!("link") => Ok(EntryType::Link),
+            sys_prefix!("migration") => Ok(EntryType::Migration),
+            _ => Ok(EntryType::Data),
+        }
     }
-  }
 }
 
 impl EntryType {
-  pub fn as_str(&self) -> &'static str {
-    match *self {
-      EntryType::Data =>      panic!("should not try to convert a custom data entry to str"),
-      EntryType::AgentId =>   sys_prefix!("agent_id"),
-      EntryType::Deletion =>  sys_prefix!("deletion"),
-      EntryType::Dna =>       sys_prefix!("dna"),
-      EntryType::Headers =>   sys_prefix!("headers"),
-      EntryType::Key =>       sys_prefix!("key"),
-      EntryType::Link =>      sys_prefix!("link"),
-      EntryType::Migration => sys_prefix!("migration"),
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            EntryType::Data => panic!("should not try to convert a custom data entry to str"),
+            EntryType::AgentId => sys_prefix!("agent_id"),
+            EntryType::Deletion => sys_prefix!("deletion"),
+            EntryType::Dna => sys_prefix!("dna"),
+            EntryType::Headers => sys_prefix!("headers"),
+            EntryType::Key => sys_prefix!("key"),
+            EntryType::Link => sys_prefix!("link"),
+            EntryType::Migration => sys_prefix!("migration"),
+        }
     }
-  }
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -73,42 +72,32 @@ impl EntryType {
 //-------------------------------------------------------------------------------------------------
 
 impl ToEntry for Dna {
-  fn to_entry(&self) -> Entry {
-    Entry::new(
-      EntryType::Dna.as_str(),
-      &self.to_json().unwrap(),
-    )
-  }
+    fn to_entry(&self) -> Entry {
+        Entry::new(EntryType::Dna.as_str(), &self.to_json().unwrap())
+    }
 
-  fn from_entry(entry: &Entry) -> Self {
-    assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::Dna);
-    return Dna::new_from_json(&entry.content())
-      .expect("entry is not a valid Dna Entry")
-    ;
-  }
+    fn from_entry(entry: &Entry) -> Self {
+        assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::Dna);
+        return Dna::new_from_json(&entry.content()).expect("entry is not a valid Dna Entry");
+    }
 }
-
 
 //-------------------------------------------------------------------------------------------------
 // Agent Entry
 //-------------------------------------------------------------------------------------------------
 
 impl ToEntry for Agent {
-  fn to_entry(&self) -> Entry {
-    Entry::new(
-      EntryType::AgentId.as_str(),
-      &self.to_string(),
-    )
-  }
+    fn to_entry(&self) -> Entry {
+        Entry::new(EntryType::AgentId.as_str(), &self.to_string())
+    }
 
-  fn from_entry(entry: &Entry) -> Self {
-    assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::AgentId);
-    let id_content : String = serde_json::from_str(&entry.content())
-      .expect("entry is not a valid AgentId Entry");
-    Agent::new(Identity::new(id_content))
-  }
+    fn from_entry(entry: &Entry) -> Self {
+        assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::AgentId);
+        let id_content: String =
+            serde_json::from_str(&entry.content()).expect("entry is not a valid AgentId Entry");
+        Agent::new(Identity::new(id_content))
+    }
 }
-
 
 //-------------------------------------------------------------------------------------------------
 // UNIT TESTS
@@ -116,94 +105,101 @@ impl ToEntry for Agent {
 
 #[cfg(test)]
 pub mod tests {
-  extern crate test_utils;
+    extern crate test_utils;
 
-  use holochain_dna::Dna;
-  use hash_table::entry::Entry;
-  use holochain_agent::Agent;
-  use holochain_agent::Identity;
-  use action::ActionWrapper;
-  use action::Action;
-  use hash_table::sys_entry::EntryType;
-  use hash_table::sys_entry::ToEntry;
-  use std::{
-    sync::{mpsc::channel, Arc, Mutex},
-    str::FromStr,
-  };
+    use action::{Action, ActionWrapper};
+    use hash_table::{
+        entry::Entry,
+        sys_entry::{EntryType, ToEntry},
+    };
+    use holochain_agent::{Agent, Identity};
+    use holochain_dna::Dna;
+    use std::{
+        str::FromStr,
+        sync::{mpsc::channel, Arc, Mutex},
+    };
 
-  use instance::{
-    tests::{test_context, test_instance, test_instance_blank},
-    Instance,
-  };
+    use instance::{
+        tests::{test_context, test_instance, test_instance_blank},
+        Instance,
+    };
 
-  // Committing a DnaEntry to source chain should work
-  #[test]
-  fn can_commit_dna() {
-    // Create Context, Agent, Dna, and Commit AgentIdEntry Action
-    let context = test_context("alex");
-    let mut dna = test_utils::create_test_dna_with_wat("test_zome", "test_cap", None);
-    let dna_entry = dna.to_entry();
-    let commit_action = ActionWrapper::new(&Action::Commit(dna_entry));
+    // Committing a DnaEntry to source chain should work
+    #[test]
+    fn can_commit_dna() {
+        // Create Context, Agent, Dna, and Commit AgentIdEntry Action
+        let context = test_context("alex");
+        let mut dna = test_utils::create_test_dna_with_wat("test_zome", "test_cap", None);
+        let dna_entry = dna.to_entry();
+        let commit_action = ActionWrapper::new(&Action::Commit(dna_entry));
 
-    // Set up instance and dispatch action
-    let mut instance = Instance::new();
-    instance.start_action_loop(context);
-    instance.dispatch_and_wait(&commit_action);
+        // Set up instance and dispatch action
+        let mut instance = Instance::new();
+        instance.start_action_loop(context);
+        instance.dispatch_and_wait(&commit_action);
 
-    // Check if AgentIdEntry is found
-    let mut count = 0;
-    instance.state().history.iter()
+        // Check if AgentIdEntry is found
+        let mut count = 0;
+        instance
+            .state()
+            .history
+            .iter()
             .find(|aw| match aw.action() {
-              Action::Commit(entry) => {
-                assert_eq!(EntryType::from_str(&entry.entry_type()).unwrap(), EntryType::Dna);
-                count += 1;
-                true
-              },
-              _ => false,
+                Action::Commit(entry) => {
+                    assert_eq!(
+                        EntryType::from_str(&entry.entry_type()).unwrap(),
+                        EntryType::Dna
+                    );
+                    count += 1;
+                    true
+                }
+                _ => false,
             });
-    assert_eq!(count, 1);
+        assert_eq!(count, 1);
+    }
 
-  }
+    // Committing a DnaEntry to source chain should work only if first entry
+    #[test]
+    fn cannot_commit_dna() {
+        // FIXME
+    }
 
+    // Committing an AgentIdEntry to source chain should work
+    #[test]
+    fn can_commit_agent() {
+        // Create Context, Agent and Commit AgentIdEntry Action
+        let context = test_context("alex");
+        let agent_entry = context.agent.to_entry();
+        let commit_agent_action = ActionWrapper::new(&Action::Commit(agent_entry));
 
-  // Committing a DnaEntry to source chain should work only if first entry
-  #[test]
-  fn cannot_commit_dna() {
-    // FIXME
-  }
+        // Set up instance and dispatch action
+        let mut instance = Instance::new();
+        instance.start_action_loop(context);
+        instance.dispatch_and_wait(&commit_agent_action);
 
+        // Check if AgentIdEntry is found
+        let mut count = 0;
+        instance
+            .state()
+            .history
+            .iter()
+            .find(|aw| match aw.action() {
+                Action::Commit(entry) => {
+                    assert_eq!(
+                        EntryType::from_str(&entry.entry_type()).unwrap(),
+                        EntryType::AgentId
+                    );
+                    count += 1;
+                    true
+                }
+                _ => false,
+            });
+        assert_eq!(count, 1);
+    }
 
-  // Committing an AgentIdEntry to source chain should work
-  #[test]
-  fn can_commit_agent() {
-    // Create Context, Agent and Commit AgentIdEntry Action
-    let context = test_context("alex");
-    let agent_entry = context.agent.to_entry();
-    let commit_agent_action = ActionWrapper::new(&Action::Commit(agent_entry));
-
-    // Set up instance and dispatch action
-    let mut instance = Instance::new();
-    instance.start_action_loop(context);
-    instance.dispatch_and_wait(&commit_agent_action);
-
-    // Check if AgentIdEntry is found
-    let mut count = 0;
-    instance.state().history.iter()
-      .find(|aw| match aw.action() {
-        Action::Commit(entry) => {
-          assert_eq!(EntryType::from_str(&entry.entry_type()).unwrap(), EntryType::AgentId);
-          count += 1;
-          true
-        },
-        _ => false,
-      });
-    assert_eq!(count, 1);
-  }
-
-
-  // Committing an AgentIdEntry to source chain should work only as second entry
-  #[test]
-  fn cannot_commit_agent() {
-    // FIXME
-  }
+    // Committing an AgentIdEntry to source chain should work only as second entry
+    #[test]
+    fn cannot_commit_agent() {
+        // FIXME
+    }
 }

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -111,7 +111,8 @@ pub mod tests {
     use hash_table::sys_entry::{EntryType, ToEntry};
     use std::str::FromStr;
 
-    use instance::{tests::test_context, Instance};
+    use instance::{tests::test_context, Instance, Observer};
+    use std::sync::mpsc::channel;
 
     /// Committing a DnaEntry to source chain should work
     #[test]
@@ -122,10 +123,17 @@ pub mod tests {
         let dna_entry = dna.to_entry();
         let commit_action = ActionWrapper::new(Action::Commit(dna_entry));
 
-        // Set up instance and dispatch action
-        let mut instance = Instance::new();
-        instance.start_action_loop(context);
-        instance.dispatch_and_wait(commit_action);
+        // Set up instance and process the action
+        let instance = Instance::new();
+        let state_observers: Vec<Observer> = Vec::new();
+        let (_, rx_observer) = channel::<Observer>();
+        instance.process_action(
+            commit_action,
+            state_observers,
+            &rx_observer,
+            &context,
+        );
+
 
         // Check if AgentIdEntry is found
         assert_eq!(1, instance.state().history.iter().count());
@@ -153,10 +161,16 @@ pub mod tests {
         let agent_entry = context.agent.to_entry();
         let commit_agent_action = ActionWrapper::new(Action::Commit(agent_entry));
 
-        // Set up instance and dispatch action
-        let mut instance = Instance::new();
-        instance.start_action_loop(context);
-        instance.dispatch_and_wait(commit_agent_action);
+        // Set up instance and process the action
+        let instance = Instance::new();
+        let state_observers: Vec<Observer> = Vec::new();
+        let (_, rx_observer) = channel::<Observer>();
+        instance.process_action(
+            commit_agent_action,
+            state_observers,
+            &rx_observer,
+            &context,
+        );
 
         // Check if AgentIdEntry is found
         assert_eq!(1, instance.state().history.iter().count());

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -1,0 +1,180 @@
+
+use holochain_dna::Dna;
+use hash_table::entry::Entry;
+use std::str::FromStr;
+use holochain_agent::Agent;
+use holochain_agent::Identity;
+use serde_json;
+
+pub trait ToEntry {
+  fn to_entry(&self) -> Entry;
+  // Maybe change to `new_from_entry` ?
+  fn from_entry(&Entry) -> Self;
+}
+
+
+//-------------------------------------------------------------------------------------------------
+// Entry Type
+//-------------------------------------------------------------------------------------------------
+
+macro_rules! sys_prefix {
+    ($s:expr) => ( concat!("%", $s) )
+}
+
+#[derive(Clone, PartialEq)]
+pub enum EntryType {
+  AgentId,
+  Deletion,
+  Data,
+  Dna,
+  Headers,
+  Key,
+  Link,
+  Migration,
+}
+
+impl FromStr for EntryType {
+  type Err = usize;
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      sys_prefix!("agent_id") => Ok(EntryType::AgentId),
+      sys_prefix!("deletion") => Ok(EntryType::Deletion),
+      sys_prefix!("dna") => Ok(EntryType::Dna),
+      sys_prefix!("headers") => Ok(EntryType::Headers),
+      sys_prefix!("key") => Ok(EntryType::Key),
+      sys_prefix!("link") => Ok(EntryType::Link),
+      sys_prefix!("migration") => Ok(EntryType::Migration),
+      _ => Ok(EntryType::Data),
+    }
+  }
+}
+
+impl EntryType {
+  pub fn as_str(&self) -> &'static str {
+    match *self {
+      EntryType::Data =>      panic!("should not try to convert a custom data entry to str"),
+      EntryType::AgentId =>   sys_prefix!("agent_id"),
+      EntryType::Deletion =>  sys_prefix!("deletion"),
+      EntryType::Dna =>       sys_prefix!("dna"),
+      EntryType::Headers =>   sys_prefix!("headers"),
+      EntryType::Key =>       sys_prefix!("key"),
+      EntryType::Link =>      sys_prefix!("link"),
+      EntryType::Migration => sys_prefix!("migration"),
+    }
+  }
+}
+
+//-------------------------------------------------------------------------------------------------
+// Dna Entry
+//-------------------------------------------------------------------------------------------------
+
+impl ToEntry for Dna {
+  fn to_entry(&self) -> Entry {
+    Entry::new(
+      EntryType::Dna.as_str(),
+      &self.to_json().unwrap(),
+    )
+  }
+
+  fn from_entry(entry: &Entry) -> Self {
+    assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::Dna);
+    return Dna::new_from_json(&entry.content())
+      .expect("entry is not a valid Dna Entry")
+    ;
+  }
+}
+
+
+//-------------------------------------------------------------------------------------------------
+// Agent Entry
+//-------------------------------------------------------------------------------------------------
+
+impl ToEntry for Agent {
+  fn to_entry(&self) -> Entry {
+    Entry::new(
+      EntryType::AgentId.as_str(),
+      &self.to_string(),
+    )
+  }
+
+  fn from_entry(entry: &Entry) -> Self {
+    assert!(EntryType::from_str(&entry.entry_type()).unwrap() == EntryType::AgentId);
+    let id_content : String = serde_json::from_str(&entry.content())
+      .expect("entry is not a valid AgentId Entry");
+    Agent::new(Identity::new(id_content))
+  }
+}
+
+
+//-------------------------------------------------------------------------------------------------
+// UNIT TESTS
+//-------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+pub mod tests {
+//  extern crate test_utils;
+//  extern crate holochain_agent;
+//  use super::*;
+////  extern crate holochain_core;
+////  use holochain_core::{
+////    context::Context,
+////    nucleus::ribosome::{callback::Callback, Defn},
+////    persister::SimplePersister,
+////  };
+//  use std::sync::{Arc, Mutex};
+//  use test_utils::{create_test_dna_with_wasm, create_test_dna_with_wat, create_wasm_from_file};
+//
+//  use instance::{
+//    tests::{test_context, test_instance, test_instance_blank},
+//    Instance,
+//  };
+
+  // Committing a DnaEntry to source chain should work
+  #[test]
+  fn can_commit_dna() {
+//    // FIXME
+//    // Setup the holochain instance
+//    let wasm = create_wasm_from_file(
+//      "wasm-test/source_chain/target/wasm32-unknown-unknown/debug/source_chain.wasm",
+//    );
+//    let dna = create_test_dna_with_wasm("test_zome", "test_cap", wasm);
+//    let (context, _) = test_context("alex");
+//
+//
+//    let mut hc = Holochain::new(dna.clone(), context).unwrap();
+//    // Run the holochain instance
+//    hc.start().expect("couldn't start");
+//    // Call the exposed wasm function that calls the Commit API function
+//    let result = hc.call("test_zome", "test_cap", "can_commit_dna", r#"{}"#);
+//    // Expect normal OK result with hash
+//    match result {
+//      Ok(result) => assert_eq!(
+//        result,
+//        r#"{"hash":"QmRN6wdp1S2A5EtjW9A3M1vKSBuQQGcgvuhoMUoEz4iiT5"}"#
+//      ),
+//      Err(_) => assert!(false),
+//    };
+
+  }
+
+
+  // Committing a DnaEntry to source chain should work only if first entry
+  #[test]
+  fn cannot_commit_dna() {
+    // FIXME
+  }
+
+
+  // Committing an AgentIdEntry to source chain should work
+  #[test]
+  fn can_commit_agent() {
+    // FIXME
+  }
+
+
+  // Committing an AgentIdEntry to source chain should work only as second entry
+  #[test]
+  fn cannot_commit_agent() {
+    // FIXME
+  }
+}

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -8,7 +8,7 @@ use serde_json;
 
 pub trait ToEntry {
   fn to_entry(&self) -> Entry;
-  // Maybe change to `new_from_entry` ?
+  // FIXME - Maybe change to `new_from_entry` ?
   fn from_entry(&Entry) -> Self;
 }
 
@@ -17,11 +17,12 @@ pub trait ToEntry {
 // Entry Type
 //-------------------------------------------------------------------------------------------------
 
+// Macro for statically concatanating the system entry prefix for entry types of system entries
 macro_rules! sys_prefix {
     ($s:expr) => ( concat!("%", $s) )
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum EntryType {
   AgentId,
   Deletion,

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -87,7 +87,6 @@ impl ToEntry for Dna {
 //-------------------------------------------------------------------------------------------------
 
 impl ToEntry for Agent {
-
     fn to_entry(&self) -> Entry {
         Entry::new(EntryType::AgentId.as_str(), &self.to_string())
     }
@@ -109,15 +108,10 @@ pub mod tests {
     extern crate test_utils;
 
     use action::{Action, ActionWrapper};
-    use hash_table::{
-        sys_entry::{EntryType, ToEntry},
-    };
+    use hash_table::sys_entry::{EntryType, ToEntry};
     use std::str::FromStr;
 
-    use instance::{
-        tests::test_context,
-        Instance,
-    };
+    use instance::{tests::test_context, Instance};
 
     // Committing a DnaEntry to source chain should work
     #[test]

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -127,13 +127,7 @@ pub mod tests {
         let instance = Instance::new();
         let state_observers: Vec<Observer> = Vec::new();
         let (_, rx_observer) = channel::<Observer>();
-        instance.process_action(
-            commit_action,
-            state_observers,
-            &rx_observer,
-            &context,
-        );
-
+        instance.process_action(commit_action, state_observers, &rx_observer, &context);
 
         // Check if AgentIdEntry is found
         assert_eq!(1, instance.state().history.iter().count());
@@ -165,12 +159,7 @@ pub mod tests {
         let instance = Instance::new();
         let state_observers: Vec<Observer> = Vec::new();
         let (_, rx_observer) = channel::<Observer>();
-        instance.process_action(
-            commit_agent_action,
-            state_observers,
-            &rx_observer,
-            &context,
-        );
+        instance.process_action(commit_agent_action, state_observers, &rx_observer, &context);
 
         // Check if AgentIdEntry is found
         assert_eq!(1, instance.state().history.iter().count());

--- a/core/src/hash_table/sys_entry.rs
+++ b/core/src/hash_table/sys_entry.rs
@@ -113,7 +113,7 @@ pub mod tests {
 
     use instance::{tests::test_context, Instance};
 
-    // Committing a DnaEntry to source chain should work
+    /// Committing a DnaEntry to source chain should work
     #[test]
     fn can_commit_dna() {
         // Create Context, Agent, Dna, and Commit AgentIdEntry Action
@@ -128,7 +128,7 @@ pub mod tests {
         instance.dispatch_and_wait(commit_action);
 
         // Check if AgentIdEntry is found
-        let mut count = 0;
+        assert_eq!(1, instance.state().history.iter().count());
         instance
             .state()
             .history
@@ -139,21 +139,13 @@ pub mod tests {
                         EntryType::from_str(&entry.entry_type()).unwrap(),
                         EntryType::Dna
                     );
-                    count += 1;
                     true
                 }
                 _ => false,
             });
-        assert_eq!(count, 1);
     }
 
-    // Committing a DnaEntry to source chain should work only if first entry
-    #[test]
-    fn cannot_commit_dna() {
-        // FIXME
-    }
-
-    // Committing an AgentIdEntry to source chain should work
+    /// Committing an AgentIdEntry to source chain should work
     #[test]
     fn can_commit_agent() {
         // Create Context, Agent and Commit AgentIdEntry Action
@@ -167,7 +159,7 @@ pub mod tests {
         instance.dispatch_and_wait(commit_agent_action);
 
         // Check if AgentIdEntry is found
-        let mut count = 0;
+        assert_eq!(1, instance.state().history.iter().count());
         instance
             .state()
             .history
@@ -178,17 +170,9 @@ pub mod tests {
                         EntryType::from_str(&entry.entry_type()).unwrap(),
                         EntryType::AgentId
                     );
-                    count += 1;
                     true
                 }
                 _ => false,
             });
-        assert_eq!(count, 1);
-    }
-
-    // Committing an AgentIdEntry to source chain should work only as second entry
-    #[test]
-    fn cannot_commit_agent() {
-        // FIXME
     }
 }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -321,7 +321,7 @@ pub mod tests {
                 }
                 _ => false,
             })
-            == None
+            .is_none()
         {
             println!("Waiting for Commit for genesis");
             sleep(Duration::from_millis(10))

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -232,11 +232,13 @@ pub mod tests {
     use logger::Logger;
     use nucleus::ribosome::{callback::Callback, Defn};
     use persister::SimplePersister;
+    use hash_table::sys_entry::EntryType;
     use state::State;
     use std::{
         sync::{mpsc::channel, Arc, Mutex},
         thread::sleep,
         time::Duration,
+        str::FromStr,
     };
 
     #[derive(Clone, Debug)]
@@ -312,7 +314,10 @@ pub mod tests {
           .history
           .iter()
           .find(|aw| match aw.action() {
-              Action::Commit(_) => true, // FIXME
+              Action::Commit(entry) => {
+                  assert_eq!(EntryType::from_str(&entry.entry_type()).unwrap(), EntryType::Dna);
+                  true
+              },
               _ => false,
           }) == None
           {

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -308,6 +308,20 @@ pub mod tests {
         }
 
         while instance
+          .state()
+          .history
+          .iter()
+          .find(|aw| match aw.action() {
+              Action::Commit(_) => true, // FIXME
+              _ => false,
+          }) == None
+          {
+              println!("Waiting for Commit for genesis");
+              sleep(Duration::from_millis(10))
+          }
+
+
+        while instance
             .state()
             .history
             .iter()
@@ -433,7 +447,7 @@ pub mod tests {
 
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(instance.state().history.len(), 4);
+        assert_eq!(instance.state().history.len(), 5);
         assert!(instance.state().nucleus().has_initialized());
     }
 
@@ -463,7 +477,7 @@ pub mod tests {
 
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(instance.state().history.len(), 4);
+        assert_eq!(instance.state().history.len(), 5);
         assert!(instance.state().nucleus().has_initialized());
     }
 
@@ -493,7 +507,7 @@ pub mod tests {
 
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(instance.state().history.len(), 4);
+        assert_eq!(instance.state().history.len(), 5);
         assert!(instance.state().nucleus().has_initialized() == false);
     }
 }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -92,24 +92,24 @@ impl Instance {
             // don't rely on time can be written
             // @see https://github.com/holochain/holochain-rust/issues/169
             for action_wrapper in rx_action {
-                        // Mutate state
-                        {
+                // Mutate state
+                {
                     let mut state = state_mutex
                         .write()
                         .expect("owners of the state RwLock shouldn't panic");
-                            *state = state.reduce(
+                    *state = state.reduce(
                         Arc::clone(&context),
-                                action_wrapper,
-                                &tx_action,
-                                &tx_observer,
-                            );
-                        }
+                        action_wrapper,
+                        &tx_action,
+                        &tx_observer,
+                    );
+                }
 
-                        // Add new observers
+                // Add new observers
                 state_observers.extend(rx_observer.try_iter());
 
-                        // Run all observer closures
-                        {
+                // Run all observer closures
+                {
                     let state = state_mutex
                         .read()
                         .expect("owners of the state RwLock shouldn't panic");
@@ -334,7 +334,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ExecuteZomeFunction(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for ExecuteZomeFunction for genesis");
             sleep(Duration::from_millis(10))
@@ -347,7 +348,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnZomeFunctionResult(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for ReturnZomeFunctionResult from genesis");
             sleep(Duration::from_millis(10))
@@ -360,7 +362,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnInitializationResult(_) => true,
                 _ => false,
-            }).is_none()
+            })
+            .is_none()
         {
             println!("Waiting for ReturnInitializationResult");
             sleep(Duration::from_millis(10))

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -107,7 +107,7 @@ impl Instance {
 
     /// Calls the reducers for an action and calls the observers with the new state
     /// returns the new vector of observers
-    fn process_action(
+    pub(crate) fn process_action(
         &self,
         action_wrapper: ActionWrapper,
         mut state_observers: Vec<Observer>,
@@ -528,9 +528,6 @@ pub mod tests {
 
         let instance = test_instance(dna);
 
-        // @TODO don't use history length in tests
-        // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(instance.state().history.len(), 5);
         assert!(instance.state().nucleus().has_initialized());
     }
 
@@ -558,9 +555,6 @@ pub mod tests {
 
         let instance = test_instance(dna);
 
-        // @TODO don't use history length in tests
-        // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(instance.state().history.len(), 5);
         assert!(instance.state().nucleus().has_initialized());
     }
 
@@ -588,9 +582,6 @@ pub mod tests {
 
         let instance = test_instance(dna);
 
-        // @TODO don't use history length in tests
-        // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(instance.state().history.len(), 5);
         assert!(instance.state().nucleus().has_initialized() == false);
     }
 }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -227,18 +227,18 @@ pub mod tests {
     use super::Instance;
     use action::{Action, ActionWrapper};
     use context::Context;
+    use hash_table::sys_entry::EntryType;
     use holochain_agent::Agent;
     use holochain_dna::{zome::Zome, Dna};
     use logger::Logger;
     use nucleus::ribosome::{callback::Callback, Defn};
     use persister::SimplePersister;
-    use hash_table::sys_entry::EntryType;
     use state::State;
     use std::{
+        str::FromStr,
         sync::{mpsc::channel, Arc, Mutex},
         thread::sleep,
         time::Duration,
-        str::FromStr,
     };
 
     #[derive(Clone, Debug)]
@@ -303,28 +303,32 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::InitApplication(_) => true,
                 _ => false,
-            }) == None
+            })
+            == None
         {
             println!("Waiting for InitApplication");
             sleep(Duration::from_millis(10))
         }
 
         while instance
-          .state()
-          .history
-          .iter()
-          .find(|aw| match aw.action() {
-              Action::Commit(entry) => {
-                  assert_eq!(EntryType::from_str(&entry.entry_type()).unwrap(), EntryType::Dna);
-                  true
-              },
-              _ => false,
-          }) == None
-          {
-              println!("Waiting for Commit for genesis");
-              sleep(Duration::from_millis(10))
-          }
-
+            .state()
+            .history
+            .iter()
+            .find(|aw| match aw.action() {
+                Action::Commit(entry) => {
+                    assert_eq!(
+                        EntryType::from_str(&entry.entry_type()).unwrap(),
+                        EntryType::Dna
+                    );
+                    true
+                }
+                _ => false,
+            })
+            == None
+        {
+            println!("Waiting for Commit for genesis");
+            sleep(Duration::from_millis(10))
+        }
 
         while instance
             .state()
@@ -333,7 +337,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ExecuteZomeFunction(_) => true,
                 _ => false,
-            }) == None
+            })
+            == None
         {
             println!("Waiting for ExecuteZomeFunction for genesis");
             sleep(Duration::from_millis(10))
@@ -346,7 +351,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnZomeFunctionResult(_) => true,
                 _ => false,
-            }) == None
+            })
+            == None
         {
             println!("Waiting for ReturnZomeFunctionResult from genesis");
             sleep(Duration::from_millis(10))
@@ -359,7 +365,8 @@ pub mod tests {
             .find(|aw| match aw.action() {
                 Action::ReturnZomeFunctionResult(_) => true,
                 _ => false,
-            }) == None
+            })
+            == None
         {
             println!("Waiting for ReturnInitializationResult");
             sleep(Duration::from_millis(10))

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -222,7 +222,8 @@ fn reduce_ia(
             ::instance::dispatch_action_and_wait(
                 &genesis_action_channel,
                 &genesis_observer_channel,
-                commit_genesis_action);
+                commit_genesis_action,
+            );
         }
 
         // map genesis across every zome

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -6,8 +6,7 @@ use context::Context;
 use error::HolochainError;
 
 use action::{Action, ActionWrapper, NucleusReduceFn};
-use instance::Observer;
-use instance::dispatch_action_with_observer;
+use instance::{dispatch_action_with_observer, Observer};
 use nucleus::{
     ribosome::callback::{genesis::genesis, CallbackParams, CallbackResult},
     state::{NucleusState, NucleusStatus},
@@ -221,7 +220,7 @@ fn reduce_ia(
 
             // TODO - Change to `dispatch_action_with_observer`
             // since we want to make sure commit succeeded
-            ::instance::dispatch_action(&genesis_action_channel,&commit_genesis_action);
+            ::instance::dispatch_action(&genesis_action_channel, &commit_genesis_action);
         }
 
         // map genesis across every zome
@@ -256,10 +255,9 @@ fn reduce_ia(
         // map the genesis results to initialization result responses
         for result in results {
             match result {
-                CallbackResult::Fail(s) => return_initialization_result(
-                    Some(s.to_string()),
-                    &genesis_action_channel,
-                ),
+                CallbackResult::Fail(s) => {
+                    return_initialization_result(Some(s.to_string()), &genesis_action_channel)
+                }
                 _ => return_initialization_result(None, &genesis_action_channel),
             }
         }

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -7,6 +7,7 @@ use error::HolochainError;
 
 use action::{Action, ActionWrapper, NucleusReduceFn};
 use instance::Observer;
+use instance::dispatch_action_with_observer;
 use nucleus::{
     ribosome::callback::{genesis::genesis, CallbackParams, CallbackResult},
     state::{NucleusState, NucleusStatus},
@@ -19,6 +20,8 @@ use std::{
     },
     thread,
 };
+
+use hash_table::sys_entry::*;
 
 /// Struct holding data for requesting the execution of a Zome function (ExecutionZomeFunction Action)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -70,7 +73,7 @@ pub fn call_zome_and_wait_for_result(
 
     // Dispatch action with observer closure that waits for a result in the state
     let (sender, receiver) = channel();
-    ::instance::dispatch_action_with_observer(
+    dispatch_action_with_observer(
         action_channel,
         observer_channel,
         &call_action_wrapper,
@@ -172,8 +175,9 @@ fn return_initialization_result(result: Option<String>, action_channel: &Sender<
 }
 
 /// Reduce InitApplication Action
-/// Initialize Nucleus by setting the DNA
-/// and sending ExecuteFunction Action of genesis of each zome
+/// Initialize the Holochain's Nucleus by doing the following:
+/// Send Commit Action for Genesis Entry
+/// Send ExecuteZomeFunction Action of the genesis callback of every zome
 #[allow(unknown_lints)]
 #[allow(needless_pass_by_value)]
 fn reduce_ia(
@@ -183,72 +187,83 @@ fn reduce_ia(
     action_channel: &Sender<ActionWrapper>,
     observer_channel: &Sender<Observer>,
 ) {
-    match state.status() {
-        NucleusStatus::New => {
-            let action = action_wrapper.action();
-            let dna = unwrap_to!(action => Action::InitApplication);
-
-            // Update status
-            state.status = NucleusStatus::Initializing;
-
-            // Set DNA
-            state.dna = Some(dna.clone());
-
-            // Create & launch thread
-            let genesis_action_channel = action_channel.clone();
-            let genesis_observer_channel = observer_channel.clone();
-            let dna_clone = dna.clone();
-
-            thread::spawn(move || {
-                // map genesis across every zome
-                let mut results: Vec<_> = dna_clone
-                    .zomes
-                    .iter()
-                    .map(|zome| {
-                        genesis(
-                            &genesis_action_channel,
-                            &genesis_observer_channel,
-                            &zome.name(),
-                            &CallbackParams::Genesis,
-                        )
-                    })
-                    .collect();
-
-                // pad out a single pass if there are no zome results
-                // @TODO is this really OK?
-                // should we be steamrolling ahead with an instance that has no zomes and no
-                // genesis?
-                // actually this can cause some really nasty edge case bugs for code that assumes
-                // there is a genesis (real example: wait for length 4 in history) in a loop before
-                // moving forward. it will seem to work OK, but then hang if ever hit with an empty
-                // Dna.
-                // on the flip side, code cannot simply wait for 2 items in history, or even the
-                // initialization result on its own, because then it will miss the genesis
-                // sometimes where a genesis does happen.
-                if results.is_empty() {
-                    results.push(CallbackResult::Pass);
-                }
-
-                // map the genesis results to initialization result responses
-                for result in results {
-                    match result {
-                        CallbackResult::Fail(s) => return_initialization_result(
-                            Some(s.to_string()),
-                            &genesis_action_channel,
-                        ),
-                        _ => return_initialization_result(None, &genesis_action_channel),
-                    }
-                }
-            });
-        }
-        _ => {
-            // Send bad start state ReturnInitializationResult Action
-            return_initialization_result(
-                Some("Nucleus already initialized or initializing".to_string()),
-                &action_channel,
-            );
-        }
+    // check pre-condition
+    if state.status() != NucleusStatus::New {
+        // Send bad start state ReturnInitializationResult Action
+        return_initialization_result(
+            Some("Nucleus already initialized or initializing".to_string()),
+            &action_channel,
+        );
+        return;
     }
+
+    let ia_action = action_wrapper.action();
+    let dna = unwrap_to!(ia_action => Action::InitApplication);
+
+    // Update status
+    state.status = NucleusStatus::Initializing;
+
+    // Set DNA
+    state.dna = Some(dna.clone());
+
+    // Create & launch thread
+    let genesis_action_channel = action_channel.clone();
+    let genesis_observer_channel = observer_channel.clone();
+    let dna_clone = dna.clone();
+    // let action_wrapper_clone = action_wrapper.clone();
+
+    thread::spawn(move || {
+        // Send Commit Action for Genesis Entry
+        {
+            // Create Commit Action for Genesis Entry
+            let genesis_entry = dna_clone.to_entry();
+            let commit_genesis_action = ActionWrapper::new(&Action::Commit(genesis_entry));
+
+            // TODO - Change to `dispatch_action_with_observer`
+            // since we want to make sure commit succeeded
+            ::instance::dispatch_action(&genesis_action_channel,&commit_genesis_action);
+        }
+
+        // map genesis across every zome
+        let mut results: Vec<_> = dna_clone
+            .zomes
+            .iter()
+            .map(|zome| {
+                genesis(
+                    &genesis_action_channel,
+                    &genesis_observer_channel,
+                    &zome.name(),
+                    &CallbackParams::Genesis,
+                )
+            })
+            .collect();
+
+        // pad out a single pass if there are no zome results
+        // @TODO is this really OK?
+        // should we be steamrolling ahead with an instance that has no zomes and no
+        // genesis?
+        // actually this can cause some really nasty edge case bugs for code that assumes
+        // there is a genesis (real example: wait for length 4 in history) in a loop before
+        // moving forward. it will seem to work OK, but then hang if ever hit with an empty
+        // Dna.
+        // on the flip side, code cannot simply wait for 2 items in history, or even the
+        // initialization result on its own, because then it will miss the genesis
+        // sometimes where a genesis does happen.
+        if results.is_empty() {
+            results.push(CallbackResult::Pass);
+        }
+
+        // map the genesis results to initialization result responses
+        for result in results {
+            match result {
+                CallbackResult::Fail(s) => return_initialization_result(
+                    Some(s.to_string()),
+                    &genesis_action_channel,
+                ),
+                _ => return_initialization_result(None, &genesis_action_channel),
+            }
+        }
+    });
 }
 
 /// Reduce ExecuteZomeFunction Action

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -218,11 +218,10 @@ fn reduce_ia(
             let commit_genesis_action = ActionWrapper::new(Action::Commit(genesis_entry));
 
             // Send Action and wait for it
-            ::instance::dispatch_action_and_wait(
+            // TODO #249 - Do `dispatch_action_and_wait` instead to make sure dna commit succeeded
+            ::instance::dispatch_action(
                 &genesis_action_channel,
-                &genesis_observer_channel,
-                commit_genesis_action,
-            );
+                commit_genesis_action);
         }
 
         // map genesis across every zome

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -219,9 +219,7 @@ fn reduce_ia(
 
             // Send Action and wait for it
             // TODO #249 - Do `dispatch_action_and_wait` instead to make sure dna commit succeeded
-            ::instance::dispatch_action(
-                &genesis_action_channel,
-                commit_genesis_action);
+            ::instance::dispatch_action(&genesis_action_channel, commit_genesis_action);
         }
 
         // map genesis across every zome

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -218,9 +218,11 @@ fn reduce_ia(
             let genesis_entry = dna_clone.to_entry();
             let commit_genesis_action = ActionWrapper::new(&Action::Commit(genesis_entry));
 
-            // TODO - Change to `dispatch_action_with_observer`
-            // since we want to make sure commit succeeded
-            ::instance::dispatch_action(&genesis_action_channel, &commit_genesis_action);
+            // Send Action and wait for it
+            ::instance::dispatch_action_and_wait(
+                &genesis_action_channel,
+                &genesis_observer_channel,
+                &commit_genesis_action);
         }
 
         // map genesis across every zome

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -21,7 +21,7 @@ use std::{
     thread,
 };
 
-use hash_table::sys_entry::*;
+use hash_table::sys_entry::ToEntry;
 
 /// Struct holding data for requesting the execution of a Zome function (ExecutionZomeFunction Action)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -209,7 +209,6 @@ fn reduce_ia(
     let genesis_action_channel = action_channel.clone();
     let genesis_observer_channel = observer_channel.clone();
     let dna_clone = dna.clone();
-    // let action_wrapper_clone = action_wrapper.clone();
 
     thread::spawn(move || {
         // Send Commit Action for Genesis Entry
@@ -241,7 +240,7 @@ fn reduce_ia(
             .collect();
 
         // pad out a single pass if there are no zome results
-        // @TODO is this really OK?
+        // @TODO #78 - is this really OK?
         // should we be steamrolling ahead with an instance that has no zomes and no
         // genesis?
         // actually this can cause some really nasty edge case bugs for code that assumes

--- a/core/src/nucleus/ribosome/api/get.rs
+++ b/core/src/nucleus/ribosome/api/get.rs
@@ -100,9 +100,9 @@ mod tests {
             test_zome_api_function_runtime(ZomeAPIFunction::GetEntry.as_str(), test_args_bytes());
 
         let mut expected = "".to_owned();
-        expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"");
+        expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"link\":null,\"entry_hash\":\"");
         expected.push_str(&test_entry_hash());
-        expected.push_str("\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
+        expected.push_str("\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
 
         assert_eq!(runtime.result, expected);
     }

--- a/core/src/nucleus/ribosome/api/get.rs
+++ b/core/src/nucleus/ribosome/api/get.rs
@@ -90,9 +90,9 @@ mod tests {
         let (runtime, _) = test_zome_api_function_runtime("get", test_args_bytes());
 
         let mut expected = "".to_owned();
-        expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry_hash\":\"");
+        expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"prev\":null,\"entry_hash\":\"");
         expected.push_str(&test_entry_hash());
-        expected.push_str("\",\"same_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
+        expected.push_str("\",\"entry_signature\":\"\",\"prev_same\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
 
         assert_eq!(runtime.result, expected,);
     }

--- a/core/src/nucleus/ribosome/api/get.rs
+++ b/core/src/nucleus/ribosome/api/get.rs
@@ -90,9 +90,9 @@ mod tests {
         let (runtime, _) = test_zome_api_function_runtime("get", test_args_bytes());
 
         let mut expected = "".to_owned();
-        expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry\":\"");
+        expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"time\":\"\",\"next\":null,\"entry_hash\":\"");
         expected.push_str(&test_entry_hash());
-        expected.push_str("\",\"type_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
+        expected.push_str("\",\"same_next\":null,\"signature\":\"\"},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
 
         assert_eq!(runtime.result, expected,);
     }

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -408,7 +408,7 @@ mod tests {
         hc.start().expect("couldn't start");
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 4);
+        assert_eq!(hc.state().unwrap().history.len(), 5);
 
         // Call the exposed wasm function that calls the Commit API function
         let result = hc.call("test_zome", "test_cap", "test", r#"{}"#);
@@ -425,7 +425,7 @@ mod tests {
         // Check in holochain instance's history that the commit event has been processed
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 9);
+        assert_eq!(hc.state().unwrap().history.len(), 10);
     }
 
     #[test]
@@ -443,7 +443,7 @@ mod tests {
         hc.start().expect("couldn't start");
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 4);
+        assert_eq!(hc.state().unwrap().history.len(), 5);
 
         // Call the exposed wasm function that calls the Commit API function
         let result = hc.call("test_zome", "test_cap", "test_fail", r#"{}"#);
@@ -457,7 +457,7 @@ mod tests {
         // Check in holochain instance's history that the commit event has been processed
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 6);
+        assert_eq!(hc.state().unwrap().history.len(), 7);
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod tests {
         hc.start().expect("couldn't start");
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 4);
+        assert_eq!(hc.state().unwrap().history.len(), 5);
 
         // Call the exposed wasm function that calls the Commit API function
         let result = hc.call("test_zome", "test_cap", "debug_hello", r#"{}"#);
@@ -490,7 +490,7 @@ mod tests {
         // Check in holochain instance's history that the debug event has been processed
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 6);
+        assert_eq!(hc.state().unwrap().history.len(), 7);
     }
 
     #[test]
@@ -509,7 +509,7 @@ mod tests {
         hc.start().expect("couldn't start");
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 4);
+        assert_eq!(hc.state().unwrap().history.len(), 5);
 
         // Call the exposed wasm function that calls the Commit API function
         let result = hc.call("test_zome", "test_cap", "debug_multiple", r#"{}"#);
@@ -521,6 +521,6 @@ mod tests {
         // Check in holochain instance's history that the deb event has been processed
         // @TODO don't use history length in tests
         // @see https://github.com/holochain/holochain-rust/issues/195
-        assert_eq!(hc.state().unwrap().history.len(), 6);
+        assert_eq!(hc.state().unwrap().history.len(), 7);
     }
 }


### PR DESCRIPTION
### System Entry Types
Added `enum EntryType` which lists all entry types. `Data` is the enum variant name for the non-system entry type (entries defined by app dna).
This enum can be converted to a string and has a system-prefix like in the Go Version.

System entry types uses the `Entry` struct. Its just the content that changes and must follow a specific schema (yet to be defined by system entry type).
So I added a `ToEntry` trait, which is a `to_entry()` method that returns an `Entry`.
`Dna` and `Agent` implements that trait, which converts them to their system entry equivalent.

### Genesis Pair at InitApplication 
I added the genesis pair commit in the InitApplication reducer. 
The genesis pair holds the DNA system entry. 

### Renamed functions
When trying to understand the code on Chains and Entries, it seemed important to me to rename a couple of methods to make it clearer and coherent with previous holochain documentation like [this picture](https://holochain.org/assets/images/holochain/private_source_chain_diagram.png). The renamed methods are in `Chain` and `Header`.

The most controversial might be `next` changed to `prev`
I understand that `next` is for coherence with the Iterator pattern, but for me coherence with the mental modal of an append-only chain is more important. `prev` means going back in time which is what we are doing when going through chain from top to bottom.

I also find `Pair` confusing but I didn't find a better alternative than `ChainLink` which I also don't like very much...