### PR TITLE
use native From<String> for HashString

### DIFF
--- a/core/src/cas/memory/mod.rs
+++ b/core/src/cas/memory/mod.rs
@@ -10,7 +10,7 @@ pub struct MemoryStorage {
 }
 
 impl MemoryStorage {
-    fn new() -> MemoryStorage {
+    pub fn new() -> MemoryStorage {
         MemoryStorage {
             storage: HashMap::new(),
         }
@@ -45,7 +45,6 @@ pub mod tests {
         memory::MemoryStorage,
         storage::ContentAddressableStorage,
     };
-    use tempfile::{tempdir, TempDir};
 
     #[test]
     fn memory_round_trip() {

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -57,6 +57,17 @@ pub mod tests {
     }
 
     #[test]
+    /// show From<String> implementation
+    fn from_string_test() {
+        assert_eq!(HashString::new(), HashString::from("".to_string()),);
+
+        assert_eq!(
+            test_hash(),
+            HashString::from(test_entry().key().to_string()),
+        );
+    }
+
+    #[test]
     /// mimics tests from legacy golang holochain core hashing bytes
     fn bytes_to_b58_known_golang() {
         assert_eq!(

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -14,15 +14,18 @@ impl fmt::Display for HashString {
     }
 }
 
+impl From<String> for HashString {
+    fn from(s: String) -> HashString {
+        HashString(s)
+    }
+}
+
 impl HashString {
     pub fn new() -> HashString {
         HashString("".to_string())
     }
     pub fn to_str(self) -> String {
         self.0
-    }
-    pub fn from(s: String) -> HashString {
-        HashString(s)
     }
 
     /// convert bytes to a b58 hashed string


### PR DESCRIPTION
moves `from` into the native rust trait `From<String>` and tests it for `HashString`