### PR TITLE
ribosome_return_code! macro

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -115,22 +115,22 @@ mod tests {
         }
     }
 
-    #[test]
-    #[should_panic]
-    fn test_deadlock() {
-        let mut context = Context::new(
-            holochain_agent::Agent::from_string("Terence".to_string()),
-            test_logger(),
-            Arc::new(Mutex::new(SimplePersister::new())),
-        );
-
-        let global_state = Arc::new(RwLock::new(State::new()));
-        context.set_state(global_state.clone());
-
-        {
-            let _write_lock = global_state.write().unwrap();
-            // This line panics because we would enter into a deadlock
-            context.state();
-        }
-    }
+//    #[test]
+//    #[should_panic]
+//    fn test_deadlock() {
+//        let mut context = Context::new(
+//            holochain_agent::Agent::from_string("Terence".to_string()),
+//            test_logger(),
+//            Arc::new(Mutex::new(SimplePersister::new())),
+//        );
+//
+//        let global_state = Arc::new(RwLock::new(State::new()));
+//        context.set_state(global_state.clone());
+//
+//        {
+//            let _write_lock = global_state.write().unwrap();
+//            // This line panics because we would enter into a deadlock
+//            context.state();
+//        }
+//    }
 }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -115,22 +115,22 @@ mod tests {
         }
     }
 
-//    #[test]
-//    #[should_panic]
-//    fn test_deadlock() {
-//        let mut context = Context::new(
-//            holochain_agent::Agent::from_string("Terence".to_string()),
-//            test_logger(),
-//            Arc::new(Mutex::new(SimplePersister::new())),
-//        );
-//
-//        let global_state = Arc::new(RwLock::new(State::new()));
-//        context.set_state(global_state.clone());
-//
-//        {
-//            let _write_lock = global_state.write().unwrap();
-//            // This line panics because we would enter into a deadlock
-//            context.state();
-//        }
-//    }
+    #[test]
+    #[should_panic]
+    fn test_deadlock() {
+        let mut context = Context::new(
+            holochain_agent::Agent::from_string("Terence".to_string()),
+            test_logger(),
+            Arc::new(Mutex::new(SimplePersister::new())),
+        );
+
+        let global_state = Arc::new(RwLock::new(State::new()));
+        context.set_state(global_state.clone());
+
+        {
+            let _write_lock = global_state.write().unwrap();
+            // This line panics because we would enter into a deadlock
+            context.state();
+        }
+    }
 }

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -2,17 +2,15 @@ use action::{Action, ActionWrapper};
 use context::Context;
 use error::HolochainError;
 use holochain_dna::zome::capabilities::Membrane;
+use holochain_wasm_utils::error::RibosomeReturnCode;
 use instance::RECV_DEFAULT_TIMEOUT_MS;
 use nucleus::{
-    get_capability_with_zome_call, launch_zome_fn_call,
-    ribosome::api::Runtime,
-    state::NucleusState,
-    ZomeFnCall,
+    get_capability_with_zome_call, launch_zome_fn_call, ribosome::api::Runtime,
+    state::NucleusState, ZomeFnCall,
 };
 use serde_json;
 use std::sync::{mpsc::channel, Arc};
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
-use holochain_wasm_utils::error::RibosomeReturnCode;
 
 /// Struct for input data received when Call API function is invoked
 #[derive(Deserialize, Default, Clone, PartialEq, Eq, Hash, Debug, Serialize)]

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -2,7 +2,7 @@ extern crate futures;
 use agent::{actions::commit::*, state::ActionResponse};
 use futures::{executor::block_on, FutureExt};
 use hash_table::entry::Entry;
-use holochain_wasm_utils::error::{HcApiReturnCode, RibosomeErrorReport};
+use holochain_wasm_utils::error::{RibosomeReturnCode, RibosomeErrorReport};
 use json::ToJson;
 use nucleus::{actions::validate::*, ribosome::api::Runtime};
 use serde_json;
