### PR TITLE
Hashstring newtype

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,6 +1,7 @@
 use agent::state::AgentState;
 use context::Context;
-use hash_table::{entry::Entry, HashString};
+use hash_table::{entry::Entry};
+use hash::HashString;
 use holochain_dna::Dna;
 use instance::Observer;
 use nucleus::{state::NucleusState, EntrySubmission, ZomeFnCall, ZomeFnResult};
@@ -61,7 +62,7 @@ impl Hash for ActionWrapper {
     }
 }
 
-#[derive(Clone, PartialEq, Hash, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Action {
     /// entry to Commit
     /// MUST already have passed all callback checks

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,7 +1,7 @@
 use agent::state::AgentState;
 use context::Context;
-use hash_table::{entry::Entry};
 use hash::HashString;
+use hash_table::entry::Entry;
 use holochain_dna::Dna;
 use instance::Observer;
 use nucleus::{state::NucleusState, EntrySubmission, ZomeFnCall, ZomeFnResult};

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -5,6 +5,7 @@ use hash_table::{pair::Pair, pair_meta::PairMeta};
 use riker::actors::*;
 use riker_default::DefaultModel;
 use riker_patterns::ask::ask;
+use hash::HashString;
 
 #[derive(Clone, Debug)]
 /// riker protocol for all our actors
