### PR TITLE
[REFACTOR] Channels: now sync and in context

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -3,7 +3,6 @@ use context::Context;
 use hash::HashString;
 use hash_table::{entry::Entry, links_entry::Link};
 use holochain_dna::Dna;
-use instance::Observer;
 use nucleus::{
     ribosome::api::get_links::GetLinksArgs,
     state::{NucleusState, ValidationResult},
@@ -12,7 +11,7 @@ use nucleus::{
 use snowflake;
 use std::{
     hash::{Hash, Hasher},
-    sync::{mpsc::Sender, Arc},
+    sync::Arc,
 };
 
 /// Wrapper for actions that provides a unique ID
@@ -108,7 +107,7 @@ pub enum Action {
 pub type AgentReduceFn = ReduceFn<AgentState>;
 pub type NucleusReduceFn = ReduceFn<NucleusState>;
 pub type ReduceFn<S> =
-    fn(Arc<Context>, &mut S, &ActionWrapper, &Sender<ActionWrapper>, &Sender<Observer>);
+    fn(Arc<Context>, &mut S, &ActionWrapper);
 
 #[cfg(test)]
 pub mod tests {

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -106,8 +106,7 @@ pub enum Action {
 // @see https://github.com/holochain/holochain-rust/issues/194
 pub type AgentReduceFn = ReduceFn<AgentState>;
 pub type NucleusReduceFn = ReduceFn<NucleusState>;
-pub type ReduceFn<S> =
-    fn(Arc<Context>, &mut S, &ActionWrapper);
+pub type ReduceFn<S> = fn(Arc<Context>, &mut S, &ActionWrapper);
 
 #[cfg(test)]
 pub mod tests {

--- a/core/src/agent/actions/commit.rs
+++ b/core/src/agent/actions/commit.rs
@@ -5,7 +5,7 @@ use context::Context;
 use futures::Future;
 use hash_table::entry::Entry;
 use instance::dispatch_action;
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::{mpsc::SyncSender, Arc};
 
 /// Commit Action Creator
 /// This is the high-level commit function that wraps the whole commit process and is what should
@@ -14,7 +14,7 @@ use std::sync::{mpsc::Sender, Arc};
 /// Returns a future that resolves to an ActionResponse.
 pub fn commit_entry(
     entry: Entry,
-    action_channel: &Sender<ActionWrapper>,
+    action_channel: &SyncSender<ActionWrapper>,
     context: &Arc<Context>,
 ) -> CommitFuture {
     let action_wrapper = ActionWrapper::new(Action::Commit(entry));

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -7,10 +7,7 @@ use hash::HashString;
 use hash_table::entry::Entry;
 use json::ToJson;
 use key::Key;
-use std::{
-    collections::HashMap,
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 /// The state-slice for the Agent.
 /// Holds the agent's source chain and keys.
@@ -155,11 +152,7 @@ pub fn reduce(
     match handler {
         Some(f) => {
             let mut new_state: AgentState = (*old_state).clone();
-            f(
-                context,
-                &mut new_state,
-                &action_wrapper,
-            );
+            f(context, &mut new_state, &action_wrapper);
             Arc::new(new_state)
         }
         None => old_state,
@@ -217,11 +210,7 @@ pub mod tests {
         let mut state = test_agent_state();
         let action_wrapper = test_action_wrapper_commit();
 
-        reduce_commit_entry(
-            test_context("bob"),
-            &mut state,
-            &action_wrapper,
-        );
+        reduce_commit_entry(test_context("bob"), &mut state, &action_wrapper);
 
         assert_eq!(
             state.actions().get(&action_wrapper),
@@ -236,11 +225,7 @@ pub mod tests {
         let context = test_context("foo");
 
         let aw1 = test_action_wrapper_get();
-        reduce_get_entry(
-            Arc::clone(&context),
-            &mut state,
-            &aw1,
-        );
+        reduce_get_entry(Arc::clone(&context), &mut state, &aw1);
 
         // nothing has been committed so the get must be None
         assert_eq!(
@@ -256,11 +241,7 @@ pub mod tests {
         );
 
         let aw2 = test_action_wrapper_get();
-        reduce_get_entry(
-            Arc::clone(&context),
-            &mut state,
-            &aw2,
-        );
+        reduce_get_entry(Arc::clone(&context), &mut state, &aw2);
 
         assert_eq!(state.actions().get(&aw2), Some(&test_action_response_get()),);
     }

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -5,12 +5,11 @@ use context::Context;
 use error::HolochainError;
 use hash::HashString;
 use hash_table::entry::Entry;
-use instance::Observer;
 use json::ToJson;
 use key::Key;
 use std::{
     collections::HashMap,
-    sync::{mpsc::Sender, Arc},
+    sync::Arc,
 };
 
 /// The state-slice for the Agent.
@@ -98,8 +97,6 @@ fn reduce_commit_entry(
     _context: Arc<Context>,
     state: &mut AgentState,
     action_wrapper: &ActionWrapper,
-    _action_channel: &Sender<ActionWrapper>,
-    _observer_channel: &Sender<Observer>,
 ) {
     let action = action_wrapper.action();
     let entry = unwrap_to!(action => Action::Commit);
@@ -124,8 +121,6 @@ fn reduce_get_entry(
     _context: Arc<Context>,
     state: &mut AgentState,
     action_wrapper: &ActionWrapper,
-    _action_channel: &Sender<ActionWrapper>,
-    _observer_channel: &Sender<Observer>,
 ) {
     let action = action_wrapper.action();
     let key = unwrap_to!(action => Action::GetEntry);
@@ -155,8 +150,6 @@ pub fn reduce(
     context: Arc<Context>,
     old_state: Arc<AgentState>,
     action_wrapper: &ActionWrapper,
-    action_channel: &Sender<ActionWrapper>,
-    observer_channel: &Sender<Observer>,
 ) -> Arc<AgentState> {
     let handler = resolve_reducer(action_wrapper);
     match handler {
@@ -166,8 +159,6 @@ pub fn reduce(
                 context,
                 &mut new_state,
                 &action_wrapper,
-                action_channel,
-                observer_channel,
             );
             Arc::new(new_state)
         }
@@ -182,7 +173,7 @@ pub mod tests {
     use chain::{pair::tests::test_pair, tests::test_chain};
     use error::HolochainError;
     use hash_table::entry::tests::test_entry;
-    use instance::tests::{test_context, test_instance_blank};
+    use instance::tests::test_context;
     use json::ToJson;
     use key::Key;
     use std::{collections::HashMap, sync::Arc};
@@ -226,14 +217,10 @@ pub mod tests {
         let mut state = test_agent_state();
         let action_wrapper = test_action_wrapper_commit();
 
-        let instance = test_instance_blank();
-
         reduce_commit_entry(
             test_context("bob"),
             &mut state,
             &action_wrapper,
-            &instance.action_channel().clone(),
-            &instance.observer_channel().clone(),
         );
 
         assert_eq!(
@@ -248,15 +235,11 @@ pub mod tests {
         let mut state = test_agent_state();
         let context = test_context("foo");
 
-        let instance = test_instance_blank();
-
         let aw1 = test_action_wrapper_get();
         reduce_get_entry(
             Arc::clone(&context),
             &mut state,
             &aw1,
-            &instance.action_channel().clone(),
-            &instance.observer_channel().clone(),
         );
 
         // nothing has been committed so the get must be None
@@ -270,8 +253,6 @@ pub mod tests {
             Arc::clone(&context),
             &mut state,
             &test_action_wrapper_commit(),
-            &instance.action_channel().clone(),
-            &instance.observer_channel().clone(),
         );
 
         let aw2 = test_action_wrapper_get();
@@ -279,8 +260,6 @@ pub mod tests {
             Arc::clone(&context),
             &mut state,
             &aw2,
-            &instance.action_channel().clone(),
-            &instance.observer_channel().clone(),
         );
 
         assert_eq!(state.actions().get(&aw2), Some(&test_action_response_get()),);

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -1,11 +1,14 @@
 use action::ActionWrapper;
 use error::HolochainError;
 use holochain_agent::Agent;
-use logger::Logger;
 use instance::Observer;
+use logger::Logger;
 use persister::Persister;
 use state::State;
-use std::sync::{Arc, mpsc::{sync_channel, SyncSender}, Mutex, RwLock, RwLockReadGuard};
+use std::sync::{
+    mpsc::{sync_channel, SyncSender},
+    Arc, Mutex, RwLock, RwLockReadGuard,
+};
 
 /// Context holds the components that parts of a Holochain instance need in order to operate.
 /// This includes components that are injected from the outside like logger and persister
@@ -18,7 +21,7 @@ pub struct Context {
     pub persister: Arc<Mutex<Persister>>,
     state: Option<Arc<RwLock<State>>>,
     pub action_channel: SyncSender<ActionWrapper>,
-    pub observer_channel: SyncSender<Observer>
+    pub observer_channel: SyncSender<Observer>,
 }
 
 impl Context {

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -25,13 +25,17 @@ pub struct Context {
 }
 
 impl Context {
+    pub fn default_channel_buffer_size() -> usize {
+        100
+    }
+
     pub fn new(
         agent: Agent,
         logger: Arc<Mutex<Logger>>,
         persister: Arc<Mutex<Persister>>,
     ) -> Context {
-        let (tx_action, _) = sync_channel(100);
-        let (tx_observer, _) = sync_channel(100);
+        let (tx_action, _) = sync_channel(Self::default_channel_buffer_size());
+        let (tx_observer, _) = sync_channel(Self::default_channel_buffer_size());
         Context {
             agent,
             logger,
@@ -86,6 +90,11 @@ mod tests {
     use persister::SimplePersister;
     use state::State;
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn default_buffer_size_test() {
+        assert_eq!(Context::default_channel_buffer_size(), 100);
+    }
 
     #[test]
     fn test_state() {

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -83,8 +83,10 @@ impl Instance {
 
     /// Returns recievers for actions and observers that get added to this instance
     fn initialize_channels(&mut self) -> (Receiver<ActionWrapper>, Receiver<Observer>) {
-        let (tx_action, rx_action) = sync_channel::<ActionWrapper>(Self::default_channel_buffer_size());
-        let (tx_observer, rx_observer) = sync_channel::<Observer>(Self::default_channel_buffer_size());
+        let (tx_action, rx_action) =
+            sync_channel::<ActionWrapper>(Self::default_channel_buffer_size());
+        let (tx_observer, rx_observer) =
+            sync_channel::<Observer>(Self::default_channel_buffer_size());
         self.action_channel = tx_action.clone();
         self.observer_channel = tx_observer.clone();
 

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -32,6 +32,10 @@ pub struct Observer {
 pub static DISPATCH_WITHOUT_CHANNELS: &str = "dispatch called without channels open";
 
 impl Instance {
+    pub fn default_channel_buffer_size() -> usize {
+        100
+    }
+
     /// get a clone of the action channel
     pub fn action_channel(&self) -> SyncSender<ActionWrapper> {
         self.action_channel.clone()
@@ -79,8 +83,8 @@ impl Instance {
 
     /// Returns recievers for actions and observers that get added to this instance
     fn initialize_channels(&mut self) -> (Receiver<ActionWrapper>, Receiver<Observer>) {
-        let (tx_action, rx_action) = sync_channel::<ActionWrapper>(100);
-        let (tx_observer, rx_observer) = sync_channel::<Observer>(100);
+        let (tx_action, rx_action) = sync_channel::<ActionWrapper>(Self::default_channel_buffer_size());
+        let (tx_observer, rx_observer) = sync_channel::<Observer>(Self::default_channel_buffer_size());
         self.action_channel = tx_action.clone();
         self.observer_channel = tx_observer.clone();
 
@@ -334,6 +338,11 @@ pub mod tests {
             action_channel.clone(),
             observer_channel.clone(),
         ))
+    }
+
+    #[test]
+    fn default_buffer_size_test() {
+        assert_eq!(Context::default_channel_buffer_size(), 100);
     }
 
     /// create a test instance

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -136,10 +136,7 @@ impl Instance {
                     .expect("owners of the state RwLock shouldn't panic");
 
                 // Create new state by reducing the action on old state
-                new_state = state.reduce(
-                    context.clone(),
-                    action_wrapper,
-                );
+                new_state = state.reduce(context.clone(), action_wrapper);
             }
 
             // Get write lock
@@ -323,7 +320,11 @@ pub mod tests {
     }
 
     /// create a test context
-    pub fn test_context_with_channels(agent_name: &str, action_channel: &SyncSender<ActionWrapper>, observer_channel: &SyncSender<Observer>) -> Arc<Context> {
+    pub fn test_context_with_channels(
+        agent_name: &str,
+        action_channel: &SyncSender<ActionWrapper>,
+        observer_channel: &SyncSender<Observer>,
+    ) -> Arc<Context> {
         let agent = Agent::from_string(agent_name.to_string());
         let logger = test_logger();
         Arc::new(Context::new_with_channels(

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -337,6 +337,7 @@ pub mod tests {
     }
 
     /// create a test instance
+    #[cfg_attr(tarpaulin, skip)]
     pub fn test_instance(dna: Dna) -> Instance {
         // Create instance and plug in our DNA
         let mut instance = Instance::new();
@@ -406,6 +407,7 @@ pub mod tests {
     }
 
     /// create a test instance with a blank DNA
+    #[cfg_attr(tarpaulin, skip)]
     pub fn test_instance_blank() -> Instance {
         let mut dna = Dna::new();
         dna.zomes.insert("".to_string(), Zome::default());

--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -4,7 +4,7 @@ use context::Context;
 use futures::{Async, Future};
 use hash_table::entry::Entry;
 use instance::dispatch_action;
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::Arc;
 
 /// ValidateEntry Action Creator
 /// This is the high-level validate function that wraps the whole validation process and is what should
@@ -13,11 +13,10 @@ use std::sync::{mpsc::Sender, Arc};
 /// Returns a future that resolves to an Ok(ActionWrapper) or an Err(error_message:String).
 pub fn validate_entry(
     entry: Entry,
-    action_channel: &Sender<ActionWrapper>,
     context: &Arc<Context>,
 ) -> ValidationFuture {
     let action_wrapper = ActionWrapper::new(Action::ValidateEntry(entry));
-    dispatch_action(action_channel, action_wrapper.clone());
+    dispatch_action(&context.action_channel, action_wrapper.clone());
     ValidationFuture {
         context: context.clone(),
         action: action_wrapper,

--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -11,10 +11,7 @@ use std::sync::Arc;
 /// be called from zome api functions and other contexts that don't care about implementation details.
 ///
 /// Returns a future that resolves to an Ok(ActionWrapper) or an Err(error_message:String).
-pub fn validate_entry(
-    entry: Entry,
-    context: &Arc<Context>,
-) -> ValidationFuture {
+pub fn validate_entry(entry: Entry, context: &Arc<Context>) -> ValidationFuture {
     let action_wrapper = ActionWrapper::new(Action::ValidateEntry(entry));
     dispatch_action(&context.action_channel, action_wrapper.clone());
     ValidationFuture {

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -208,6 +208,7 @@ pub mod tests {
     use test_utils::create_test_dna_with_cap;
 
     /// dummy commit args from standard test entry
+    #[cfg_attr(tarpaulin, skip)]
     pub fn test_bad_args_bytes() -> Vec<u8> {
         let args = ZomeCallArgs {
             zome_name: "zome_name".to_string(),
@@ -220,6 +221,7 @@ pub mod tests {
             .into_bytes()
     }
 
+    #[cfg_attr(tarpaulin, skip)]
     pub fn test_args_bytes() -> Vec<u8> {
         let args = ZomeCallArgs {
             zome_name: test_zome_name(),
@@ -232,6 +234,7 @@ pub mod tests {
             .into_bytes()
     }
 
+    #[cfg_attr(tarpaulin, skip)]
     fn create_context() -> Arc<Context> {
         Arc::new(Context::new(
             Agent::from_string("alex".to_string()),
@@ -240,6 +243,7 @@ pub mod tests {
         ))
     }
 
+    #[cfg_attr(tarpaulin, skip)]
     fn test_reduce_call(
         dna: Dna,
         expected: Result<Result<String, HolochainError>, RecvTimeoutError>,

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -10,10 +10,7 @@ use nucleus::{
     ZomeFnCall,
 };
 use serde_json;
-use std::sync::{
-    mpsc::channel,
-    Arc,
-};
+use std::sync::{mpsc::channel, Arc};
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 /// Struct for input data received when Call API function is invoked
@@ -179,12 +176,7 @@ pub(crate) fn reduce_call(
     let code =
         maybe_code.expect("zome not found, Should have failed before when getting capability.");
     state.zome_calls.insert(fn_call.clone(), None);
-    launch_zome_fn_call(
-        context,
-        fn_call,
-        &code,
-        state.dna.clone().unwrap().name,
-    );
+    launch_zome_fn_call(context, fn_call, &code, state.dna.clone().unwrap().name);
 }
 
 #[cfg(test)]
@@ -196,7 +188,10 @@ pub mod tests {
     use context::Context;
     use holochain_agent::Agent;
     use holochain_dna::{zome::capabilities::Capability, Dna, DnaError};
-    use instance::{Observer, tests::{test_instance, TestLogger}};
+    use instance::{
+        tests::{test_instance, TestLogger},
+        Observer,
+    };
     use nucleus::ribosome::{
         api::{
             tests::{

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -44,9 +44,9 @@ pub fn invoke_commit_app_entry(
     // Wait for future to be resolved
     let task_result: Result<ActionResponse, String> = block_on(
         // First validate entry:
-        validate_entry(entry.clone(), &runtime.action_channel, &runtime.context)
+        validate_entry(entry.clone(), &runtime.context)
             // if successful, commit entry:
-            .and_then(|_| commit_entry(entry.clone(), &runtime.action_channel, &runtime.context)),
+            .and_then(|_| commit_entry(entry.clone(), &runtime.context.action_channel, &runtime.context)),
     );
 
     let json = match task_result {

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -36,8 +36,8 @@ pub fn invoke_get_entry(
 
     let (sender, receiver) = channel();
     ::instance::dispatch_action_with_observer(
-        &runtime.action_channel,
-        &runtime.observer_channel,
+        &runtime.context.action_channel,
+        &runtime.context.observer_channel,
         action_wrapper.clone(),
         move |state: &::state::State| {
             let mut actions_copy = state.agent().actions();
@@ -206,8 +206,6 @@ mod tests {
         let commit_runtime = call(
             &dna.name.to_string(),
             Arc::clone(&context),
-            &instance.action_channel(),
-            &instance.observer_channel(),
             wasm.clone(),
             &commit_call,
             Some(test_commit_args_bytes()),
@@ -227,8 +225,6 @@ mod tests {
         let get_runtime = call(
             &dna.name.to_string(),
             Arc::clone(&context),
-            &instance.action_channel(),
-            &instance.observer_channel(),
             wasm.clone(),
             &get_call,
             Some(test_get_args_bytes()),

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -43,8 +43,8 @@ pub fn invoke_get_links(
     let (sender, receiver) = channel();
     // TODO #338 - lookup in DHT instead when it will be available (for caching). Will also be redesigned with Futures.
     ::instance::dispatch_action_with_observer(
-        &runtime.action_channel,
-        &runtime.observer_channel,
+        &runtime.context.action_channel,
+        &runtime.context.observer_channel,
         action_wrapper.clone(),
         move |state: &::state::State| {
             // TODO #338 - lookup in DHT instead when it will be available. Will also be redesigned with Futures.

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -22,10 +22,7 @@ use nucleus::{
     ZomeFnCall,
 };
 use num_traits::FromPrimitive;
-use std::{
-    str::FromStr,
-    sync::Arc,
-};
+use std::{str::FromStr, sync::Arc};
 use wasmi::{
     self, Error as InterpreterError, Externals, FuncInstance, FuncRef, ImportsBuilder,
     ModuleImportResolver, ModuleInstance, NopExternals, RuntimeArgs, RuntimeValue, Signature, Trap,

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -7,11 +7,9 @@ pub mod debug;
 pub mod get_entry;
 pub mod get_links;
 pub mod init_globals;
-use action::ActionWrapper;
 use context::Context;
 use holochain_dna::zome::capabilities::ReservedCapabilityNames;
 use holochain_wasm_utils::{HcApiReturnCode, SinglePageAllocation};
-use instance::Observer;
 use nucleus::{
     memory::SinglePageManager,
     ribosome::{
@@ -26,7 +24,7 @@ use nucleus::{
 use num_traits::FromPrimitive;
 use std::{
     str::FromStr,
-    sync::{mpsc::Sender, Arc},
+    sync::Arc,
 };
 use wasmi::{
     self, Error as InterpreterError, Externals, FuncInstance, FuncRef, ImportsBuilder,
@@ -158,8 +156,6 @@ impl ZomeApiFunction {
 pub struct Runtime {
     pub context: Arc<Context>,
     pub result: String,
-    action_channel: Sender<ActionWrapper>,
-    observer_channel: Sender<Observer>,
     memory_manager: SinglePageManager,
     zome_call: ZomeFnCall,
     pub app_name: String,
@@ -225,8 +221,6 @@ impl Runtime {
 pub fn call(
     app_name: &str,
     context: Arc<Context>,
-    action_channel: &Sender<ActionWrapper>,
-    observer_channel: &Sender<Observer>,
     wasm: Vec<u8>,
     zome_call: &ZomeFnCall,
     parameters: Option<Vec<u8>>,
@@ -314,8 +308,6 @@ pub fn call(
     let mut runtime = Runtime {
         context,
         result: String::new(),
-        action_channel: action_channel.clone(),
-        observer_channel: observer_channel.clone(),
         memory_manager: SinglePageManager::new(&wasm_instance),
         zome_call: zome_call.clone(),
         app_name: app_name.to_string(),
@@ -496,7 +488,7 @@ pub mod tests {
         app_name: &str,
         context: Arc<Context>,
         logger: Arc<Mutex<TestLogger>>,
-        instance: &Instance,
+        _instance: &Instance,
         wasm: &Vec<u8>,
         args_bytes: Vec<u8>,
     ) -> (Runtime, Arc<Mutex<TestLogger>>) {
@@ -510,8 +502,6 @@ pub mod tests {
             call(
                 &app_name,
                 context,
-                &instance.action_channel(),
-                &instance.observer_channel(),
                 wasm.clone(),
                 &zome_call,
                 Some(args_bytes),

--- a/core/src/nucleus/ribosome/callback/genesis.rs
+++ b/core/src/nucleus/ribosome/callback/genesis.rs
@@ -9,12 +9,7 @@ pub fn genesis(
     // we ignore params for genesis
     params: &CallbackParams,
 ) -> CallbackResult {
-    call(
-        context,
-        zome,
-        &Callback::Genesis,
-        params,
-    )
+    call(context, zome, &Callback::Genesis, params)
 }
 
 #[cfg(test)]
@@ -33,11 +28,7 @@ pub mod tests {
         let instance = test_callback_instance(zome, Callback::Genesis.as_str(), 0);
         let context = instance.initialize_context(test_context("test"));
 
-        let result = genesis(
-            context,
-            zome,
-            &CallbackParams::Genesis,
-        );
+        let result = genesis(context, zome, &CallbackParams::Genesis);
 
         assert_eq!(CallbackResult::Pass, result);
     }
@@ -54,11 +45,7 @@ pub mod tests {
 
         let context = instance.initialize_context(test_context("test"));
 
-        let result = genesis(
-            context,
-            zome,
-            &CallbackParams::Genesis,
-        );
+        let result = genesis(context, zome, &CallbackParams::Genesis);
 
         assert_eq!(CallbackResult::NotImplemented, result);
     }
@@ -69,11 +56,7 @@ pub mod tests {
         let instance = test_callback_instance(zome, Callback::Genesis.as_str(), 1);
         let context = instance.initialize_context(test_context("test"));
 
-        let result = genesis(
-            context,
-            zome,
-            &CallbackParams::Genesis,
-        );
+        let result = genesis(context, zome, &CallbackParams::Genesis);
 
         // @TODO how to get fail strings back out?
         // @see https://github.com/holochain/holochain-rust/issues/205

--- a/core/src/nucleus/ribosome/callback/genesis.rs
+++ b/core/src/nucleus/ribosome/callback/genesis.rs
@@ -1,22 +1,16 @@
 use super::call;
-use action::ActionWrapper;
 use context::Context;
-use instance::Observer;
 use nucleus::ribosome::callback::{Callback, CallbackParams, CallbackResult};
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::Arc;
 
 pub fn genesis(
     context: Arc<Context>,
-    action_channel: &Sender<ActionWrapper>,
-    observer_channel: &Sender<Observer>,
     zome: &str,
     // we ignore params for genesis
     params: &CallbackParams,
 ) -> CallbackResult {
     call(
         context,
-        action_channel,
-        observer_channel,
         zome,
         &Callback::Genesis,
         params,
@@ -41,8 +35,6 @@ pub mod tests {
 
         let result = genesis(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::Genesis,
         );
@@ -64,8 +56,6 @@ pub mod tests {
 
         let result = genesis(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::Genesis,
         );
@@ -81,8 +71,6 @@ pub mod tests {
 
         let result = genesis(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::Genesis,
         );

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -18,12 +18,7 @@ use nucleus::{
     ZomeFnCall,
 };
 use num_traits::FromPrimitive;
-use std::{
-    str::FromStr,
-    sync::Arc,
-    thread::sleep,
-    time::Duration,
-};
+use std::{str::FromStr, sync::Arc, thread::sleep, time::Duration};
 
 /// Enumeration of all Zome Callbacks known and used by Holochain
 /// Enumeration can convert to str
@@ -67,16 +62,8 @@ impl FromStr for Callback {
 impl Callback {
     pub fn as_fn(
         &self,
-    ) -> fn(
-        context: Arc<Context>,
-        zome: &str,
-        params: &CallbackParams,
-    ) -> CallbackResult {
-        fn noop(
-            _context: Arc<Context>,
-            _zome: &str,
-            _params: &CallbackParams,
-        ) -> CallbackResult {
+    ) -> fn(context: Arc<Context>, zome: &str, params: &CallbackParams) -> CallbackResult {
+        fn noop(_context: Arc<Context>, _zome: &str, _params: &CallbackParams) -> CallbackResult {
             CallbackResult::Pass
         }
 
@@ -225,12 +212,7 @@ pub fn call(
             if wasm.code.is_empty() {
                 CallbackResult::NotImplemented
             } else {
-                run_callback(
-                    context.clone(),
-                    zome_call,
-                    wasm,
-                    dna.name.clone(),
-                )
+                run_callback(context.clone(), zome_call, wasm, dna.name.clone())
             }
         }
     }

--- a/core/src/nucleus/ribosome/callback/receive.rs
+++ b/core/src/nucleus/ribosome/callback/receive.rs
@@ -1,22 +1,16 @@
 use super::call;
-use action::ActionWrapper;
 use context::Context;
-use instance::Observer;
 use nucleus::ribosome::callback::{Callback, CallbackParams, CallbackResult};
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::Arc;
 
 pub fn receive(
     context: Arc<Context>,
-    action_channel: &Sender<ActionWrapper>,
-    observer_channel: &Sender<Observer>,
     zome: &str,
     // we ignore params for genesis
     params: &CallbackParams,
 ) -> CallbackResult {
     call(
         context,
-        action_channel,
-        observer_channel,
         zome,
         &Callback::Receive,
         params,
@@ -41,8 +35,6 @@ pub mod tests {
 
         let result = receive(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::Receive,
         );
@@ -63,8 +55,6 @@ pub mod tests {
 
         let result = receive(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::Receive,
         );
@@ -80,8 +70,6 @@ pub mod tests {
 
         let result = receive(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::Receive,
         );

--- a/core/src/nucleus/ribosome/callback/receive.rs
+++ b/core/src/nucleus/ribosome/callback/receive.rs
@@ -9,12 +9,7 @@ pub fn receive(
     // we ignore params for genesis
     params: &CallbackParams,
 ) -> CallbackResult {
-    call(
-        context,
-        zome,
-        &Callback::Receive,
-        params,
-    )
+    call(context, zome, &Callback::Receive, params)
 }
 
 #[cfg(test)]
@@ -33,11 +28,7 @@ pub mod tests {
         let instance = test_callback_instance(zome, Callback::Receive.as_str(), 0);
         let context = instance.initialize_context(test_context("test"));
 
-        let result = receive(
-            context,
-            zome,
-            &CallbackParams::Receive,
-        );
+        let result = receive(context, zome, &CallbackParams::Receive);
 
         assert_eq!(CallbackResult::Pass, result);
     }
@@ -53,11 +44,7 @@ pub mod tests {
         );
         let context = instance.initialize_context(test_context("test"));
 
-        let result = receive(
-            context,
-            zome,
-            &CallbackParams::Receive,
-        );
+        let result = receive(context, zome, &CallbackParams::Receive);
 
         assert_eq!(CallbackResult::NotImplemented, result);
     }
@@ -68,11 +55,7 @@ pub mod tests {
         let instance = test_callback_instance(zome, Callback::Receive.as_str(), 1);
         let context = instance.initialize_context(test_context("test"));
 
-        let result = receive(
-            context,
-            zome,
-            &CallbackParams::Receive,
-        );
+        let result = receive(context, zome, &CallbackParams::Receive);
 
         // @TODO how to get fail strings back out?
         // @see https://github.com/holochain/holochain-rust/issues/205

--- a/core/src/nucleus/ribosome/callback/validate_commit.rs
+++ b/core/src/nucleus/ribosome/callback/validate_commit.rs
@@ -1,21 +1,15 @@
 use super::call;
-use action::ActionWrapper;
 use context::Context;
-use instance::Observer;
 use nucleus::ribosome::callback::{Callback, CallbackParams, CallbackResult};
-use std::sync::{mpsc::Sender, Arc};
+use std::sync::Arc;
 
 pub fn validate_commit(
     context: Arc<Context>,
-    action_channel: &Sender<ActionWrapper>,
-    observer_channel: &Sender<Observer>,
     zome: &str,
     params: &CallbackParams,
 ) -> CallbackResult {
     call(
         context,
-        action_channel,
-        observer_channel,
         zome,
         &Callback::ValidateCommit,
         params,
@@ -41,8 +35,6 @@ pub mod tests {
 
         let result = validate_commit(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::ValidateCommit(test_entry()),
         );
@@ -63,8 +55,6 @@ pub mod tests {
 
         let result = validate_commit(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::ValidateCommit(test_entry()),
         );
@@ -80,8 +70,6 @@ pub mod tests {
 
         let result = validate_commit(
             context,
-            &instance.action_channel(),
-            &instance.observer_channel(),
             zome,
             &CallbackParams::ValidateCommit(test_entry()),
         );

--- a/core/src/nucleus/ribosome/callback/validate_commit.rs
+++ b/core/src/nucleus/ribosome/callback/validate_commit.rs
@@ -8,12 +8,7 @@ pub fn validate_commit(
     zome: &str,
     params: &CallbackParams,
 ) -> CallbackResult {
-    call(
-        context,
-        zome,
-        &Callback::ValidateCommit,
-        params,
-    )
+    call(context, zome, &Callback::ValidateCommit, params)
 }
 
 #[cfg(test)]
@@ -33,11 +28,7 @@ pub mod tests {
         let instance = test_callback_instance(zome, Callback::ValidateCommit.as_str(), 0);
         let context = instance.initialize_context(test_context("test"));
 
-        let result = validate_commit(
-            context,
-            zome,
-            &CallbackParams::ValidateCommit(test_entry()),
-        );
+        let result = validate_commit(context, zome, &CallbackParams::ValidateCommit(test_entry()));
 
         assert_eq!(CallbackResult::Pass, result);
     }
@@ -53,11 +44,7 @@ pub mod tests {
         );
         let context = instance.initialize_context(test_context("test"));
 
-        let result = validate_commit(
-            context,
-            zome,
-            &CallbackParams::ValidateCommit(test_entry()),
-        );
+        let result = validate_commit(context, zome, &CallbackParams::ValidateCommit(test_entry()));
 
         assert_eq!(CallbackResult::NotImplemented, result);
     }
@@ -68,11 +55,7 @@ pub mod tests {
         let instance = test_callback_instance(zome, Callback::ValidateCommit.as_str(), 1);
         let context = instance.initialize_context(test_context("test"));
 
-        let result = validate_commit(
-            context,
-            zome,
-            &CallbackParams::ValidateCommit(test_entry()),
-        );
+        let result = validate_commit(context, zome, &CallbackParams::ValidateCommit(test_entry()));
 
         // @TODO how to get fail strings back out?
         // @see https://github.com/holochain/holochain-rust/issues/205

--- a/core/src/persister.rs
+++ b/core/src/persister.rs
@@ -50,10 +50,7 @@ mod tests {
         let state = State::new();
         let action_wrapper = test_action_wrapper_commit();
 
-        let new_state = state.reduce(
-            test_context("jane"),
-            action_wrapper.clone(),
-        );
+        let new_state = state.reduce(test_context("jane"), action_wrapper.clone());
 
         store.save(new_state.clone());
 

--- a/core/src/persister.rs
+++ b/core/src/persister.rs
@@ -34,9 +34,8 @@ impl SimplePersister {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use action::{tests::test_action_wrapper_commit, ActionWrapper};
+    use action::tests::test_action_wrapper_commit;
     use instance::tests::test_context;
-    use std::sync::mpsc::channel;
 
     #[test]
     fn can_instantiate() {
@@ -48,18 +47,12 @@ mod tests {
     #[test]
     fn can_roundtrip() {
         let mut store = SimplePersister::new();
-
         let state = State::new();
-
         let action_wrapper = test_action_wrapper_commit();
 
-        let (sender, _receiver) = channel::<ActionWrapper>();
-        let (tx_observer, _observer) = channel::<::instance::Observer>();
         let new_state = state.reduce(
             test_context("jane"),
             action_wrapper.clone(),
-            &sender,
-            &tx_observer,
         );
 
         store.save(new_state.clone());

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -3,11 +3,10 @@ use agent::state::AgentState;
 use chain::Chain;
 use context::Context;
 use hash_table::{actor::HashTableActor, memory::MemTable};
-use instance::Observer;
 use nucleus::state::NucleusState;
 use std::{
     collections::HashSet,
-    sync::{mpsc::Sender, Arc},
+    sync::Arc,
 };
 
 /// The Store of the Holochain instance Object, according to Redux pattern.
@@ -39,23 +38,17 @@ impl State {
         &self,
         context: Arc<Context>,
         action_wrapper: ActionWrapper,
-        action_channel: &Sender<ActionWrapper>,
-        observer_channel: &Sender<Observer>,
     ) -> Self {
         let mut new_state = State {
             nucleus: ::nucleus::reduce(
                 Arc::clone(&context),
                 Arc::clone(&self.nucleus),
                 &action_wrapper,
-                action_channel,
-                observer_channel,
             ),
             agent: ::agent::state::reduce(
                 Arc::clone(&context),
                 Arc::clone(&self.agent),
                 &action_wrapper,
-                action_channel,
-                observer_channel,
             ),
             history: self.history.clone(),
         };

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -4,10 +4,7 @@ use chain::Chain;
 use context::Context;
 use hash_table::{actor::HashTableActor, memory::MemTable};
 use nucleus::state::NucleusState;
-use std::{
-    collections::HashSet,
-    sync::Arc,
-};
+use std::{collections::HashSet, sync::Arc};
 
 /// The Store of the Holochain instance Object, according to Redux pattern.
 /// It's composed of all sub-module's state slices.
@@ -34,11 +31,7 @@ impl State {
         }
     }
 
-    pub fn reduce(
-        &self,
-        context: Arc<Context>,
-        action_wrapper: ActionWrapper,
-    ) -> Self {
+    pub fn reduce(&self, context: Arc<Context>, action_wrapper: ActionWrapper) -> Self {
         let mut new_state = State {
             nucleus: ::nucleus::reduce(
                 Arc::clone(&context),


### PR DESCRIPTION
preparation for #350 (pure reducer refactoring)

Sync channels (https://doc.rust-lang.org/std/sync/mpsc/fn.sync_channel.html) can easily be passed around between threads (which I need for #350).
Since I had to touch every line that mentions channels (or their `Senders`) to change to `SyncSender` and since we have the `context` object holding the state and being passed to everything, I've put those channels into the context.