### PR TITLE
ADR 7 - Abstraction for network layer

### DIFF
--- a/doc/architecture/decisions/0007-abstraction-for-network-layer.md
+++ b/doc/architecture/decisions/0007-abstraction-for-network-layer.md
@@ -4,7 +4,7 @@ Date: 2018-05-16
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 


### PR DESCRIPTION
Old ADR that really is accepted since we are much further down the line of spec'ing and soon implementing this network abstraction.