### PR TITLE
move header in chain

### DIFF
--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -121,8 +121,8 @@ impl Key for Header {
 
 #[cfg(test)]
 mod tests {
-    use chain::{tests::test_chain, SourceChain};
-    use hash_table::{entry::Entry, header::Header, pair::tests::test_pair};
+    use chain::{tests::test_chain, SourceChain, header::Header};
+    use hash_table::{entry::Entry, pair::tests::test_pair};
     use key::Key;
 
     /// returns a dummy header for use in tests

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -121,7 +121,7 @@ impl Key for Header {
 
 #[cfg(test)]
 mod tests {
-    use chain::{tests::test_chain, SourceChain, header::Header};
+    use chain::{header::Header, tests::test_chain, SourceChain};
     use hash_table::{entry::Entry, pair::tests::test_pair};
     use key::Key;
 

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -8,6 +8,7 @@ use json::ToJson;
 use key::Key;
 use riker::actors::*;
 use serde_json;
+pub mod header;
 
 /// Iterator type for pairs in a chain
 /// next method may panic if there is an error in the underlying table

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -173,7 +173,7 @@ impl SourceChain for Chain {
             )));
         }
 
-        self.table.commit_pair(&pair.clone())?;
+        self.table.put_pair(&pair.clone())?;
 
         // @TODO instead of unwrapping this, move all the above validation logic inside of
         // set_top_pair()

--- a/core/src/hash_table/actor.rs
+++ b/core/src/hash_table/actor.rs
@@ -22,7 +22,7 @@ impl HashTable for ActorRef<Protocol> {
         unwrap_to!(response => Protocol::TeardownResult).clone()
     }
 
-    fn commit_pair(&mut self, pair: &Pair) -> Result<(), HolochainError> {
+    fn put_pair(&mut self, pair: &Pair) -> Result<(), HolochainError> {
         let response = self.block_on_ask(Protocol::Commit(pair.clone()));
         unwrap_to!(response => Protocol::CommitResult).clone()
     }
@@ -118,7 +118,7 @@ impl<HT: HashTable> Actor for HashTableActor<HT> {
 
                     Protocol::Teardown => Protocol::TeardownResult(self.table.teardown()),
 
-                    Protocol::Commit(pair) => Protocol::CommitResult(self.table.commit_pair(&pair)),
+                    Protocol::Commit(pair) => Protocol::CommitResult(self.table.put_pair(&pair)),
 
                     Protocol::Pair(hash) => Protocol::PairResult(self.table.pair(&hash)),
 
@@ -176,7 +176,7 @@ pub mod tests {
 
         assert_eq!(table_actor.pair(&test_hash()).unwrap(), None,);
 
-        table_actor.commit_pair(&test_pair()).unwrap();
+        table_actor.put_pair(&test_pair()).unwrap();
 
         assert_eq!(
             table_actor.pair(&test_pair().key()).unwrap(),
@@ -207,7 +207,7 @@ pub mod tests {
         thread::spawn(move || {
             rx1.recv().unwrap();
             let pair = test_pair();
-            table_actor_thread.commit_pair(&pair).unwrap();
+            table_actor_thread.put_pair(&pair).unwrap();
             // push the committed pair through to the next thread
             tx2.send(pair).unwrap();
         });

--- a/core/src/hash_table/file/mod.rs
+++ b/core/src/hash_table/file/mod.rs
@@ -92,7 +92,7 @@ impl FileTable {
 }
 
 impl HashTable for FileTable {
-    fn commit_pair(&mut self, pair: &Pair) -> Result<(), HolochainError> {
+    fn put_pair(&mut self, pair: &Pair) -> Result<(), HolochainError> {
         self.upsert(Table::Pairs, pair)
     }
 

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -21,7 +21,7 @@ impl MemTable {
 }
 
 impl HashTable for MemTable {
-    fn commit_pair(&mut self, pair: &Pair) -> Result<(), HolochainError> {
+    fn put_pair(&mut self, pair: &Pair) -> Result<(), HolochainError> {
         self.pairs.insert(pair.key(), pair.clone());
         Ok(())
     }

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -36,7 +36,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
 
     // crud
     /// add a Pair to the HashTable, analogous to chain.push() but ordering is not enforced
-    fn commit_pair(&mut self, pair: &Pair) -> Result<(), HolochainError>;
+    fn put_pair(&mut self, pair: &Pair) -> Result<(), HolochainError>;
 
     /// lookup a Pair from the HashTable by Pair/Header key
     fn pair(&self, key: &str) -> Result<Option<Pair>, HolochainError>;
@@ -48,7 +48,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
         old_pair: &Pair,
         new_pair: &Pair,
     ) -> Result<(), HolochainError> {
-        self.commit_pair(new_pair)?;
+        self.put_pair(new_pair)?;
 
         // @TODO what if meta fails when commit succeeds?
         // @see https://github.com/holochain/holochain-rust/issues/142

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -1,7 +1,6 @@
 pub mod actor;
 pub mod entry;
 pub mod file;
-pub mod header;
 pub mod memory;
 pub mod pair;
 pub mod pair_meta;

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -1,6 +1,7 @@
 use chain::Chain;
 use error::HolochainError;
-use hash_table::{entry::Entry, header::Header};
+use chain::header::Header;
+use hash_table::entry::Entry;
 use json::{FromJson, RoundTripJson, ToJson};
 use key::Key;
 use serde_json;
@@ -105,13 +106,12 @@ impl RoundTripJson for Pair {}
 #[cfg(test)]
 pub mod tests {
     use super::Pair;
-    use chain::{tests::test_chain, SourceChain};
+    use chain::{tests::test_chain, SourceChain, header::Header};
     use hash_table::{
         entry::{
             tests::{test_entry, test_entry_b, test_entry_unique},
             Entry,
         },
-        header::Header,
     };
     use json::{FromJson, ToJson};
 

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -1,6 +1,5 @@
-use chain::Chain;
+use chain::{header::Header, Chain};
 use error::HolochainError;
-use chain::header::Header;
 use hash_table::entry::Entry;
 use json::{FromJson, RoundTripJson, ToJson};
 use key::Key;
@@ -106,12 +105,10 @@ impl RoundTripJson for Pair {}
 #[cfg(test)]
 pub mod tests {
     use super::Pair;
-    use chain::{tests::test_chain, SourceChain, header::Header};
-    use hash_table::{
-        entry::{
-            tests::{test_entry, test_entry_b, test_entry_unique},
-            Entry,
-        },
+    use chain::{header::Header, tests::test_chain, SourceChain};
+    use hash_table::entry::{
+        tests::{test_entry, test_entry_b, test_entry_unique},
+        Entry,
     };
     use json::{FromJson, ToJson};
 

--- a/core/src/hash_table/test_util.rs
+++ b/core/src/hash_table/test_util.rs
@@ -18,7 +18,7 @@ use key::Key;
 pub fn test_pair_round_trip<HT: HashTable>(table: &mut HT) {
     let pair = test_pair_unique();
     table
-        .commit_pair(&pair)
+        .put_pair(&pair)
         .expect("should be able to commit valid pair");
     assert_eq!(table.pair(&pair.key()), Ok(Some(pair)));
 }
@@ -28,7 +28,7 @@ pub fn test_modify_pair<HT: HashTable>(table: &mut HT) {
     let pair_2 = test_pair_unique();
 
     table
-        .commit_pair(&pair_1)
+        .put_pair(&pair_1)
         .expect("should be able to commit valid pair");
     table
         .modify_pair(&test_keys(), &pair_1, &pair_2)
@@ -63,7 +63,7 @@ pub fn test_retract_pair<HT: HashTable>(table: &mut HT) {
     let empty_vec: Vec<PairMeta> = Vec::new();
 
     table
-        .commit_pair(&pair)
+        .put_pair(&pair)
         .expect("should be able to commit valid pair");
     assert_eq!(
         empty_vec,


### PR DESCRIPTION
fixes #274 

- moves header into chain
- code is already `push_entry` for chain
- changes `commit_pair` to `put_pair`