### PR TITLE
rename new_from_encoded to from_encoded for SinglePageStack

### DIFF
--- a/core/src/nucleus/wasm-test/src/lib.rs
+++ b/core/src/nucleus/wasm-test/src/lib.rs
@@ -33,7 +33,7 @@ fn hdk_debug(mem_stack: &mut SinglePageStack, s: &str) {
 /// holding input arguments
 #[no_mangle]
 pub extern "C" fn debug_hello(encoded_allocation_of_input: usize) -> i32 {
-  let mut mem_stack = SinglePageStack::new_from_encoded(encoded_allocation_of_input as u32);
+  let mut mem_stack = SinglePageStack::from_encoded(encoded_allocation_of_input as u32);
   hdk_debug(&mut mem_stack, "Hello world!");
   return 0;
 }
@@ -43,7 +43,7 @@ pub extern "C" fn debug_hello(encoded_allocation_of_input: usize) -> i32 {
 /// holding input arguments
 #[no_mangle]
 pub extern "C" fn debug_multiple(encoded_allocation_of_input: usize) -> i32 {
-  let mut mem_stack = SinglePageStack::new_from_encoded(encoded_allocation_of_input as u32);
+  let mut mem_stack = SinglePageStack::from_encoded(encoded_allocation_of_input as u32);
   hdk_debug(&mut mem_stack, "Hello");
   hdk_debug(&mut mem_stack, "world");
   hdk_debug(&mut mem_stack, "!");

--- a/core_api/wasm-test/commit/src/lib.rs
+++ b/core_api/wasm-test/commit/src/lib.rs
@@ -145,7 +145,7 @@ fn test_fail_inner(mem_stack: &mut SinglePageStack) -> CommitOutputStruct
 /// returns encoded allocation used to store output
 #[no_mangle]
 pub extern "C" fn test(encoded_allocation_of_input: usize) -> i32 {
-  let mut mem_stack = SinglePageStack::new_from_encoded(encoded_allocation_of_input as u32);
+  let mut mem_stack = SinglePageStack::from_encoded(encoded_allocation_of_input as u32);
   let output = test_inner(&mut mem_stack);
   return serialize_into_encoded_allocation(&mut mem_stack, output);
 }
@@ -156,7 +156,7 @@ pub extern "C" fn test(encoded_allocation_of_input: usize) -> i32 {
 /// returns encoded allocation used to store output
 #[no_mangle]
 pub extern "C" fn test_fail(encoded_allocation_of_input: usize) -> i32 {
-  let mut mem_stack = SinglePageStack::new_from_encoded(encoded_allocation_of_input as u32);
+  let mut mem_stack = SinglePageStack::from_encoded(encoded_allocation_of_input as u32);
   let output = test_fail_inner(&mut mem_stack);
   return serialize_into_encoded_allocation(&mut mem_stack, output);
 }

--- a/core_api/wasm-test/round_trip/src/lib.rs
+++ b/core_api/wasm-test/round_trip/src/lib.rs
@@ -41,7 +41,7 @@ fn test_inner(input: InputStruct) -> OutputStruct {
 /// returns encoded allocation used to store output
 #[no_mangle]
 pub extern "C" fn test(encoded_allocation_of_input: usize) -> i32 {
-    let mut mem_stack = SinglePageStack::new_from_encoded(encoded_allocation_of_input as u32);
+    let mut mem_stack = SinglePageStack::from_encoded(encoded_allocation_of_input as u32);
     let input = deserialize_allocation(encoded_allocation_of_input as u32);
     let output = test_inner(input);
     return serialize_into_encoded_allocation(&mut mem_stack, output);

--- a/wasm_utils/src/lib.rs
+++ b/wasm_utils/src/lib.rs
@@ -124,7 +124,7 @@ impl SinglePageStack {
         }
     }
 
-    pub fn new_from_encoded(encoded_last_allocation: u32) -> Self {
+    pub fn from_encoded(encoded_last_allocation: u32) -> Self {
         let last_allocation = SinglePageAllocation::new(encoded_last_allocation as u32);
         let last_allocation =
             last_allocation.expect("received error instead of valid encoded allocation");


### PR DESCRIPTION
delivers function rename from #269 