@@ -47,7 +48,7 @@ pub enum Protocol {
     AssertMetaResult(Result<(), HolochainError>),
 
     /// HashTable::pair_meta()
-    GetPairMeta(String),
+    GetPairMeta(HashString),
     GetPairMetaResult(Result<Option<PairMeta>, HolochainError>),
 
     /// HashTable::all_metas_for_pair()
@@ -55,7 +56,7 @@ pub enum Protocol {
     GetMetasForPairResult(Result<Vec<PairMeta>, HolochainError>),
 
     /// HashTable::pair()
-    GetPair(String),
+    GetPair(HashString),
     GetPairResult(Result<Option<Pair>, HolochainError>),
 
     /// HashTable::put_pair()

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,11 +1,11 @@
 use agent::keys::Keys;
 use error::HolochainError;
 use futures::executor::block_on;
+use hash::HashString;
 use hash_table::{pair::Pair, pair_meta::PairMeta};
 use riker::actors::*;
 use riker_default::DefaultModel;
 use riker_patterns::ask::ask;
-use hash::HashString;
 
 #[derive(Clone, Debug)]
 /// riker protocol for all our actors

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -1,6 +1,6 @@
 use chain::{Chain, SourceChain};
-use hash_table::entry::Entry;
 use hash::HashString;
+use hash_table::entry::Entry;
 use key::Key;
 use multihash::Hash;
 
@@ -122,9 +122,9 @@ impl Key for Header {
 #[cfg(test)]
 mod tests {
     use chain::{header::Header, tests::test_chain, SourceChain};
+    use hash::HashString;
     use hash_table::{entry::Entry, pair::tests::test_pair};
     use key::Key;
-    use hash::HashString;
 
     /// returns a dummy header for use in tests
     pub fn test_header() -> Header {
@@ -299,8 +299,10 @@ mod tests {
         let e = Entry::new(t, "");
         let h = Header::new(&chain, &e);
 
-        assert_eq!(HashString::from("QmSpmouzp7PoTFeEcrG1GWVGVneacJcuwU91wkDCGYvPZ9".to_string()),
-                   h.hash());
+        assert_eq!(
+            HashString::from("QmSpmouzp7PoTFeEcrG1GWVGVneacJcuwU91wkDCGYvPZ9".to_string()),
+            h.hash()
+        );
     }
 
     #[test]

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -1,6 +1,6 @@
 use chain::{Chain, SourceChain};
-use hash;
-use hash_table::{entry::Entry, HashString};
+use hash_table::entry::Entry;
+use hash::HashString;
 use key::Key;
 use multihash::Hash;
 
@@ -50,7 +50,7 @@ impl Header {
             // https://github.com/holochain/holochain-rust/issues/70
             timestamp: String::new(),
             link: chain.top_pair().as_ref().map(|p| p.header().hash()),
-            entry_hash: entry.hash().to_string(),
+            entry_hash: entry.hash(),
             link_same_type: chain
                 .top_pair_type(&entry.entry_type())
                 // @TODO inappropriate expect()?
@@ -71,15 +71,15 @@ impl Header {
         &self.timestamp
     }
     /// link getter
-    pub fn link(&self) -> Option<String> {
+    pub fn link(&self) -> Option<HashString> {
         self.link.clone()
     }
     /// entry_hash getter
-    pub fn entry_hash(&self) -> &str {
+    pub fn entry_hash(&self) -> &HashString {
         &self.entry_hash
     }
     /// link_same_type getter
-    pub fn link_same_type(&self) -> Option<String> {
+    pub fn link_same_type(&self) -> Option<HashString> {
         self.link_same_type.clone()
     }
     /// entry_signature getter
@@ -88,22 +88,22 @@ impl Header {
     }
 
     /// hashes the header
-    pub fn hash(&self) -> String {
+    pub fn hash(&self) -> HashString {
         // @TODO this is the wrong string being hashed
         // @see https://github.com/holochain/holochain-rust/issues/103
         let pieces: [&str; 6] = [
             &self.entry_type,
             &self.timestamp,
-            &self.link.clone().unwrap_or_default(),
-            &self.entry_hash,
-            &self.link_same_type.clone().unwrap_or_default(),
+            &self.link.clone().unwrap_or_default().to_str(),
+            &self.entry_hash.clone().to_str(),
+            &self.link_same_type.clone().unwrap_or_default().to_str(),
             &self.entry_signature,
         ];
         let string_to_hash = pieces.concat();
 
         // @TODO the hashing algo should not be hardcoded
         // @see https://github.com/holochain/holochain-rust/issues/104
-        hash::str_to_b58_hash(&string_to_hash, Hash::SHA2256)
+        HashString::encode_from_str(&string_to_hash, Hash::SHA2256)
     }
 
     /// returns true if the header is valid
@@ -114,7 +114,7 @@ impl Header {
 }
 
 impl Key for Header {
-    fn key(&self) -> String {
+    fn key(&self) -> HashString {
         self.hash()
     }
 }
@@ -124,6 +124,7 @@ mod tests {
     use chain::{header::Header, tests::test_chain, SourceChain};
     use hash_table::{entry::Entry, pair::tests::test_pair};
     use key::Key;
+    use hash::HashString;
 
     /// returns a dummy header for use in tests
     pub fn test_header() -> Header {
@@ -175,9 +176,9 @@ mod tests {
         let e = Entry::new(t, "foo");
         let h = Header::new(&chain, &e);
 
-        assert_eq!(h.entry_hash(), e.hash());
+        assert_eq!(h.entry_hash(), &e.hash());
         assert_eq!(h.link(), None);
-        assert_ne!(h.hash(), "");
+        assert_ne!(h.hash(), HashString::new());
         assert!(h.validate());
     }
 
@@ -238,7 +239,7 @@ mod tests {
         let e = Entry::new(t, "");
         let h = Header::new(&chain, &e);
 
-        assert_eq!(h.entry_hash(), e.hash());
+        assert_eq!(h.entry_hash(), &e.hash());
     }
 
     #[test]
@@ -298,7 +299,8 @@ mod tests {
         let e = Entry::new(t, "");
         let h = Header::new(&chain, &e);
 
-        assert_eq!("QmSpmouzp7PoTFeEcrG1GWVGVneacJcuwU91wkDCGYvPZ9", h.hash());
+        assert_eq!(HashString::from("QmSpmouzp7PoTFeEcrG1GWVGVneacJcuwU91wkDCGYvPZ9".to_string()),
+                   h.hash());
     }
 
     #[test]

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -4,12 +4,12 @@ pub mod header;
 use actor::{AskSelf, Protocol};
 use chain::actor::{AskChain, ChainActor};
 use error::HolochainError;
+use hash::HashString;
 use hash_table::{entry::Entry, pair::Pair, HashTable};
 use json::ToJson;
 use key::Key;
 use riker::actors::*;
 use serde_json;
-use hash::HashString;
 
 /// Iterator type for pairs in a chain
 /// next method may panic if there is an error in the underlying table
@@ -222,6 +222,7 @@ pub mod tests {
 
     use super::Chain;
     use chain::SourceChain;
+    use hash::HashString;
     use hash_table::{
         actor::tests::test_table_actor,
         entry::tests::{test_entry, test_entry_a, test_entry_b, test_type_a, test_type_b},
@@ -231,7 +232,6 @@ pub mod tests {
     use json::ToJson;
     use key::Key;
     use std::thread;
-    use hash::HashString;
 
     /// builds a dummy chain for testing
     pub fn test_chain() -> Chain {

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -4,20 +4,16 @@ use serde::Serialize;
 use serde_json;
 use std::fmt;
 
-// Newtype HashString
-// pub type HashString = String;
-// #[derive(Clone, PartialEq, Eq)]
+// HashString newtype for String
 #[derive(PartialOrd, Eq, Ord, Clone, Debug, Serialize, Deserialize, Default, Hash)]
 pub struct HashString(String);
 impl PartialEq for HashString {
     #[inline]
     fn eq(&self, other: &HashString) -> bool {
-        // PartialEq::eq(&self[..], &other[..])
         self.0 == other.0
     }
     #[inline]
     fn ne(&self, other: &HashString) -> bool {
-        // PartialEq::ne(&self[..], &other[..])
         self.0 != other.0
     }
 }

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -28,10 +28,15 @@ impl fmt::Display for HashString {
 }
 
 impl HashString {
-    pub fn new() -> HashString { HashString("".to_string()) }
-    pub fn to_str(self) -> String { self.0 }
-    pub fn from(s: String) -> HashString { HashString(s) }
-
+    pub fn new() -> HashString {
+        HashString("".to_string())
+    }
+    pub fn to_str(self) -> String {
+        self.0
+    }
+    pub fn from(s: String) -> HashString {
+        HashString(s)
+    }
 
     /// convert bytes to a b58 hashed string
     pub fn encode_from_bytes(bytes: &[u8], hash_type: Hash) -> HashString {

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -1,22 +1,52 @@
-// use multihash::Multihash;
 use multihash::{encode, Hash};
 use rust_base58::ToBase58;
 use serde::Serialize;
 use serde_json;
+use std::fmt;
 
-/// convert bytes to a b58 hashed string
-pub fn bytes_to_b58_hash(bytes: &[u8], hash_type: Hash) -> String {
-    encode(hash_type, bytes).unwrap().to_base58()
+// Newtype HashString
+// pub type HashString = String;
+// #[derive(Clone, PartialEq, Eq)]
+#[derive(PartialOrd, Eq, Ord, Clone, Debug, Serialize, Deserialize, Default, Hash)]
+pub struct HashString(String);
+impl PartialEq for HashString {
+    #[inline]
+    fn eq(&self, other: &HashString) -> bool {
+        // PartialEq::eq(&self[..], &other[..])
+        self.0 == other.0
+    }
+    #[inline]
+    fn ne(&self, other: &HashString) -> bool {
+        // PartialEq::ne(&self[..], &other[..])
+        self.0 != other.0
+    }
+}
+impl fmt::Display for HashString {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
-/// convert a string as bytes to a b58 hashed string
-pub fn str_to_b58_hash(s: &str, hash_type: Hash) -> String {
-    bytes_to_b58_hash(s.as_bytes(), hash_type)
-}
+impl HashString {
+    pub fn new() -> HashString { HashString("".to_string()) }
+    pub fn to_str(self) -> String { self.0 }
+    pub fn from(s: String) -> HashString { HashString(s) }
 
-/// magic all in one fn, take a serializable something + hash type and get a hashed b58 string back
-pub fn serializable_to_b58_hash<S: Serialize>(s: S, hash_type: Hash) -> String {
-    str_to_b58_hash(&serde_json::to_string(&s).unwrap(), hash_type)
+
+    /// convert bytes to a b58 hashed string
+    pub fn encode_from_bytes(bytes: &[u8], hash_type: Hash) -> HashString {
+        HashString::from(encode(hash_type, bytes).unwrap().to_base58())
+    }
+
+    /// convert a string as bytes to a b58 hashed string
+    pub fn encode_from_str(s: &str, hash_type: Hash) -> HashString {
+        HashString::encode_from_bytes(s.as_bytes(), hash_type)
+    }
+
+    /// magic all in one fn, take a serializable something + hash type and get a hashed b58 string back
+    pub fn encode_from_serializable<S: Serialize>(s: S, hash_type: Hash) -> HashString {
+        HashString::encode_from_str(&serde_json::to_string(&s).unwrap(), hash_type)
+    }
 }
 
 #[cfg(test)]
@@ -27,7 +57,7 @@ pub mod tests {
     use multihash::Hash;
 
     /// dummy hash based on the key of test_entry()
-    pub fn test_hash() -> String {
+    pub fn test_hash() -> HashString {
         test_entry().key()
     }
 
@@ -35,7 +65,7 @@ pub mod tests {
     /// mimics tests from legacy golang holochain core hashing bytes
     fn bytes_to_b58_known_golang() {
         assert_eq!(
-            bytes_to_b58_hash(b"test data", Hash::SHA2256),
+            HashString::encode_from_bytes(b"test data", Hash::SHA2256).to_str(),
             "QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqh2"
         )
     }
@@ -44,7 +74,7 @@ pub mod tests {
     /// mimics tests from legacy golang holochain core hashing strings
     fn str_to_b58_hash_known_golang() {
         assert_eq!(
-            str_to_b58_hash("test data", Hash::SHA2256),
+            HashString::encode_from_str("test data", Hash::SHA2256).to_str(),
             "QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqh2"
         );
     }
@@ -59,7 +89,7 @@ pub mod tests {
 
         assert_eq!(
             "Qme7Bu4NVYMtpsRtb7e4yyhcbE1zdB9PsrKTdosaqF3Bu3",
-            serializable_to_b58_hash(Foo { foo: 5 }, Hash::SHA2256),
+            HashString::encode_from_serializable(Foo { foo: 5 }, Hash::SHA2256).to_str(),
         );
     }
 }

--- a/core/src/hash_table/actor.rs
+++ b/core/src/hash_table/actor.rs
@@ -4,6 +4,7 @@ use error::HolochainError;
 use hash_table::{pair::Pair, pair_meta::PairMeta, HashTable};
 use riker::actors::*;
 use snowflake;
+use hash::HashString;
 
 // anything that can be asked of HashTable and block on responses
 // needed to support implementing ask on upstream ActorRef from riker
@@ -27,8 +28,8 @@ impl HashTable for ActorRef<Protocol> {
         unwrap_to!(response => Protocol::PutPairResult).clone()
     }
 
-    fn pair(&self, key: &str) -> Result<Option<Pair>, HolochainError> {
-        let response = self.block_on_ask(Protocol::GetPair(key.to_string()));
+    fn pair(&self, key: &HashString) -> Result<Option<Pair>, HolochainError> {
+        let response = self.block_on_ask(Protocol::GetPair(key.clone()));
         unwrap_to!(response => Protocol::GetPairResult).clone()
     }
 
@@ -59,8 +60,8 @@ impl HashTable for ActorRef<Protocol> {
         unwrap_to!(response => Protocol::AssertMetaResult).clone()
     }
 
-    fn pair_meta(&mut self, key: &str) -> Result<Option<PairMeta>, HolochainError> {
-        let response = self.block_on_ask(Protocol::GetPairMeta(key.to_string()));
+    fn pair_meta(&mut self, key: &HashString) -> Result<Option<PairMeta>, HolochainError> {
+        let response = self.block_on_ask(Protocol::GetPairMeta(key.clone()));
         unwrap_to!(response => Protocol::GetPairMetaResult).clone()
     }
 

--- a/core/src/hash_table/actor.rs
+++ b/core/src/hash_table/actor.rs
@@ -1,10 +1,10 @@
 use actor::{AskSelf, Protocol, SYS};
 use agent::keys::Keys;
 use error::HolochainError;
+use hash::HashString;
 use hash_table::{pair::Pair, pair_meta::PairMeta, HashTable};
 use riker::actors::*;
 use snowflake;
-use hash::HashString;
 
 // anything that can be asked of HashTable and block on responses
 // needed to support implementing ask on upstream ActorRef from riker

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -1,5 +1,4 @@
 use error::HolochainError;
-use hash;
 use hash_table::sys_entry::EntryType;
 use json::{FromJson, ToJson};
 use key::Key;
@@ -9,6 +8,7 @@ use std::{
     hash::{Hash as StdHash, Hasher},
     str::FromStr,
 };
+use hash::HashString;
 
 /// Structure holding actual data in a source chain "Item"
 /// data is stored as a JSON string
@@ -54,14 +54,14 @@ impl Entry {
     }
 
     /// hashes the entry
-    pub fn hash(&self) -> String {
+    pub fn hash(&self) -> HashString {
         // @TODO - this is the wrong string being hashed
         // @see https://github.com/holochain/holochain-rust/issues/103
         let string_to_hash = &self.content;
 
         // @TODO the hashing algo should not be hardcoded
         // @see https://github.com/holochain/holochain-rust/issues/104
-        hash::str_to_b58_hash(string_to_hash, Hash::SHA2256)
+        HashString::encode_from_str(string_to_hash, Hash::SHA2256)
     }
 
     /// content getter
@@ -92,7 +92,7 @@ impl Entry {
 }
 
 impl Key for Entry {
-    fn key(&self) -> String {
+    fn key(&self) -> HashString {
         self.hash()
     }
 }
@@ -119,6 +119,7 @@ pub mod tests {
     use json::{FromJson, ToJson};
     use key::Key;
     use snowflake;
+    use hash::HashString;
 
     /// dummy entry type
     pub fn test_type() -> String {
@@ -156,8 +157,8 @@ pub mod tests {
     }
 
     /// the correct hash for test_entry()
-    pub fn test_entry_hash() -> String {
-        "QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT".into()
+    pub fn test_entry_hash() -> HashString {
+        HashString::from("QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT".to_string())
     }
 
     /// dummy entry, same as test_entry()
@@ -227,7 +228,7 @@ pub mod tests {
         let e = Entry::new(t, c);
 
         assert_eq!(e.content(), c);
-        assert_ne!(e.hash(), "");
+        assert_ne!(e.hash(), HashString::new());
         assert!(e.validate());
     }
 

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -1,4 +1,5 @@
 use error::HolochainError;
+use hash::HashString;
 use hash_table::sys_entry::EntryType;
 use json::{FromJson, ToJson};
 use key::Key;
@@ -8,7 +9,6 @@ use std::{
     hash::{Hash as StdHash, Hasher},
     str::FromStr,
 };
-use hash::HashString;
 
 /// Structure holding actual data in a source chain "Item"
 /// data is stored as a JSON string
@@ -115,11 +115,11 @@ impl FromJson for Entry {
 
 #[cfg(test)]
 pub mod tests {
+    use hash::HashString;
     use hash_table::{entry::Entry, sys_entry::EntryType};
     use json::{FromJson, ToJson};
     use key::Key;
     use snowflake;
-    use hash::HashString;
 
     /// dummy entry type
     pub fn test_type() -> String {

--- a/core/src/hash_table/file/mod.rs
+++ b/core/src/hash_table/file/mod.rs
@@ -4,12 +4,12 @@ use std::{
     path::{Path, MAIN_SEPARATOR},
 };
 
+use hash::HashString;
 use hash_table::{pair::Pair, pair_meta::PairMeta, HashTable};
 use json::{FromJson, ToJson};
 use key::Key;
 use std::fs::create_dir_all;
 use walkdir::WalkDir;
-use hash::HashString;
 
 // folders actually... wish-it-was-tables
 #[derive(Debug, Clone)]
@@ -146,6 +146,7 @@ impl HashTable for FileTable {
 pub mod tests {
     use super::Table;
     use error::HolochainError;
+    use hash::HashString;
     use hash_table::{
         file::{FileTable, Row},
         test_util::standard_suite,
@@ -156,7 +157,6 @@ pub mod tests {
     use serde_json;
     use std::path::MAIN_SEPARATOR;
     use tempfile::{tempdir, TempDir};
-    use hash::HashString;
 
     /// returns a new FileTable for testing and the TempDir created for it
     /// the fs directory associated with TempDir will be deleted when the TempDir goes out of scope

--- a/core/src/hash_table/file/mod.rs
+++ b/core/src/hash_table/file/mod.rs
@@ -9,6 +9,7 @@ use json::{FromJson, ToJson};
 use key::Key;
 use std::fs::create_dir_all;
 use walkdir::WalkDir;
+use hash::HashString;
 
 // folders actually... wish-it-was-tables
 #[derive(Debug, Clone)]
@@ -69,7 +70,7 @@ impl FileTable {
         Ok(dir_string)
     }
 
-    fn row_path(&self, table: Table, key: &str) -> Result<String, HolochainError> {
+    fn row_path(&self, table: Table, key: &HashString) -> Result<String, HolochainError> {
         let dir = self.dir(table)?;
         Ok(format!("{}{}{}.json", dir, MAIN_SEPARATOR, key))
     }
@@ -82,7 +83,7 @@ impl FileTable {
     }
 
     /// Returns a JSON string option for the given key in the given table
-    fn lookup(&self, table: Table, key: &str) -> Result<Option<String>, HolochainError> {
+    fn lookup(&self, table: Table, key: &HashString) -> Result<Option<String>, HolochainError> {
         let path_string = self.row_path(table, key)?;
         if Path::new(&path_string).is_file() {
             Ok(Some(fs::read_to_string(path_string)?))
@@ -97,7 +98,7 @@ impl HashTable for FileTable {
         self.upsert(Table::Pairs, pair)
     }
 
-    fn pair(&self, key: &str) -> Result<Option<Pair>, HolochainError> {
+    fn pair(&self, key: &HashString) -> Result<Option<Pair>, HolochainError> {
         match self.lookup(Table::Pairs, key)? {
             Some(json) => Ok(Some(Pair::from_json(&json)?)),
             None => Ok(None),
@@ -108,7 +109,7 @@ impl HashTable for FileTable {
         self.upsert(Table::Metas, meta)
     }
 
-    fn pair_meta(&mut self, key: &str) -> Result<Option<PairMeta>, HolochainError> {
+    fn pair_meta(&mut self, key: &HashString) -> Result<Option<PairMeta>, HolochainError> {
         match self.lookup(Table::Metas, key)? {
             Some(json) => Ok(Some(PairMeta::from_json(&json)?)),
             None => Ok(None),
@@ -125,7 +126,7 @@ impl HashTable for FileTable {
             let path = meta.path();
             if let Some(stem) = path.file_stem() {
                 if let Some(key) = stem.to_str() {
-                    if let Some(pair_meta) = self.pair_meta(&key)? {
+                    if let Some(pair_meta) = self.pair_meta(&HashString::from(key.to_string()))? {
                         if pair_meta.pair_hash() == pair.key() {
                             metas.push(pair_meta);
                         }
@@ -155,6 +156,7 @@ pub mod tests {
     use serde_json;
     use std::path::MAIN_SEPARATOR;
     use tempfile::{tempdir, TempDir};
+    use hash::HashString;
 
     /// returns a new FileTable for testing and the TempDir created for it
     /// the fs directory associated with TempDir will be deleted when the TempDir goes out of scope
@@ -232,7 +234,7 @@ pub mod tests {
                 assert!(
                     re(s, k).is_match(
                         &table
-                            .row_path(t.clone(), k.clone())
+                            .row_path(t.clone(), &HashString::from(k.to_string()))
                             .expect(&format!("could not get row path for {:?} in {:?}", k, t)),
                     )
                 );
@@ -255,8 +257,8 @@ pub mod tests {
         }
 
         impl Key for SomeData {
-            fn key(&self) -> String {
-                "bar".to_string()
+            fn key(&self) -> HashString {
+                HashString::from("bar".to_string())
             }
         }
 

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -3,12 +3,13 @@ use std::collections::HashMap;
 use error::HolochainError;
 use hash_table::{pair::Pair, pair_meta::PairMeta, HashTable};
 use key::Key;
+use hash::HashString;
 
 /// Struct implementing the HashTable Trait by storing the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 pub struct MemTable {
-    pairs: HashMap<String, Pair>,
-    meta: HashMap<String, PairMeta>,
+    pairs: HashMap<HashString, Pair>,
+    meta: HashMap<HashString, PairMeta>,
 }
 
 impl MemTable {
@@ -26,7 +27,7 @@ impl HashTable for MemTable {
         Ok(())
     }
 
-    fn pair(&self, key: &str) -> Result<Option<Pair>, HolochainError> {
+    fn pair(&self, key: &HashString) -> Result<Option<Pair>, HolochainError> {
         Ok(self.pairs.get(key).cloned())
     }
 
@@ -35,7 +36,7 @@ impl HashTable for MemTable {
         Ok(())
     }
 
-    fn pair_meta(&mut self, key: &str) -> Result<Option<PairMeta>, HolochainError> {
+    fn pair_meta(&mut self, key: &HashString) -> Result<Option<PairMeta>, HolochainError> {
         Ok(self.meta.get(key).cloned())
     }
 

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use error::HolochainError;
+use hash::HashString;
 use hash_table::{pair::Pair, pair_meta::PairMeta, HashTable};
 use key::Key;
-use hash::HashString;
 
 /// Struct implementing the HashTable Trait by storing the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -11,13 +11,13 @@ pub mod test_util;
 
 use agent::keys::Keys;
 use error::HolochainError;
+use hash::HashString;
 use hash_table::{
     pair::Pair,
     pair_meta::PairMeta,
     status::{CrudStatus, LINK_NAME, STATUS_NAME},
 };
 use key::Key;
-use hash::HashString;
 
 /// Trait of the data structure storing the source chain
 /// source chain is stored as a hash table of Pairs.
@@ -60,7 +60,12 @@ pub trait HashTable: Send + Sync + Clone + 'static {
 
         // @TODO what if meta fails when commit succeeds?
         // @see https://github.com/holochain/holochain-rust/issues/142
-        self.assert_pair_meta(&PairMeta::new(keys, &old_pair, LINK_NAME, &new_pair.key().to_str()))
+        self.assert_pair_meta(&PairMeta::new(
+            keys,
+            &old_pair,
+            LINK_NAME,
+            &new_pair.key().to_str(),
+        ))
     }
 
     /// set the status of a Pair to DELETED
@@ -100,6 +105,5 @@ pub mod tests {
     fn test_hash() {
         let stringy: String = "toto".to_string();
         print_hashstring(HashString::from(stringy));
-
     }
 }

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -17,8 +17,7 @@ use hash_table::{
     status::{CrudStatus, LINK_NAME, STATUS_NAME},
 };
 use key::Key;
-
-pub type HashString = String;
+use hash::HashString;
 
 /// Trait of the data structure storing the source chain
 /// source chain is stored as a hash table of Pairs.
@@ -39,7 +38,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
     fn put_pair(&mut self, pair: &Pair) -> Result<(), HolochainError>;
 
     /// lookup a Pair from the HashTable by Pair/Header key
-    fn pair(&self, key: &str) -> Result<Option<Pair>, HolochainError>;
+    fn pair(&self, key: &HashString) -> Result<Option<Pair>, HolochainError>;
 
     /// add a new Pair to the HashTable as per commit and status link an old Pair as MODIFIED
     fn modify_pair(
@@ -61,7 +60,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
 
         // @TODO what if meta fails when commit succeeds?
         // @see https://github.com/holochain/holochain-rust/issues/142
-        self.assert_pair_meta(&PairMeta::new(keys, &old_pair, LINK_NAME, &new_pair.key()))
+        self.assert_pair_meta(&PairMeta::new(keys, &old_pair, LINK_NAME, &new_pair.key().to_str()))
     }
 
     /// set the status of a Pair to DELETED
@@ -79,7 +78,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
     fn assert_pair_meta(&mut self, meta: &PairMeta) -> Result<(), HolochainError>;
 
     /// lookup a PairMeta from the HashTable by PairMeta key
-    fn pair_meta(&mut self, key: &str) -> Result<Option<PairMeta>, HolochainError>;
+    fn pair_meta(&mut self, key: &HashString) -> Result<Option<PairMeta>, HolochainError>;
     /// lookup all PairMeta for a given Pair
     fn metas_for_pair(&mut self, pair: &Pair) -> Result<Vec<PairMeta>, HolochainError>;
 
@@ -87,4 +86,20 @@ pub trait HashTable: Send + Sync + Clone + 'static {
     // @TODO how should we handle queries?
     // @see https://github.com/holochain/holochain-rust/issues/141
     // fn query (&self, query: &Query) -> Result<std::collections::HashSet, HolochainError>;
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    fn print_hashstring(input: HashString) {
+        println!("0x{}", input);
+    }
+
+    #[test]
+    fn test_hash() {
+        let stringy: String = "toto".to_string();
+        print_hashstring(HashString::from(stringy));
+
+    }
 }

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -92,18 +92,3 @@ pub trait HashTable: Send + Sync + Clone + 'static {
     // @see https://github.com/holochain/holochain-rust/issues/141
     // fn query (&self, query: &Query) -> Result<std::collections::HashSet, HolochainError>;
 }
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    fn print_hashstring(input: HashString) {
-        println!("0x{}", input);
-    }
-
-    #[test]
-    fn test_hash() {
-        let stringy: String = "toto".to_string();
-        print_hashstring(HashString::from(stringy));
-    }
-}

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -4,6 +4,7 @@ use hash_table::entry::Entry;
 use json::{FromJson, RoundTripJson, ToJson};
 use key::Key;
 use serde_json;
+use hash::HashString;
 
 /// Struct for holding a source chain "Item"
 /// It is like a pair holding the entry and header separately
@@ -63,14 +64,14 @@ impl Pair {
         // the header and entry must validate independently
         self.header.validate() && self.entry.validate()
         // the header entry hash must be the same as the entry hash
-        && self.header.entry_hash() == self.entry.hash()
+        && self.header.entry_hash() == &self.entry.hash()
         // the entry_type must line up across header and entry
         && self.header.entry_type() == self.entry.entry_type()
     }
 }
 
 impl Key for Pair {
-    fn key(&self) -> String {
+    fn key(&self) -> HashString {
         self.header.hash()
     }
 }
@@ -140,7 +141,7 @@ pub mod tests {
         let e1 = Entry::new(t, "some content");
         let h1 = Header::new(&chain, &e1);
 
-        assert_eq!(h1.entry_hash(), e1.hash());
+        assert_eq!(h1.entry_hash(), &e1.hash());
         assert_eq!(h1.link(), None);
 
         let p1 = Pair::new(&chain, &e1.clone());

--- a/core/src/hash_table/pair.rs
+++ b/core/src/hash_table/pair.rs
@@ -1,10 +1,10 @@
 use chain::{header::Header, Chain};
 use error::HolochainError;
+use hash::HashString;
 use hash_table::entry::Entry;
 use json::{FromJson, RoundTripJson, ToJson};
 use key::Key;
 use serde_json;
-use hash::HashString;
 
 /// Struct for holding a source chain "Item"
 /// It is like a pair holding the entry and header separately

--- a/core/src/hash_table/pair_meta.rs
+++ b/core/src/hash_table/pair_meta.rs
@@ -1,12 +1,12 @@
 use agent::keys::Keys;
 use error::HolochainError;
-use hash::serializable_to_b58_hash;
 use hash_table::pair::Pair;
 use json::{FromJson, RoundTripJson, ToJson};
 use key::Key;
 use multihash::Hash;
 use serde_json;
 use std::cmp::Ordering;
+use hash::HashString;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// PairMeta represents an extended form of EAV (entity-attribute-value) data
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 /// source = the agent making the meta assertion
 /// signature = the asserting agent's signature of the meta assertion
 pub struct PairMeta {
-    pair_hash: String,
+    pair_hash: HashString,
     attribute: String,
     value: String,
     // @TODO implement local transaction ordering
@@ -66,7 +66,7 @@ impl PairMeta {
     }
 
     /// getter for pair clone
-    pub fn pair_hash(&self) -> String {
+    pub fn pair_hash(&self) -> HashString {
         self.pair_hash.clone()
     }
 
@@ -87,8 +87,8 @@ impl PairMeta {
 }
 
 impl Key for PairMeta {
-    fn key(&self) -> String {
-        serializable_to_b58_hash(&self, Hash::SHA2256)
+    fn key(&self) -> HashString {
+        HashString::encode_from_serializable(&self, Hash::SHA2256)
     }
 }
 

--- a/core/src/hash_table/pair_meta.rs
+++ b/core/src/hash_table/pair_meta.rs
@@ -1,12 +1,12 @@
 use agent::keys::Keys;
 use error::HolochainError;
+use hash::HashString;
 use hash_table::pair::Pair;
 use json::{FromJson, RoundTripJson, ToJson};
 use key::Key;
 use multihash::Hash;
 use serde_json;
 use std::cmp::Ordering;
-use hash::HashString;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// PairMeta represents an extended form of EAV (entity-attribute-value) data

--- a/core/src/hash_table/test_util.rs
+++ b/core/src/hash_table/test_util.rs
@@ -36,7 +36,7 @@ pub fn test_modify_pair<HT: HashTable>(table: &mut HT) {
 
     assert_eq!(
         vec![
-            PairMeta::new(&test_keys(), &pair_1, LINK_NAME, &pair_2.key()),
+            PairMeta::new(&test_keys(), &pair_1, LINK_NAME, &pair_2.key().to_str()),
             PairMeta::new(
                 &test_keys(),
                 &pair_1,

--- a/core/src/key.rs
+++ b/core/src/key.rs
@@ -1,4 +1,6 @@
+use hash::HashString;
+
 pub trait Key {
     /// returns the key for self that can be used in key/value contexts
-    fn key(&self) -> String;
+    fn key(&self) -> HashString;
 }

--- a/core/src/nucleus/ribosome/api/get.rs
+++ b/core/src/nucleus/ribosome/api/get.rs
@@ -1,11 +1,11 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
+use hash::HashString;
 use json::ToJson;
 use nucleus::ribosome::api::{HcApiReturnCode, Runtime};
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
-use hash::HashString;
 
 #[derive(Deserialize, Default, Debug, Serialize)]
 struct GetArgs {

--- a/core/src/nucleus/ribosome/api/get.rs
+++ b/core/src/nucleus/ribosome/api/get.rs
@@ -5,10 +5,11 @@ use nucleus::ribosome::api::{HcApiReturnCode, Runtime};
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
+use hash::HashString;
 
 #[derive(Deserialize, Default, Debug, Serialize)]
 struct GetArgs {
-    key: String,
+    key: HashString,
 }
 
 pub fn invoke_get_entry(
@@ -211,7 +212,7 @@ mod tests {
 
         let mut expected = "".to_owned();
         expected.push_str("{\"header\":{\"entry_type\":\"testEntryType\",\"timestamp\":\"\",\"link\":\"QmT1NRaxbwMqpxXU1Adt1pVqtgnDXYxH1qH5rRbWPGxrkW\",\"entry_hash\":\"");
-        expected.push_str(&test_entry_hash());
+        expected.push_str(&test_entry_hash().to_str());
         expected.push_str("\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":{\"content\":\"test entry content\",\"entry_type\":\"testEntryType\"}}\u{0}");
 
         assert_eq!(get_runtime.result, expected,);


### PR DESCRIPTION
Rust's `type` does not enforce types statically so I changed `HashString` into a newtype.
And since HashString is a real type of its own, I changed the functions in `hash\mod.rs`  to methods of HashString.