### PR TITLE
use native to_string() instead of to_str() for HashString

### DIFF
--- a/core/src/cas/memory/mod.rs
+++ b/core/src/cas/memory/mod.rs
@@ -10,7 +10,7 @@ pub struct MemoryStorage {
 }
 
 impl MemoryStorage {
-    fn new() -> MemoryStorage {
+    pub fn new() -> MemoryStorage {
         MemoryStorage {
             storage: HashMap::new(),
         }
@@ -45,7 +45,6 @@ pub mod tests {
         memory::MemoryStorage,
         storage::ContentAddressableStorage,
     };
-    use tempfile::{tempdir, TempDir};
 
     #[test]
     fn memory_round_trip() {

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -103,9 +103,9 @@ impl Header {
         let pieces: [&str; 6] = [
             &self.entry_type,
             &self.timestamp,
-            &self.link.clone().unwrap_or_default().to_str(),
-            &self.entry_hash.clone().to_str(),
-            &self.link_same_type.clone().unwrap_or_default().to_str(),
+            &self.link.clone().unwrap_or_default().to_string(),
+            &self.entry_hash.clone().to_string(),
+            &self.link_same_type.clone().unwrap_or_default().to_string(),
             &self.entry_signature,
         ];
         let string_to_hash = pieces.concat();

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -18,9 +18,7 @@ impl HashString {
     pub fn new() -> HashString {
         HashString("".to_string())
     }
-    pub fn to_str(self) -> String {
-        self.0
-    }
+
     pub fn from(s: String) -> HashString {
         HashString(s)
     }
@@ -54,10 +52,20 @@ pub mod tests {
     }
 
     #[test]
+    /// show ToString implementation
+    /// automatically derived by Rust because fmt::Display is implemented
+    fn to_string_test() {
+        assert_eq!(
+            test_hash().to_string(),
+            "QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT",
+        )
+    }
+
+    #[test]
     /// mimics tests from legacy golang holochain core hashing bytes
     fn bytes_to_b58_known_golang() {
         assert_eq!(
-            HashString::encode_from_bytes(b"test data", Hash::SHA2256).to_str(),
+            HashString::encode_from_bytes(b"test data", Hash::SHA2256).to_string(),
             "QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqh2"
         )
     }
@@ -66,7 +74,7 @@ pub mod tests {
     /// mimics tests from legacy golang holochain core hashing strings
     fn str_to_b58_hash_known_golang() {
         assert_eq!(
-            HashString::encode_from_str("test data", Hash::SHA2256).to_str(),
+            HashString::encode_from_str("test data", Hash::SHA2256).to_string(),
             "QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqh2"
         );
     }
@@ -81,7 +89,7 @@ pub mod tests {
 
         assert_eq!(
             "Qme7Bu4NVYMtpsRtb7e4yyhcbE1zdB9PsrKTdosaqF3Bu3",
-            HashString::encode_from_serializable(Foo { foo: 5 }, Hash::SHA2256).to_str(),
+            HashString::encode_from_serializable(Foo { foo: 5 }, Hash::SHA2256).to_string(),
         );
     }
 }

--- a/core/src/hash_table/entry_meta.rs
+++ b/core/src/hash_table/entry_meta.rs
@@ -84,7 +84,7 @@ impl EntryMeta {
     }
 
     pub fn make_hash(entry_hash: &HashString, attribute_name: &str) -> HashString {
-        let pieces: [String; 2] = [entry_hash.clone().to_str(), attribute_name.to_string()];
+        let pieces: [String; 2] = [entry_hash.clone().to_string(), attribute_name.to_string()];
         let string_to_hash = pieces.concat();
 
         // @TODO the hashing algo should not be hardcoded

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -65,7 +65,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
             &keys.node_id(),
             &old.key(),
             LINK_NAME,
-            &new.key().to_str(),
+            &new.key().to_string(),
         ))
     }
 

--- a/core/src/hash_table/test_util.rs
+++ b/core/src/hash_table/test_util.rs
@@ -37,7 +37,7 @@ pub fn test_modify<HT: HashTable>(table: &mut HT) {
                 &test_keys().node_id(),
                 &entry_1.key(),
                 LINK_NAME,
-                &entry_2.key().to_str(),
+                &entry_2.key().to_string(),
             ),
             EntryMeta::new(
                 &test_keys().node_id(),


### PR DESCRIPTION
`to_string` natively exists for anything that implements `fmt::Display` so we can use that for `HashString`

`to_string` implements the `ToString` trait so offers compatibility with trait bounds

`to_str` is a confusing name because it returns `String` not `&str`

`to_str` is not part of any trait so it is more limited in usage