### PR TITLE
assemblyscript build needs wasm start call

### DIFF
--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -25,7 +25,7 @@ use std::{
     sync::{mpsc::Sender, Arc},
 };
 use wasmi::{
-    self, Error as InterpreterError, Externals, FuncInstance, FuncRef, ImportsBuilder,
+    self, Error as InterpreterError, Externals, NopExternals, FuncInstance, FuncRef, ImportsBuilder,
     ModuleImportResolver, ModuleInstance, RuntimeArgs, RuntimeValue, Signature, Trap, TrapKind,
     ValueType,
 };
@@ -266,10 +266,10 @@ pub fn call(
     let mut imports = ImportsBuilder::new();
     imports.push_resolver("env", &RuntimeModuleImportResolver);
 
-    // Create module instance from wasm module, and without starting it
+    // Create module instance from wasm module, and start it if start is defined
     let wasm_instance = ModuleInstance::new(&module, &imports)
         .expect("Failed to instantiate module")
-        .assert_no_start();
+        .run_start(&mut NopExternals)?;
 
     // write input arguments for module call in memory Buffer
     let input_parameters: Vec<_> = parameters.unwrap_or_default();


### PR DESCRIPTION
All three memory allocator modules implemented for assemblyscript need the `start` method in wasm to be called, so `assert_no_start` doesn't work in this use case

If start doesn't exist it doesn't get called
https://github.com/paritytech/wasmi/blob/0409913a26ad16a622f49b7f885fc6415e80f26d/src/module.rs#L676

We get WAT code that looks like this out of assemblyscript builds (section of it)
```
(func $start (; 1 ;) (type $v)
  (set_global $~lib/allocator/arena/startOffset
   (i32.and
    (i32.add
     (get_global $HEAP_BASE)
     (get_global $~lib/internal/allocator/AL_MASK)
    )
    (i32.xor
     (get_global $~lib/internal/allocator/AL_MASK)
     (i32.const -1)
    )
   )
  )
  (set_global $~lib/allocator/arena/offset
   (get_global $~lib/allocator/arena/startOffset)
  )
 )
)
```