### PR TITLE
ADR#11 - Clarification rewrite + approval

### DIFF
--- a/doc/architecture/decisions/0011-build-hcadmin-app-with-qt-c.md
+++ b/doc/architecture/decisions/0011-build-hcadmin-app-with-qt-c.md
@@ -4,31 +4,32 @@ Date: 2018-05-16
 
 ## Status
 
-proposed
+Accepted
 
 ## Context
 
-In the alpha version we had *hcd* that runs a single Holochain app/agent as a background demon.
+In the alpha version we had *hcd* that runs a single Holochain app as a background daemon.
 
-Going forward we need a more sophisticated container of several Holochain apps for several reasons:
-* UX - One end-user friendly tool with GUI to administer all installed and running Holochain apps
-* coalescing of the network layer / having one network manager, to handle ports etc.
-* Mid-term roadmap entails having a generalized Holochain UI / browser that would act as an app container as well
+Going forward we will need a more sophisticated administration app for several reasons:
+* UX - One end-user friendly tool with GUI to administer all installed and running genomes.
+* Coalescing of the network layer, i.e. having one network manager that handles ports for example.
+* In the mid-term critical path of having a generalized Holochain UI / browser (i.e. developments made for the new admin app would serve the Holochain browser app).
 
-Since with ADR 8 we want to go mobile first, we need to have an easy way to run Holochain apps on mobile phones.
+Since with ADR #8 we want to go mobile first, we need to have an easy way to run dApps and hApps on mobile phones.
 
-Qt sports QML for rapid UI development and compiles the same code natively to Windows/Linux/MacOS/Android/iOS/Blackberry.
+Qt is cross-plateform and sports QML for rapid UI development. It compiles the same code natively to Windows/Linux/MacOS/Android/iOS/Blackberry.
+
 For system and network capabilities, C++ would be at our disposal.
 
 ## Decision
 
-Use Qt framework for building a cross platform Holochain app container as a replacement for *hcadmin* for Holochain app management & deployment, and possiblly integrating *hcd* into it if we can manage the Rust integration.
+Use the Qt framework for building a cross-platform app that replaces *hcadmin* for genome management & deployment, and possibly integrating *hcd* into it if we can manage the Rust integration.
 
 ## Consequences
 
-* We could have a system tray app to manage/start/stop HC apps.
+* We could have a system tray user interface to manage/start/stop genomes.
 * We could have the exact same UI on all relevant platforms including mobile with only one code base.
-* -> a mobile app would be easy to build.
+* A mobile hApp would be easy to build.
 * Cross-platform C++ code needs to be maintained.
-* UI/UX needs to be considered regarding conforming to different platform standards vs. creating one HC design & feel.  
+* UI/UX needs to be considered regarding conforming to different platform standards vs. creating one Holochain design & feel.  
 * We need to figure out how to incorporate the rust based binary.


### PR DESCRIPTION
Use newly agreed vocabulary and clarifies distinction between admin app and browser app.
We don't have specs / PRD for any of those apps but basically admin app is for managing genomes whereas browser app is for managing hApps.
I think they should be separate apps because we would want genomes used in dApps to be manageable without having to run the dApps in question.