### PR TITLE
use HashString in Action enum

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,6 +1,6 @@
 use agent::state::AgentState;
 use context::Context;
-use hash_table::entry::Entry;
+use hash_table::{entry::Entry, HashString};
 use holochain_dna::Dna;
 use instance::Observer;
 use nucleus::{state::NucleusState, EntrySubmission, FunctionCall, FunctionResult};

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -67,7 +67,7 @@ pub enum Action {
     /// MUST already have passed all callback checks
     Commit(Entry),
     /// hash to Get
-    Get(String),
+    Get(HashString),
 
     /// execute a function in a zome WASM
     ExecuteZomeFunction(FunctionCall),
@@ -79,14 +79,12 @@ pub enum Action {
     /// may call genesis internally
     InitApplication(Dna),
     /// return the result of an InitApplication action
+    /// the result is Some arbitrary string
     ReturnInitializationResult(Option<String>),
 
     /// ???
     // @TODO how does this relate to validating a commit?
     ValidateEntry(EntrySubmission),
-
-    /// add a network peer
-    AddPeer(String),
 }
 
 /// function signature for action handler functions


### PR DESCRIPTION
fixes #283 

also drops `AddPeer` as this is not used nor will be used according to @zippy 