@@ -28,12 +28,7 @@ pub fn invoke_commit_app_entry(
     let input: CommitAppEntryArgs = match serde_json::from_str(&args_str) {
         Ok(entry_input) => entry_input,
         // Exit on error
-        Err(_) => {
-            // Return Error code in i32 format
-            return Ok(Some(RuntimeValue::I32(
-                HcApiReturnCode::ArgumentDeserializationFailed as i32,
-            )));
-        }
+        Err(_) => return ribosome_return_code!(ArgumentDeserializationFailed),
     };
 
     // Create Chain Entry
@@ -50,14 +45,10 @@ pub fn invoke_commit_app_entry(
     let maybe_json = match task_result {
         Ok(action_response) => match action_response {
             ActionResponse::Commit(_) => action_response.to_json(),
-            _ => {
-                return Ok(Some(RuntimeValue::I32(
-                    HcApiReturnCode::ReceivedWrongActionResult as i32,
-                )))
-            }
+            _ => return ribosome_return_code!(ReceivedWrongActionResult),
         },
         Err(error_string) => {
-            let error_report = report_error!(format!(
+            let error_report = ribosome_error_report!(format!(
                 "Call to `hc_commit_entry()` failed: {}",
                 error_string
             ));
@@ -70,9 +61,7 @@ pub fn invoke_commit_app_entry(
     // allocate and encode result
     match maybe_json {
         Ok(json) => runtime.store_utf8(&json),
-        Err(_) => Ok(Some(RuntimeValue::I32(
-            HcApiReturnCode::ResponseSerializationFailed as i32,
-        ))),
+        Err(_) => ribosome_return_code!(ResponseSerializationFailed),
     }
 
     // @TODO test that failing validation prevents commits happening

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -2,7 +2,7 @@ extern crate futures;
 use agent::{actions::commit::*, state::ActionResponse};
 use futures::{executor::block_on, FutureExt};
 use hash_table::entry::Entry;
-use holochain_wasm_utils::error::{RibosomeReturnCode, RibosomeErrorReport};
+use holochain_wasm_utils::error::{RibosomeErrorReport, RibosomeReturnCode};
 use json::ToJson;
 use nucleus::{actions::validate::*, ribosome::api::Runtime};
 use serde_json;

--- a/core/src/nucleus/ribosome/api/debug.rs
+++ b/core/src/nucleus/ribosome/api/debug.rs
@@ -1,6 +1,6 @@
+use holochain_wasm_utils::error::RibosomeReturnCode;
 use nucleus::ribosome::api::Runtime;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
-use holochain_wasm_utils::error::RibosomeReturnCode;
 
 /// ZomeApiFunction::Debug function code
 /// args: [0] encoded MemoryAllocation as u32

--- a/core/src/nucleus/ribosome/api/debug.rs
+++ b/core/src/nucleus/ribosome/api/debug.rs
@@ -1,5 +1,6 @@
 use nucleus::ribosome::api::Runtime;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
+use holochain_wasm_utils::error::RibosomeReturnCode;
 
 /// ZomeApiFunction::Debug function code
 /// args: [0] encoded MemoryAllocation as u32
@@ -13,7 +14,7 @@ pub fn invoke_debug(
 
     println!("{}", arg);
     let _ = runtime.context.log(&arg);
-    Ok(Some(RuntimeValue::I32(0 as i32)))
+    ribosome_return_code!(Success)
 }
 
 #[cfg(test)]

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -1,12 +1,12 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
 use hash::HashString;
+use holochain_wasm_utils::error::RibosomeReturnCode;
 use json::ToJson;
 use nucleus::ribosome::api::Runtime;
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
-use holochain_wasm_utils::error::RibosomeReturnCode;
 
 #[derive(Deserialize, Default, Debug, Serialize)]
 struct GetAppEntryArgs {

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -2,10 +2,11 @@ use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
 use hash::HashString;
 use json::ToJson;
-use nucleus::ribosome::api::{HcApiReturnCode, Runtime};
+use nucleus::ribosome::api::Runtime;
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
+use holochain_wasm_utils::error::RibosomeReturnCode;
 
 #[derive(Deserialize, Default, Debug, Serialize)]
 struct GetAppEntryArgs {
@@ -25,10 +26,7 @@ pub fn invoke_get_entry(
     let res_entry: Result<GetAppEntryArgs, _> = serde_json::from_str(&args_str);
     // Exit on error
     if res_entry.is_err() {
-        // Return Error code in i32 format
-        return Ok(Some(RuntimeValue::I32(
-            HcApiReturnCode::ArgumentDeserializationFailed as i32,
-        )));
+        return ribosome_return_code!(ArgumentDeserializationFailed);
     }
     let input = res_entry.unwrap();
 
@@ -68,14 +66,10 @@ pub fn invoke_get_entry(
             let json_str = maybe_entry.expect("should be valid json entry").to_json();
             match json_str {
                 Ok(json) => runtime.store_utf8(&json),
-                Err(_) => Ok(Some(RuntimeValue::I32(
-                    HcApiReturnCode::ResponseSerializationFailed as i32,
-                ))),
+                Err(_) => ribosome_return_code!(ResponseSerializationFailed),
             }
         }
-        _ => Ok(Some(RuntimeValue::I32(
-            HcApiReturnCode::ReceivedWrongActionResult as i32,
-        ))),
+        _ => ribosome_return_code!(ReceivedWrongActionResult),
     }
 }
 

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -1,10 +1,11 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
 use hash::HashString;
-use nucleus::ribosome::api::{HcApiReturnCode, Runtime};
+use nucleus::ribosome::api::Runtime;
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
+use holochain_wasm_utils::error::RibosomeReturnCode;
 
 #[derive(Deserialize, Default, Debug, Serialize, Clone, PartialEq, Eq, Hash)]
 pub struct GetLinksArgs {
@@ -31,10 +32,7 @@ pub fn invoke_get_links(
     let res_entry: Result<GetLinksArgs, _> = serde_json::from_str(&args_str);
     // Exit on error
     if res_entry.is_err() {
-        // Return Error code in i32 format
-        return Ok(Some(RuntimeValue::I32(
-            HcApiReturnCode::ArgumentDeserializationFailed as i32,
-        )));
+        return ribosome_return_code!(ArgumentDeserializationFailed);
     }
     let input = res_entry.unwrap();
     // Create GetLinks Action
@@ -73,7 +71,5 @@ pub fn invoke_get_links(
         }
     }
     // Fail
-    Ok(Some(RuntimeValue::I32(
-        HcApiReturnCode::ReceivedWrongActionResult as i32,
-    )))
+    ribosome_return_code!(ReceivedWrongActionResult)
 }

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -1,11 +1,11 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
 use hash::HashString;
+use holochain_wasm_utils::error::RibosomeReturnCode;
 use nucleus::ribosome::api::Runtime;
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
-use holochain_wasm_utils::error::RibosomeReturnCode;
 
 #[derive(Deserialize, Default, Debug, Serialize, Clone, PartialEq, Eq, Hash)]
 pub struct GetLinksArgs {

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -9,7 +9,7 @@ pub mod get_links;
 pub mod init_globals;
 use context::Context;
 use holochain_dna::zome::capabilities::ReservedCapabilityNames;
-use holochain_wasm_utils::{error::HcApiReturnCode, memory_allocation::SinglePageAllocation};
+use holochain_wasm_utils::{error::RibosomeReturnCode, memory_allocation::SinglePageAllocation};
 use nucleus::{
     ribosome::{
         api::{
@@ -126,7 +126,7 @@ impl ZomeApiFunction {
     pub fn as_fn(&self) -> (fn(&mut Runtime, &RuntimeArgs) -> Result<Option<RuntimeValue>, Trap>) {
         /// does nothing, escape hatch so the compiler can enforce exhaustive matching below
         fn noop(_runtime: &mut Runtime, _args: &RuntimeArgs) -> Result<Option<RuntimeValue>, Trap> {
-            Ok(Some(RuntimeValue::I32(0 as i32)))
+            ribosome_return_code!(Success)
         }
 
         // TODO Implement a proper "abort" function for handling assemblyscript aborts
@@ -172,7 +172,7 @@ impl Runtime {
         let encoded_allocation: u32 = args.nth(0);
         let allocation = SinglePageAllocation::new(encoded_allocation);
         // Handle empty allocation edge case
-        if let Err(HcApiReturnCode::Success) = allocation {
+        if let Err(RibosomeReturnCode::Success) = allocation {
             return String::new();
         }
         let allocation = allocation

--- a/wasm_utils/src/error.rs
+++ b/wasm_utils/src/error.rs
@@ -1,9 +1,17 @@
-use self::HcApiReturnCode::*;
+use self::RibosomeReturnCode::*;
 use std::fmt;
+
+// Macro for creating a RibosomeReturnCode as a RuntimeValue Result-Option on the spot
+#[macro_export]
+macro_rules! ribosome_return_code {
+    ($s:ident) => {
+        Ok(Some(RuntimeValue::I32(RibosomeReturnCode::$s as i32)))
+    };
+}
 
 // Macro for creating a RibosomeErrorReport on the spot with file!() and line!()
 #[macro_export]
-macro_rules! report_error {
+macro_rules! ribosome_error_report {
     ($s:expr) => {
         RibosomeErrorReport {
             description: $s.to_string(),
@@ -38,7 +46,7 @@ impl fmt::Display for RibosomeErrorReport {
 #[repr(u32)]
 #[derive(Debug, PartialEq)]
 #[cfg_attr(rustfmt, rustfmt_skip)]
-pub enum HcApiReturnCode {
+pub enum RibosomeReturnCode {
     Success                         = 0,
     Failure                         = 1 << 16,
     ArgumentDeserializationFailed   = 2 << 16,
@@ -50,7 +58,7 @@ pub enum HcApiReturnCode {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-impl ToString for HcApiReturnCode {
+impl ToString for RibosomeReturnCode {
     fn to_string(&self) -> String {
         match self {
             Success                         => "Success",
@@ -65,8 +73,8 @@ impl ToString for HcApiReturnCode {
     }
 }
 
-impl HcApiReturnCode {
-    pub fn from_offset(offset: u16) -> HcApiReturnCode {
+impl RibosomeReturnCode {
+    pub fn from_offset(offset: u16) -> RibosomeReturnCode {
         match offset {
             // @TODO what is a success error?
             // @see https://github.com/holochain/holochain-rust/issues/181
@@ -89,9 +97,9 @@ pub mod tests {
     #[test]
     fn hc_api_return_code_round_trip() {
         let oom =
-            HcApiReturnCode::from_offset(((HcApiReturnCode::OutOfMemory as u32) >> 16) as u16);
-        assert_eq!(HcApiReturnCode::OutOfMemory, oom);
-        assert_eq!(HcApiReturnCode::OutOfMemory.to_string(), oom.to_string());
+            RibosomeReturnCode::from_offset(((RibosomeReturnCode::OutOfMemory as u32) >> 16) as u16);
+        assert_eq!(RibosomeReturnCode::OutOfMemory, oom);
+        assert_eq!(RibosomeReturnCode::OutOfMemory.to_string(), oom.to_string());
     }
 
     #[test]
@@ -103,6 +111,6 @@ pub mod tests {
             line: line!().to_string(),
         };
 
-        assert_ne!(report.to_string(), report_error!(description).to_string());
+        assert_ne!(report.to_string(), ribosome_error_report!(description).to_string());
     }
 }

--- a/wasm_utils/src/error.rs
+++ b/wasm_utils/src/error.rs
@@ -96,8 +96,9 @@ pub mod tests {
 
     #[test]
     fn hc_api_return_code_round_trip() {
-        let oom =
-            RibosomeReturnCode::from_offset(((RibosomeReturnCode::OutOfMemory as u32) >> 16) as u16);
+        let oom = RibosomeReturnCode::from_offset(
+            ((RibosomeReturnCode::OutOfMemory as u32) >> 16) as u16,
+        );
         assert_eq!(RibosomeReturnCode::OutOfMemory, oom);
         assert_eq!(RibosomeReturnCode::OutOfMemory.to_string(), oom.to_string());
     }
@@ -111,6 +112,9 @@ pub mod tests {
             line: line!().to_string(),
         };
 
-        assert_ne!(report.to_string(), ribosome_error_report!(description).to_string());
+        assert_ne!(
+            report.to_string(),
+            ribosome_error_report!(description).to_string()
+        );
     }
 }


### PR DESCRIPTION
Start review by looking into `wasm_utils/src/error.rs`:
 - added `ribosome_return_code!` macro
 - renamed `HcApiReturnCode` to `RibosomeReturnCode`
 - renamed `report_error!` macro to `ribosome_error_report!`