### PR TITLE
only build master and develop branches in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ services:
 
 dist: trusty
 
+# https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches
+# we build all PRs already, don't need redundant branch builds
+branches:
+  only:
+    - master
+    - develop
+
 jobs:
   include:
     - name: "C tests"


### PR DESCRIPTION
we don't need to build every PR commit twice

this filters branch builds to develop and master

PRs should still build as they are configured to in Travis