### PR TITLE
merge address key hash

### DIFF
--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -1,6 +1,6 @@
 use agent::state::AgentState;
+use cas::content::Address;
 use context::Context;
-use hash::HashString;
 use hash_table::{entry::Entry, links_entry::Link, sys_entry::EntryType};
 use holochain_dna::Dna;
 use nucleus::{
@@ -71,12 +71,12 @@ pub enum Action {
     /// entry to Commit
     /// MUST already have passed all callback checks
     Commit(EntryType, Entry),
-    /// GetEntry by hash
-    GetEntry(HashString),
+    /// GetEntry by address
+    GetEntry(Address),
 
     /// link to add
     AddLink(Link),
-    /// get links from entry hash and attribute-name
+    /// get links from entry address and attribute-name
     GetLinks(GetLinksArgs),
 
     /// execute a function in a zome WASM
@@ -98,7 +98,7 @@ pub enum Action {
     /// A validation result that should be stored
     /// Key is an unique id of the calling context
     /// and the hash of the entry that was validated
-    ReturnValidationResult(((snowflake::ProcessUniqueId, HashString), ValidationResult)),
+    ReturnValidationResult(((snowflake::ProcessUniqueId, Address), ValidationResult)),
 }
 
 /// function signature for action handler functions

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -112,14 +112,13 @@ pub type ReduceFn<S> = fn(Arc<Context>, &mut S, &ActionWrapper);
 pub mod tests {
 
     use action::{Action, ActionWrapper};
-    use hash::tests::test_hash;
-    use hash_table::entry::tests::{test_entry, test_entry_hash, test_entry_type};
+    use hash_table::entry::tests::{test_entry, test_entry_address, test_entry_type};
     use nucleus::tests::test_call_result;
     use test_utils::calculate_hash;
 
     /// dummy action
     pub fn test_action() -> Action {
-        Action::GetEntry(test_entry_hash())
+        Action::GetEntry(test_entry_address())
     }
 
     /// dummy action wrapper with test_action()
@@ -134,7 +133,7 @@ pub mod tests {
 
     /// dummy action for a get of test_hash()
     pub fn test_action_wrapper_get() -> ActionWrapper {
-        ActionWrapper::new(Action::GetEntry(test_hash()))
+        ActionWrapper::new(Action::GetEntry(test_entry_address()))
     }
 
     pub fn test_action_wrapper_rzfr() -> ActionWrapper {

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -3,7 +3,6 @@ use cas::content::Address;
 use chain::pair::Pair;
 use error::HolochainError;
 use futures::executor::block_on;
-use hash::HashString;
 use hash_table::{
     entry::Entry,
     entry_meta::EntryMeta,
@@ -36,7 +35,7 @@ pub enum Protocol {
     TeardownResult(Result<(), HolochainError>),
 
     /// HashTable::get()
-    GetEntry(HashString),
+    GetEntry(Address),
     GetEntryResult(Result<Option<Entry>, HolochainError>),
 
     /// HashTable::put()
@@ -70,7 +69,7 @@ pub enum Protocol {
     AssertMetaResult(Result<(), HolochainError>),
 
     /// HashTable::get_meta()
-    GetMeta(HashString),
+    GetMeta(Address),
     GetMetaResult(Result<Option<EntryMeta>, HolochainError>),
 
     /// HashTable::metas_from_entry()

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,4 +1,5 @@
 use agent::keys::Keys;
+use cas::content::Address;
 use chain::pair::Pair;
 use error::HolochainError;
 use futures::executor::block_on;
@@ -78,7 +79,7 @@ pub enum Protocol {
 
     /// HashTable::meta_from_request()
     MetaFromRequest {
-        entry_hash: HashString,
+        entry_address: Address,
         attribute_name: String,
     },
     MetaFromRequestResult(Result<Option<EntryMeta>, HolochainError>),

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -6,8 +6,8 @@ use error::HolochainError;
 use hash::HashString;
 use hash_table::entry::Entry;
 use json::ToJson;
-use key::Key;
 use std::{collections::HashMap, sync::Arc};
+use cas::content::AddressableContent;
 
 /// The state-slice for the Agent.
 /// Holds the agent's source chain and keys.
@@ -65,7 +65,7 @@ impl ToJson for ActionResponse {
     fn to_json(&self) -> Result<String, HolochainError> {
         match self {
             ActionResponse::Commit(result) => match result {
-                Ok(entry) => Ok(format!("{{\"hash\":\"{}\"}}", entry.key())),
+                Ok(entry) => Ok(format!("{{\"address\":\"{}\"}}", entry.address())),
                 Err(err) => Ok((*err).to_json()?),
             },
             ActionResponse::GetEntry(result) => match result {
@@ -77,7 +77,7 @@ impl ToJson for ActionResponse {
                 Err(err) => Ok((*err).to_json()?),
             },
             ActionResponse::LinkEntries(result) => match result {
-                Ok(entry) => Ok(format!("{{\"hash\":\"{}\"}}", entry.key())),
+                Ok(entry) => Ok(format!("{{\"address\":\"{}\"}}", entry.address())),
                 Err(err) => Ok((*err).to_json()?),
             },
         }
@@ -171,8 +171,8 @@ pub mod tests {
     use hash_table::entry::tests::test_entry;
     use instance::tests::test_context;
     use json::ToJson;
-    use key::Key;
     use std::{collections::HashMap, sync::Arc};
+    use cas::content::AddressableContent;
 
     /// dummy agent state
     pub fn test_agent_state() -> AgentState {
@@ -281,7 +281,7 @@ pub mod tests {
     fn test_get_links_response_to_json() {
         assert_eq!(
             "[\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\"]",
-            ActionResponse::GetLinks(Ok(vec![test_entry().key()]))
+            ActionResponse::GetLinks(Ok(vec![test_entry().address()]))
                 .to_json()
                 .unwrap(),
         );

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -1,10 +1,9 @@
 use action::{Action, ActionWrapper, AgentReduceFn};
 use agent::keys::Keys;
-use cas::content::AddressableContent;
+use cas::content::{Address, AddressableContent};
 use chain::{Chain, SourceChain};
 use context::Context;
 use error::HolochainError;
-use hash::HashString;
 use hash_table::entry::Entry;
 use json::ToJson;
 use std::{collections::HashMap, sync::Arc};
@@ -57,7 +56,7 @@ impl AgentState {
 pub enum ActionResponse {
     Commit(Result<Entry, HolochainError>),
     GetEntry(Option<Entry>),
-    GetLinks(Result<Vec<HashString>, HolochainError>),
+    GetLinks(Result<Vec<Address>, HolochainError>),
     LinkEntries(Result<Entry, HolochainError>),
 }
 

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -1,5 +1,6 @@
 use action::{Action, ActionWrapper, AgentReduceFn};
 use agent::keys::Keys;
+use cas::content::AddressableContent;
 use chain::{Chain, SourceChain};
 use context::Context;
 use error::HolochainError;
@@ -7,7 +8,6 @@ use hash::HashString;
 use hash_table::entry::Entry;
 use json::ToJson;
 use std::{collections::HashMap, sync::Arc};
-use cas::content::AddressableContent;
 
 /// The state-slice for the Agent.
 /// Holds the agent's source chain and keys.
@@ -166,13 +166,13 @@ pub fn reduce(
 pub mod tests {
     use super::{reduce_commit_entry, reduce_get_entry, ActionResponse, AgentState};
     use action::tests::{test_action_wrapper_commit, test_action_wrapper_get};
+    use cas::content::AddressableContent;
     use chain::{pair::tests::test_pair, tests::test_chain};
     use error::HolochainError;
     use hash_table::entry::tests::test_entry;
     use instance::tests::test_context;
     use json::ToJson;
     use std::{collections::HashMap, sync::Arc};
-    use cas::content::AddressableContent;
 
     /// dummy agent state
     pub fn test_agent_state() -> AgentState {
@@ -253,7 +253,7 @@ pub mod tests {
     /// test response to json
     fn test_commit_response_to_json() {
         assert_eq!(
-            "{\"hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\"}",
+            "{\"address\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\"}",
             ActionResponse::Commit(Ok(test_pair().entry().clone()))
                 .to_json()
                 .unwrap(),
@@ -296,7 +296,7 @@ pub mod tests {
     #[test]
     fn test_link_entries_response_to_json() {
         assert_eq!(
-            "{\"hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\"}",
+            "{\"address\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\"}",
             ActionResponse::LinkEntries(Ok(test_entry()))
                 .to_json()
                 .unwrap(),

--- a/core/src/cas/content.rs
+++ b/core/src/cas/content.rs
@@ -2,7 +2,7 @@ use hash::HashString;
 use multihash::Hash;
 
 /// an Address for some Content
-/// ideally would be the Content but pragmatically must be HashString
+/// ideally would be the Content but pragmatically must be Address
 /// consider what would happen if we had multi GB addresses...
 pub type Address = HashString;
 /// the Content is a String
@@ -20,7 +20,7 @@ pub trait AddressableContent {
     /// it is recommended to implement an "address space" prefix for address algorithms that don't
     /// offer strong cryptographic guarantees like sha et. al.
     fn address(&self) -> Address {
-        HashString::encode_from_str(&self.content(), Hash::SHA2256)
+        Address::encode_from_str(&self.content(), Hash::SHA2256)
     }
     /// the Content that would be stored in a ContentAddressableStorage
     fn content(&self) -> Content;
@@ -46,7 +46,6 @@ pub mod tests {
         content::{Address, AddressableContent, Content},
         storage::ContentAddressableStorage,
     };
-    use hash::HashString;
     use multihash::Hash;
     use std::fmt::{Debug, Write};
 
@@ -90,7 +89,7 @@ pub mod tests {
         fn from_content(content: &Content) -> Self {
             OtherExampleAddressableContent {
                 content: content.clone(),
-                address: HashString::encode_from_str(&content, Hash::SHA2256),
+                address: Address::encode_from_str(&content, Hash::SHA2256),
             }
         }
     }
@@ -102,7 +101,7 @@ pub mod tests {
         pub fn addressable_content_trait_test<T>(
             content: Content,
             expected_content: T,
-            hash_string: String,
+            address_string: String,
         ) where
             T: AddressableContent + Debug + PartialEq + Clone,
         {
@@ -110,7 +109,7 @@ pub mod tests {
 
             assert_eq!(addressable_content, expected_content);
             assert_eq!(content, addressable_content.content());
-            assert_eq!(HashString::from(hash_string), addressable_content.address());
+            assert_eq!(Address::from(address_string), addressable_content.address());
         }
 
         /// test that two different addressable contents would give them same thing

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -146,7 +146,6 @@ impl AddressableContent for Header {
 pub mod tests {
     use cas::content::{Address, AddressableContent};
     use chain::{header::Header, pair::tests::test_pair, tests::test_chain, SourceChain};
-    use hash::HashString;
     use hash_table::{
         entry::tests::{
             test_entry, test_entry_a, test_entry_b, test_entry_type, test_entry_type_a,
@@ -216,7 +215,7 @@ pub mod tests {
 
         assert_eq!(header.entry_address(), &entry.address());
         assert_eq!(header.link(), None);
-        assert_ne!(header.address(), HashString::new());
+        assert_ne!(header.address(), Address::new());
     }
 
     #[test]

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -1,4 +1,4 @@
-use cas::content::{Address, Content, AddressableContent};
+use cas::content::{Address, AddressableContent, Content};
 use error::HolochainError;
 use hash_table::{
     entry::Entry,
@@ -143,7 +143,8 @@ impl AddressableContent for Header {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
+    use cas::content::{Address, AddressableContent};
     use chain::{header::Header, pair::tests::test_pair, tests::test_chain, SourceChain};
     use hash::HashString;
     use hash_table::{
@@ -153,12 +154,14 @@ mod tests {
         },
         sys_entry::ToEntry,
     };
-    use cas::content::Address;
-    use cas::content::AddressableContent;
 
     /// returns a dummy header for use in tests
     pub fn test_header() -> Header {
         test_pair().header().clone()
+    }
+
+    pub fn test_header_address() -> Address {
+        Address::from("Qmc1n5gbUU2QKW6is9ENTqmaTcEjYMBwNkcACCxe3bBDnd".to_string())
     }
 
     #[test]
@@ -331,7 +334,7 @@ mod tests {
 
     #[test]
     /// test header.address() against a known value
-    fn hash_known() {
+    fn known_address() {
         let chain = test_chain();
         let entry_type = test_entry_type();
         let entry = test_entry();
@@ -339,10 +342,7 @@ mod tests {
         // check a known hash
         let header = chain.create_next_header(&entry_type, &entry);
 
-        assert_eq!(
-            Address::from("QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA".to_string()),
-            header.address()
-        );
+        assert_eq!(test_header_address(), header.address());
     }
 
     #[test]

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -3,6 +3,7 @@ pub mod header;
 pub mod pair;
 
 use actor::Protocol;
+use cas::content::{Address, AddressableContent};
 use chain::{
     actor::{AskChain, ChainActor},
     header::Header,
@@ -17,9 +18,7 @@ use hash_table::{
 };
 use json::ToJson;
 use riker::actors::*;
-use cas::content::AddressableContent;
 use serde_json;
-use cas::content::Address;
 
 /// Iterator type for pairs in a chain
 /// next method may panic if there is an error in the underlying table
@@ -206,8 +205,8 @@ pub trait SourceChain {
     /// the newly created and pushed Pair is returned.
     fn push_entry(&mut self, entry_type: &EntryType, entry: &Entry)
         -> Result<Pair, HolochainError>;
-    /// get an Entry by Entry key from the HashTable if it exists
-    fn entry(&self, entry_hash: &HashString) -> Option<Entry>;
+    /// get an Entry by Entry address from the HashTable if it exists
+    fn entry(&self, entry_address: &Address) -> Option<Entry>;
 
     /// pair-oriented version of push_entry()
     fn push_pair(&mut self, pair: &Pair) -> Result<Pair, HolochainError>;
@@ -295,6 +294,7 @@ impl ToJson for Chain {
 pub mod tests {
 
     use super::Chain;
+    use cas::content::AddressableContent;
     use chain::{
         pair::{tests::test_pair, Pair},
         SourceChain,
@@ -310,7 +310,6 @@ pub mod tests {
     };
     use json::ToJson;
     use std::thread;
-    use cas::content::AddressableContent;
 
     /// builds a dummy chain for testing
     pub fn test_chain() -> Chain {
@@ -520,7 +519,10 @@ pub mod tests {
 
             for _ in 1..100 {
                 let pair = chain.push_entry(&entry_type, &entry).unwrap();
-                assert_eq!(Some(pair.entry().clone()), chain.entry(&pair.entry().address()),);
+                assert_eq!(
+                    Some(pair.entry().clone()),
+                    chain.entry(&pair.entry().address()),
+                );
             }
         });
         h.join().unwrap();
@@ -790,7 +792,7 @@ pub mod tests {
             .push_entry(&entry_type_a, &entry_a)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
 
-        let expected_json = "[{\"header\":{\"entry_type\":{\"App\":\"testEntryType\"},\"timestamp\":\"\",\"link\":\"QmahP5TYeaSUtQJ5PHsQv8C8oMnuf3vkezRLdEGpLUKZ36\",\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":\"QmawqBCVVap9KdaakqEHF4JzUjjLhmR7DpM5jgJko8j1rA\"},\"entry\":\"test entry content\"},{\"header\":{\"entry_type\":{\"App\":\"testEntryTypeB\"},\"timestamp\":\"\",\"link\":\"QmSnyVckgLvVRtKpVBMRdkUjFMHLpjFA3ZEtVAURX1Hbg8\",\"entry_hash\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":\"other test entry content\"},{\"header\":{\"entry_type\":{\"App\":\"testEntryType\"},\"timestamp\":\"\",\"link\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":\"test entry content\"}]"
+        let expected_json = "[{\"header\":{\"entry_type\":{\"App\":\"testEntryType\"},\"timestamp\":\"\",\"link\":\"QmR1XSoMwvjoiLG6NC7Zw3iy6cnfQsxjM5bt32thaCGbNU\",\"entry_address\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":\"Qmc1n5gbUU2QKW6is9ENTqmaTcEjYMBwNkcACCxe3bBDnd\"},\"entry\":\"test entry content\"},{\"header\":{\"entry_type\":{\"App\":\"testEntryTypeB\"},\"timestamp\":\"\",\"link\":\"Qmc1n5gbUU2QKW6is9ENTqmaTcEjYMBwNkcACCxe3bBDnd\",\"entry_address\":\"QmPz5jKXsxq7gPVAbPwx5gD2TqHfqB8n25feX5YH18JXrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":\"other test entry content\"},{\"header\":{\"entry_type\":{\"App\":\"testEntryType\"},\"timestamp\":\"\",\"link\":null,\"entry_address\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":\"test entry content\"}]"
         ;
         assert_eq!(
             expected_json,

--- a/core/src/chain/mod.rs
+++ b/core/src/chain/mod.rs
@@ -10,7 +10,6 @@ use chain::{
     pair::Pair,
 };
 use error::HolochainError;
-use hash::HashString;
 use hash_table::{
     entry::Entry,
     sys_entry::{EntryType, ToEntry},
@@ -210,8 +209,8 @@ pub trait SourceChain {
 
     /// pair-oriented version of push_entry()
     fn push_pair(&mut self, pair: &Pair) -> Result<Pair, HolochainError>;
-    /// get a Pair by Pair/Header key from the HashTable if it exists
-    fn pair(&self, pair_hash: &HashString) -> Option<Pair>;
+    /// get a Pair by Pair/Header address from the HashTable if it exists
+    fn pair(&self, pair_address: &Address) -> Option<Pair>;
 }
 
 impl SourceChain for Chain {
@@ -294,12 +293,11 @@ impl ToJson for Chain {
 pub mod tests {
 
     use super::Chain;
-    use cas::content::AddressableContent;
+    use cas::content::{Address, AddressableContent};
     use chain::{
         pair::{tests::test_pair, Pair},
         SourceChain,
     };
-    use hash::HashString;
     use hash_table::{
         actor::tests::test_table_actor,
         entry::tests::{
@@ -607,7 +605,7 @@ pub mod tests {
             .push_entry(&entry_type_a, &entry_a)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
 
-        assert_eq!(None, chain.entry(&HashString::new()));
+        assert_eq!(None, chain.entry(&Address::new()));
         assert_eq!(
             pair_c.entry().clone(),
             chain
@@ -667,7 +665,7 @@ pub mod tests {
             .push_entry(&entry_type_a, &entry_a)
             .expect("pushing a valid entry to an exclusively owned chain shouldn't fail");
 
-        assert_eq!(None, chain.entry(&HashString::new()));
+        assert_eq!(None, chain.entry(&Address::new()));
         // @TODO at this point we have p3 with the same entry key as p1...
         assert_eq!(
             pair_c.entry().clone(),

--- a/core/src/chain/pair.rs
+++ b/core/src/chain/pair.rs
@@ -1,12 +1,11 @@
 use actor::Protocol;
+use cas::content::{AddressableContent, Content};
 use chain::header::Header;
 use error::HolochainError;
 use hash_table::{entry::Entry, HashTable};
 use json::{FromJson, RoundTripJson, ToJson};
 use riker::actors::*;
 use serde_json;
-use cas::content::AddressableContent;
-use cas::content::Content;
 
 /// Struct for holding a source chain "Item"
 /// It is like a pair holding the entry and header separately
@@ -98,12 +97,12 @@ impl RoundTripJson for Pair {}
 #[cfg(test)]
 pub mod tests {
     use super::Pair;
+    use cas::content::AddressableContent;
     use chain::{tests::test_chain, SourceChain};
     use hash_table::entry::tests::{
         test_entry, test_entry_b, test_entry_type, test_entry_type_b, test_entry_unique,
     };
     use json::{FromJson, ToJson};
-    use cas::content::AddressableContent;
 
     /// dummy pair
     pub fn test_pair() -> Pair {
@@ -183,7 +182,7 @@ pub mod tests {
     #[test]
     /// test JSON roundtrip for pairs
     fn json_roundtrip() {
-        let json = "{\"header\":{\"entry_type\":{\"App\":\"testEntryType\"},\"timestamp\":\"\",\"link\":null,\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":\"test entry content\"}"
+        let json = "{\"header\":{\"entry_type\":{\"App\":\"testEntryType\"},\"timestamp\":\"\",\"link\":null,\"entry_address\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"entry_signature\":\"\",\"link_same_type\":null},\"entry\":\"test entry content\"}"
         ;
 
         assert_eq!(json, test_pair().to_json().unwrap());

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -50,9 +50,9 @@ impl HashString {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use cas::content::AddressableContent;
     use hash_table::entry::tests::test_entry;
     use multihash::Hash;
-    use cas::content::AddressableContent;
 
     /// dummy hash based on the key of test_entry()
     pub fn test_hash() -> HashString {

--- a/core/src/hash/mod.rs
+++ b/core/src/hash/mod.rs
@@ -51,12 +51,12 @@ impl HashString {
 pub mod tests {
     use super::*;
     use hash_table::entry::tests::test_entry;
-    use key::Key;
     use multihash::Hash;
+    use cas::content::AddressableContent;
 
     /// dummy hash based on the key of test_entry()
     pub fn test_hash() -> HashString {
-        test_entry().key()
+        test_entry().address()
     }
 
     #[test]
@@ -76,7 +76,7 @@ pub mod tests {
 
         assert_eq!(
             test_hash(),
-            HashString::from(test_entry().key().to_string()),
+            HashString::from(test_entry().address().to_string()),
         );
     }
 

--- a/core/src/hash_table/actor.rs
+++ b/core/src/hash_table/actor.rs
@@ -174,14 +174,13 @@ impl<HT: HashTable> Actor for HashTableActor<HT> {
 
 #[cfg(test)]
 pub mod tests {
-
+    use hash_table::entry::tests::test_entry_address;
     use super::HashTableActor;
     use actor::Protocol;
-    use hash::tests::test_hash;
+    use cas::content::AddressableContent;
     use hash_table::{
         entry::tests::test_entry, memory::tests::test_table, test_util::standard_suite, HashTable,
     };
-    use key::Key;
     use riker::actors::*;
     use std::{sync::mpsc, thread};
 
@@ -195,12 +194,12 @@ pub mod tests {
     fn round_trip() {
         let mut table_actor = test_table_actor();
 
-        assert_eq!(table_actor.entry(&test_hash()).unwrap(), None);
+        assert_eq!(table_actor.entry(&test_entry_address()).unwrap(), None);
 
         table_actor.put_entry(&test_entry()).unwrap();
 
         assert_eq!(
-            table_actor.entry(&test_entry().key()).unwrap().unwrap(),
+            table_actor.entry(&test_entry().address()).unwrap().unwrap(),
             test_entry(),
         );
     }
@@ -217,7 +216,7 @@ pub mod tests {
         let table_actor_thread = table_actor.clone();
         let (tx1, rx1) = mpsc::channel();
         thread::spawn(move || {
-            assert_eq!(table_actor_thread.entry(&test_hash()).unwrap(), None);
+            assert_eq!(table_actor_thread.entry(&test_entry_address()).unwrap(), None);
             // kick off the next thread
             tx1.send(true).unwrap();
         });
@@ -239,7 +238,7 @@ pub mod tests {
         let handle = thread::spawn(move || {
             let entry = rx2.recv().unwrap();
             assert_eq!(
-                table_actor_thread.entry(&entry.key()).unwrap().unwrap(),
+                table_actor_thread.entry(&entry.address()).unwrap().unwrap(),
                 test_entry(),
             );
         });

--- a/core/src/hash_table/entry.rs
+++ b/core/src/hash_table/entry.rs
@@ -61,12 +61,11 @@ impl FromJson for Entry {
 #[cfg(test)]
 pub mod tests {
     use cas::{
-        content::{tests::AddressableContentTestSuite, AddressableContent},
+        content::{tests::AddressableContentTestSuite, Address, AddressableContent},
         storage::tests::ExampleContentAddressableStorage,
     };
     use hash_table::{entry::Entry, sys_entry::EntryType};
     use json::{FromJson, ToJson};
-    use cas::content::Address;
     use snowflake;
 
     /// dummy entry type

--- a/core/src/hash_table/entry_meta.rs
+++ b/core/src/hash_table/entry_meta.rs
@@ -1,6 +1,5 @@
 use cas::content::{Address, AddressableContent, Content};
 use error::HolochainError;
-use hash::HashString;
 use json::{FromJson, RoundTripJson, ToJson};
 use multihash::Hash;
 use serde_json;
@@ -89,7 +88,7 @@ impl EntryMeta {
 
         // @TODO the hashing algo should not be hardcoded
         // @see https://github.com/holochain/holochain-rust/issues/104
-        HashString::encode_from_str(&string_to_address, Hash::SHA2256)
+        Address::encode_from_str(&string_to_address, Hash::SHA2256)
     }
 }
 
@@ -127,8 +126,7 @@ impl AddressableContent for EntryMeta {
 pub mod tests {
 
     use agent::keys::tests::test_keys;
-    use cas::content::AddressableContent;
-    use hash::HashString;
+    use cas::content::{Address, AddressableContent};
     use hash_table::{
         entry::{tests::test_entry, Entry},
         entry_meta::EntryMeta,
@@ -231,25 +229,25 @@ pub mod tests {
         // basic ordering
         let m_1ax = EntryMeta::new(
             &test_keys().node_id(),
-            &HashString::from("1".to_string()),
+            &Address::from("1".to_string()),
             "a",
             "x",
         );
         let m_1ay = EntryMeta::new(
             &test_keys().node_id(),
-            &HashString::from("1".to_string()),
+            &Address::from("1".to_string()),
             "a",
             "y",
         );
         let m_1bx = EntryMeta::new(
             &test_keys().node_id(),
-            &HashString::from("1".to_string()),
+            &Address::from("1".to_string()),
             "b",
             "x",
         );
         let m_2ax = EntryMeta::new(
             &test_keys().node_id(),
-            &HashString::from("2".to_string()),
+            &Address::from("2".to_string()),
             "a",
             "x",
         );

--- a/core/src/hash_table/entry_meta.rs
+++ b/core/src/hash_table/entry_meta.rs
@@ -1,12 +1,10 @@
+use cas::content::{Address, AddressableContent, Content};
 use error::HolochainError;
 use hash::HashString;
 use json::{FromJson, RoundTripJson, ToJson};
 use multihash::Hash;
 use serde_json;
 use std::cmp::Ordering;
-use cas::content::AddressableContent;
-use cas::content::Content;
-use cas::content::Address;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// Meta represents an extended form of EAV (entity-attribute-value) data
@@ -129,6 +127,7 @@ impl AddressableContent for EntryMeta {
 pub mod tests {
 
     use agent::keys::tests::test_keys;
+    use cas::content::AddressableContent;
     use hash::HashString;
     use hash_table::{
         entry::{tests::test_entry, Entry},
@@ -136,7 +135,6 @@ pub mod tests {
     };
     use json::{FromJson, ToJson};
     use std::cmp::Ordering;
-    use cas::content::AddressableContent;
 
     /// dummy test attribute name
     pub fn test_attribute() -> String {
@@ -288,7 +286,7 @@ pub mod tests {
     /// test the RoundTripJson implementation
     fn test_json_round_trip() {
         let meta = test_meta();
-        let expected = "{\"entry_hash\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"attribute\":\"meta-attribute\",\"value\":\"meta value\",\"source\":\"test node id\"}";
+        let expected = "{\"entry_address\":\"QmbXSE38SN3SuJDmHKSSw5qWWegvU7oTxrLDRavWjyxMrT\",\"attribute\":\"meta-attribute\",\"value\":\"meta value\",\"source\":\"test node id\"}";
 
         assert_eq!(expected.to_string(), meta.to_json().unwrap());
         assert_eq!(meta, EntryMeta::from_json(&expected).unwrap());

--- a/core/src/hash_table/entry_meta.rs
+++ b/core/src/hash_table/entry_meta.rs
@@ -1,10 +1,12 @@
 use error::HolochainError;
 use hash::HashString;
 use json::{FromJson, RoundTripJson, ToJson};
-use key::Key;
 use multihash::Hash;
 use serde_json;
 use std::cmp::Ordering;
+use cas::content::AddressableContent;
+use cas::content::Content;
+use cas::content::Address;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// Meta represents an extended form of EAV (entity-attribute-value) data
@@ -17,7 +19,7 @@ use std::cmp::Ordering;
 /// source = the agent making the meta assertion
 /// signature = the asserting agent's signature of the meta assertion
 pub struct EntryMeta {
-    entry_hash: HashString,
+    entry_address: Address,
     attribute: String,
     value: String,
     // @TODO implement local transaction ordering
@@ -32,7 +34,7 @@ pub struct EntryMeta {
 impl Ord for EntryMeta {
     fn cmp(&self, other: &EntryMeta) -> Ordering {
         // we want to sort by entry hash, then attribute name, then attribute value
-        match self.entry_hash.cmp(&other.entry_hash) {
+        match self.entry_address.cmp(&other.entry_address) {
             Ordering::Equal => match self.attribute.cmp(&other.attribute) {
                 Ordering::Equal => self.value.cmp(&other.value),
                 Ordering::Greater => Ordering::Greater,
@@ -54,9 +56,9 @@ impl EntryMeta {
     /// Builds a new Meta from EAV and agent keys, where E is an existing Entry
     /// @TODO need a `from()` to build a local meta from incoming network messages
     /// @see https://github.com/holochain/holochain-rust/issues/140
-    pub fn new(node_id: &str, hash: &HashString, attribute: &str, value: &str) -> EntryMeta {
+    pub fn new(node_id: &str, address: &Address, attribute: &str, value: &str) -> EntryMeta {
         EntryMeta {
-            entry_hash: hash.clone(),
+            entry_address: address.clone(),
             attribute: attribute.into(),
             value: value.into(),
             source: node_id.to_string(),
@@ -64,8 +66,8 @@ impl EntryMeta {
     }
 
     /// getter for entry
-    pub fn entry_hash(&self) -> &HashString {
-        &self.entry_hash
+    pub fn entry_address(&self) -> &Address {
+        &self.entry_address
     }
 
     /// getter for attribute clone
@@ -83,20 +85,13 @@ impl EntryMeta {
         self.source.clone()
     }
 
-    pub fn make_hash(entry_hash: &HashString, attribute_name: &str) -> HashString {
-        let pieces: [String; 2] = [entry_hash.clone().to_string(), attribute_name.to_string()];
-        let string_to_hash = pieces.concat();
+    pub fn make_address(address: &Address, attribute: &str) -> Address {
+        let pieces: [String; 2] = [address.clone().to_string(), attribute.to_string()];
+        let string_to_address = pieces.concat();
 
         // @TODO the hashing algo should not be hardcoded
         // @see https://github.com/holochain/holochain-rust/issues/104
-        HashString::encode_from_str(&string_to_hash, Hash::SHA2256)
-    }
-}
-
-impl Key for EntryMeta {
-    /// the key for HashTable lookups, e.g. table.meta()
-    fn key(&self) -> HashString {
-        HashString::encode_from_serializable(&self, Hash::SHA2256)
+        HashString::encode_from_str(&string_to_address, Hash::SHA2256)
     }
 }
 
@@ -116,6 +111,20 @@ impl FromJson for EntryMeta {
 
 impl RoundTripJson for EntryMeta {}
 
+impl AddressableContent for EntryMeta {
+    fn address(&self) -> Address {
+        EntryMeta::make_address(&self.entry_address, &self.attribute)
+    }
+
+    fn content(&self) -> Content {
+        self.to_json().expect("could not Jsonify EntryMeta Content")
+    }
+
+    fn from_content(content: &Content) -> Self {
+        EntryMeta::from_json(content).expect("could not parse JSON as EntryMeta Content")
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
 
@@ -126,8 +135,8 @@ pub mod tests {
         entry_meta::EntryMeta,
     };
     use json::{FromJson, ToJson};
-    use key::Key;
     use std::cmp::Ordering;
+    use cas::content::AddressableContent;
 
     /// dummy test attribute name
     pub fn test_attribute() -> String {
@@ -160,14 +169,14 @@ pub mod tests {
     }
 
     pub fn test_meta_for(entry: &Entry, attribute: &str, value: &str) -> EntryMeta {
-        EntryMeta::new(&test_keys().node_id(), &entry.key(), attribute, value)
+        EntryMeta::new(&test_keys().node_id(), &entry.address(), attribute, value)
     }
 
     /// returns dummy meta for testing
     pub fn test_meta() -> EntryMeta {
         EntryMeta::new(
             &test_keys().node_id(),
-            &test_entry().key(),
+            &test_entry().address(),
             &test_attribute(),
             &test_value(),
         )
@@ -182,7 +191,7 @@ pub mod tests {
     pub fn test_meta_b() -> EntryMeta {
         EntryMeta::new(
             &test_keys().node_id(),
-            &test_entry().key(),
+            &test_entry().address(),
             &test_attribute_b(),
             &test_value_b(),
         )
@@ -195,9 +204,9 @@ pub mod tests {
     }
 
     #[test]
-    // test meta.entry_hash()
-    fn entry_hash() {
-        assert_eq!(test_meta().entry_hash(), &test_entry().key());
+    // test meta.entry_address()
+    fn entry_address_test() {
+        assert_eq!(test_meta().entry_address(), &test_entry().address());
     }
 
     /// test meta.attribute()

--- a/core/src/hash_table/links_entry.rs
+++ b/core/src/hash_table/links_entry.rs
@@ -2,7 +2,6 @@ use cas::content::{Address, AddressableContent};
 use hash_table::{
     entry::Entry,
     sys_entry::{EntryType, ToEntry},
-    HashString,
 };
 use serde_json;
 
@@ -12,8 +11,8 @@ use serde_json;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Link {
-    base: HashString,
-    target: HashString,
+    base: Address,
+    target: Address,
     tag: String,
 }
 
@@ -61,12 +60,7 @@ pub struct LinkEntry {
 }
 
 impl LinkEntry {
-    pub fn new(
-        action_kind: LinkActionKind,
-        base: &HashString,
-        target: &HashString,
-        tag: &str,
-    ) -> Self {
+    pub fn new(action_kind: LinkActionKind, base: &Address, target: &Address, tag: &str) -> Self {
         LinkEntry {
             action_kind: action_kind,
             link: Link::new(base, target, tag),
@@ -133,8 +127,8 @@ pub mod tests {
 
     pub fn create_test_link() -> Link {
         Link::new(
-            &HashString::from("12".to_string()),
-            &HashString::from("34".to_string()),
+            &Address::from("12".to_string()),
+            &Address::from("34".to_string()),
             "fake",
         )
     }
@@ -145,16 +139,16 @@ pub mod tests {
 
     pub fn create_test_link_b() -> Link {
         Link::new(
-            &HashString::from("56".to_string()),
-            &HashString::from("78".to_string()),
+            &Address::from("56".to_string()),
+            &Address::from("78".to_string()),
             "faux",
         )
     }
 
     pub fn create_test_link_c() -> Link {
         Link::new(
-            &HashString::from("90".to_string()),
-            &HashString::from("ab".to_string()),
+            &Address::from("90".to_string()),
+            &Address::from("ab".to_string()),
             "fake",
         )
     }

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -2,8 +2,9 @@ use error::HolochainError;
 
 use hash::HashString;
 use hash_table::{entry::Entry, entry_meta::EntryMeta, HashTable};
-use key::Key;
 use std::collections::HashMap;
+use cas::content::Address;
+use cas::content::AddressableContent;
 
 /// Struct implementing the HashTable Trait by storing the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
@@ -23,21 +24,21 @@ impl MemTable {
 
 impl HashTable for MemTable {
     fn put_entry(&mut self, entry: &Entry) -> Result<(), HolochainError> {
-        self.entries.insert(entry.key(), entry.clone());
+        self.entries.insert(entry.address(), entry.clone());
         Ok(())
     }
 
-    fn entry(&self, key: &HashString) -> Result<Option<Entry>, HolochainError> {
-        Ok(self.entries.get(key).cloned())
+    fn entry(&self, address: &Address) -> Result<Option<Entry>, HolochainError> {
+        Ok(self.entries.get(address).cloned())
     }
 
     fn assert_meta(&mut self, meta: &EntryMeta) -> Result<(), HolochainError> {
-        self.metas.insert(meta.key(), meta.clone());
+        self.metas.insert(meta.address(), meta.clone());
         Ok(())
     }
 
-    fn get_meta(&mut self, key: &HashString) -> Result<Option<EntryMeta>, HolochainError> {
-        Ok(self.metas.get(key).cloned())
+    fn get_meta(&mut self, address: &Address) -> Result<Option<EntryMeta>, HolochainError> {
+        Ok(self.metas.get(address).cloned())
     }
 
     /// Return all the Metas for an entry
@@ -45,7 +46,7 @@ impl HashTable for MemTable {
         let mut vec_meta = self
             .metas
             .values()
-            .filter(|&m| m.entry_hash() == &entry.key())
+            .filter(|&m| m.entry_address() == &entry.address())
             .cloned()
             .collect::<Vec<EntryMeta>>();
         // @TODO should this be sorted at all at this point?

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -1,10 +1,9 @@
 use error::HolochainError;
 
+use cas::content::{Address, AddressableContent};
 use hash::HashString;
 use hash_table::{entry::Entry, entry_meta::EntryMeta, HashTable};
 use std::collections::HashMap;
-use cas::content::Address;
-use cas::content::AddressableContent;
 
 /// Struct implementing the HashTable Trait by storing the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]

--- a/core/src/hash_table/memory/mod.rs
+++ b/core/src/hash_table/memory/mod.rs
@@ -1,15 +1,14 @@
 use error::HolochainError;
 
 use cas::content::{Address, AddressableContent};
-use hash::HashString;
 use hash_table::{entry::Entry, entry_meta::EntryMeta, HashTable};
 use std::collections::HashMap;
 
 /// Struct implementing the HashTable Trait by storing the HashTable in memory
 #[derive(Serialize, Debug, Clone, PartialEq, Default)]
 pub struct MemTable {
-    entries: HashMap<HashString, Entry>,
-    metas: HashMap<HashString, EntryMeta>,
+    entries: HashMap<Address, Entry>,
+    metas: HashMap<Address, EntryMeta>,
 }
 
 impl MemTable {

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -12,7 +12,6 @@ pub mod test_util;
 use agent::keys::Keys;
 use cas::content::{Address, AddressableContent};
 use error::HolochainError;
-use hash::HashString;
 use hash_table::{
     entry::Entry,
     entry_meta::EntryMeta,

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -9,15 +9,16 @@ pub mod sys_entry;
 #[cfg(test)]
 pub mod test_util;
 
+use cas::content::Address;
 use agent::keys::Keys;
 use error::HolochainError;
 use hash::HashString;
+use cas::content::AddressableContent;
 use hash_table::{
     entry::Entry,
     entry_meta::EntryMeta,
     status::{CrudStatus, LINK_NAME, STATUS_NAME},
 };
-use key::Key;
 
 /// Trait of the data structure storing the source chain
 /// source chain is stored as a hash table of Headers and Entries.
@@ -53,7 +54,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
         // @see https://github.com/holochain/holochain-rust/issues/142
         self.assert_meta(&EntryMeta::new(
             &keys.node_id(),
-            &old.key(),
+            &old.address(),
             STATUS_NAME,
             &CrudStatus::MODIFIED.bits().to_string(),
         ))?;
@@ -63,9 +64,9 @@ pub trait HashTable: Send + Sync + Clone + 'static {
         // @see https://github.com/holochain/holochain-rust/issues/142
         self.assert_meta(&EntryMeta::new(
             &keys.node_id(),
-            &old.key(),
+            &old.address(),
             LINK_NAME,
-            &new.key().to_string(),
+            &new.address().to_string(),
         ))
     }
 
@@ -74,7 +75,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
         // Set the crud-status EntryMeta to DELETED
         self.assert_meta(&EntryMeta::new(
             &keys.node_id(),
-            &entry.key(),
+            &entry.address(),
             STATUS_NAME,
             &CrudStatus::DELETED.bits().to_string(),
         ))
@@ -83,18 +84,18 @@ pub trait HashTable: Send + Sync + Clone + 'static {
     // Meta
     /// Assert a given Meta in the HashTable.
     fn assert_meta(&mut self, meta: &EntryMeta) -> Result<(), HolochainError>;
-    /// Lookup a Meta from the HashTable by key.
-    fn get_meta(&mut self, key: &HashString) -> Result<Option<EntryMeta>, HolochainError>;
+    /// Lookup a Meta from the HashTable by address.
+    fn get_meta(&mut self, address: &Address) -> Result<Option<EntryMeta>, HolochainError>;
     /// Lookup all Meta for a given Entry.
     fn metas_from_entry(&mut self, entry: &Entry) -> Result<Vec<EntryMeta>, HolochainError>;
     /// Lookup a Meta from a request.
     fn meta_from_request(
         &mut self,
-        entry_hash: HashString,
+        entry_address: Address,
         attribute_name: &str,
     ) -> Result<Option<EntryMeta>, HolochainError> {
-        let key = EntryMeta::make_hash(&entry_hash, attribute_name);
-        self.get_meta(&key)
+        let address = EntryMeta::make_address(&entry_address, attribute_name);
+        self.get_meta(&address)
     }
 
     // query

--- a/core/src/hash_table/mod.rs
+++ b/core/src/hash_table/mod.rs
@@ -9,11 +9,10 @@ pub mod sys_entry;
 #[cfg(test)]
 pub mod test_util;
 
-use cas::content::Address;
 use agent::keys::Keys;
+use cas::content::{Address, AddressableContent};
 use error::HolochainError;
 use hash::HashString;
-use cas::content::AddressableContent;
 use hash_table::{
     entry::Entry,
     entry_meta::EntryMeta,
@@ -37,7 +36,7 @@ pub trait HashTable: Send + Sync + Clone + 'static {
     /// Add an Entry to the HashTable, analogous to chain.push() but ordering is not enforced.
     fn put_entry(&mut self, entry: &Entry) -> Result<(), HolochainError>;
     /// Lookup an Entry from the HashTable by key.
-    fn entry(&self, key: &HashString) -> Result<Option<Entry>, HolochainError>;
+    fn entry(&self, address: &Address) -> Result<Option<Entry>, HolochainError>;
 
     /// Modify an existing Entry (by adding a new one and flagging the old one as MODIFIED)
     fn modify_entry(

--- a/core/src/hash_table/test_util.rs
+++ b/core/src/hash_table/test_util.rs
@@ -1,4 +1,5 @@
 use agent::keys::tests::test_keys;
+use cas::content::AddressableContent;
 use hash_table::{
     entry::tests::test_entry_unique,
     entry_meta::{
@@ -10,7 +11,6 @@ use hash_table::{
     status::{CrudStatus, LINK_NAME, STATUS_NAME},
     HashTable,
 };
-use cas::content::AddressableContent;
 
 // standard tests that should pass for every hash table implementation
 
@@ -82,7 +82,10 @@ pub fn test_meta_round_trip<HT: HashTable>(table: &mut HT) {
     table
         .assert_meta(&meta)
         .expect("asserting metadata shouldn't fail");
-    assert_eq!(Some(&meta), table.get_meta(&meta.address()).unwrap().as_ref());
+    assert_eq!(
+        Some(&meta),
+        table.get_meta(&meta.address()).unwrap().as_ref()
+    );
 }
 
 /// assert a couple of unique metas against a single entry

--- a/core/src/hash_table/test_util.rs
+++ b/core/src/hash_table/test_util.rs
@@ -10,7 +10,7 @@ use hash_table::{
     status::{CrudStatus, LINK_NAME, STATUS_NAME},
     HashTable,
 };
-use key::Key;
+use cas::content::AddressableContent;
 
 // standard tests that should pass for every hash table implementation
 
@@ -19,7 +19,7 @@ pub fn test_round_trip<HT: HashTable>(table: &mut HT) {
     table
         .put_entry(&entry)
         .expect("should be able to commit valid entry");
-    assert_eq!(table.entry(&entry.key()), Ok(Some(entry)));
+    assert_eq!(table.entry(&entry.address()), Ok(Some(entry)));
 }
 
 pub fn test_modify<HT: HashTable>(table: &mut HT) {
@@ -35,13 +35,13 @@ pub fn test_modify<HT: HashTable>(table: &mut HT) {
         vec![
             EntryMeta::new(
                 &test_keys().node_id(),
-                &entry_1.key(),
+                &entry_1.address(),
                 LINK_NAME,
-                &entry_2.key().to_string(),
+                &entry_2.address().to_string(),
             ),
             EntryMeta::new(
                 &test_keys().node_id(),
-                &entry_1.key(),
+                &entry_1.address(),
                 STATUS_NAME,
                 &CrudStatus::MODIFIED.bits().to_string(),
             ),
@@ -66,7 +66,7 @@ pub fn test_retract<HT: HashTable>(table: &mut HT) {
     assert_eq!(
         vec![EntryMeta::new(
             &test_keys().node_id(),
-            &entry.key(),
+            &entry.address(),
             STATUS_NAME,
             &CrudStatus::DELETED.bits().to_string(),
         )],
@@ -77,12 +77,12 @@ pub fn test_retract<HT: HashTable>(table: &mut HT) {
 pub fn test_meta_round_trip<HT: HashTable>(table: &mut HT) {
     let meta = test_meta();
 
-    assert_eq!(None, table.get_meta(&meta.key()).unwrap());
+    assert_eq!(None, table.get_meta(&meta.address()).unwrap());
 
     table
         .assert_meta(&meta)
         .expect("asserting metadata shouldn't fail");
-    assert_eq!(Some(&meta), table.get_meta(&meta.key()).unwrap().as_ref());
+    assert_eq!(Some(&meta), table.get_meta(&meta.address()).unwrap().as_ref());
 }
 
 /// assert a couple of unique metas against a single entry

--- a/core/src/key.rs
+++ b/core/src/key.rs
@@ -1,6 +1,0 @@
-use hash::HashString;
-
-pub trait Key {
-    /// returns the key for self that can be used in key/value contexts
-    fn key(&self) -> HashString;
-}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -46,7 +46,6 @@ pub mod hash;
 pub mod hash_table;
 pub mod instance;
 pub mod json;
-pub mod key;
 pub mod logger;
 pub mod nucleus;
 pub mod persister;

--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -1,5 +1,6 @@
 extern crate futures;
 use action::{Action, ActionWrapper};
+use cas::content::AddressableContent;
 use context::Context;
 use futures::{future, Async, Future};
 use hash::HashString;
@@ -21,7 +22,7 @@ pub fn validate_entry(
     context: &Arc<Context>,
 ) -> Box<dyn Future<Item = HashString, Error = String>> {
     let id = snowflake::ProcessUniqueId::new();
-    let hash = entry.hash();
+    let address = entry.address();
 
     match context
         .state()
@@ -39,7 +40,7 @@ pub fn validate_entry(
         }
         Some(zome_name) => {
             let id = id.clone();
-            let hash = hash.clone();
+            let address = address.clone();
             let entry = entry.clone();
             let context = context.clone();
             thread::spawn(move || {
@@ -58,7 +59,7 @@ pub fn validate_entry(
                 context
                     .action_channel
                     .send(ActionWrapper::new(Action::ReturnValidationResult((
-                        (id, hash),
+                        (id, address),
                         validation_result,
                     ))))
                     .expect("action channel to be open in reducer");
@@ -68,7 +69,7 @@ pub fn validate_entry(
 
     Box::new(ValidationFuture {
         context: context.clone(),
-        key: (id, hash),
+        key: (id, address),
     })
 }
 

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -78,7 +78,6 @@ pub mod tests {
 
     use cas::content::AddressableContent;
     use hash_table::entry::tests::{test_entry, test_entry_type};
-    use key::Key;
     use nucleus::ribosome::{
         api::{commit::CommitAppEntryArgs, tests::test_zome_api_function_runtime, ZomeApiFunction},
         Defn,
@@ -109,7 +108,7 @@ pub mod tests {
 
         assert_eq!(
             runtime.result,
-            format!(r#"{{"hash":"{}"}}"#, test_entry().key()) + "\u{0}",
+            format!(r#"{{"address":"{}"}}"#, test_entry().address()) + "\u{0}",
         );
     }
 

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -78,9 +78,9 @@ mod tests {
     extern crate test_utils;
     extern crate wabt;
 
-    use cas::content::AddressableContent;
     use self::wabt::Wat2Wasm;
     use super::GetAppEntryArgs;
+    use cas::content::AddressableContent;
     use chain::SourceChain;
     use hash_table::entry::tests::test_entry;
     use instance::tests::{test_context_and_logger, test_instance};

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -78,12 +78,12 @@ mod tests {
     extern crate test_utils;
     extern crate wabt;
 
+    use cas::content::AddressableContent;
     use self::wabt::Wat2Wasm;
     use super::GetAppEntryArgs;
     use chain::SourceChain;
     use hash_table::entry::tests::test_entry;
     use instance::tests::{test_context_and_logger, test_instance};
-    use key::Key;
     use nucleus::{
         ribosome::api::{
             call,
@@ -98,7 +98,7 @@ mod tests {
     /// dummy get args from standard test entry
     pub fn test_get_args_bytes() -> Vec<u8> {
         let args = GetAppEntryArgs {
-            key: test_entry().hash().into(),
+            key: test_entry().address().into(),
         };
         serde_json::to_string(&args).unwrap().into_bytes()
     }
@@ -188,7 +188,7 @@ mod tests {
                 .top_pair()
                 .expect("could not get top pair")
                 .expect("top pair was None")
-                .key()
+                .address()
         );
 
         let commit_call = ZomeFnCall::new(
@@ -207,7 +207,7 @@ mod tests {
 
         assert_eq!(
             commit_runtime.result,
-            format!(r#"{{"hash":"{}"}}"#, test_entry().key()) + "\u{0}",
+            format!(r#"{{"address":"{}"}}"#, test_entry().address()) + "\u{0}",
         );
 
         let get_call = ZomeFnCall::new(

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -1,6 +1,6 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
-use hash::HashString;
+use cas::content::Address;
 use holochain_wasm_utils::error::RibosomeReturnCode;
 use json::ToJson;
 use nucleus::ribosome::api::Runtime;
@@ -10,7 +10,7 @@ use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 #[derive(Deserialize, Default, Debug, Serialize)]
 struct GetAppEntryArgs {
-    key: HashString,
+    address: Address,
 }
 
 /// ZomeApiFunction::GetAppEntry function code
@@ -30,7 +30,7 @@ pub fn invoke_get_entry(
     }
     let input = res_entry.unwrap();
 
-    let action_wrapper = ActionWrapper::new(Action::GetEntry(input.key));
+    let action_wrapper = ActionWrapper::new(Action::GetEntry(input.address));
 
     let (sender, receiver) = channel();
     ::instance::dispatch_action_with_observer(
@@ -98,7 +98,7 @@ mod tests {
     /// dummy get args from standard test entry
     pub fn test_get_args_bytes() -> Vec<u8> {
         let args = GetAppEntryArgs {
-            key: test_entry().address().into(),
+            address: test_entry().address().into(),
         };
         serde_json::to_string(&args).unwrap().into_bytes()
     }

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -1,6 +1,6 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
-use hash::HashString;
+use cas::content::Address;
 use holochain_wasm_utils::error::RibosomeReturnCode;
 use nucleus::ribosome::api::Runtime;
 use serde_json;
@@ -9,13 +9,13 @@ use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 #[derive(Deserialize, Default, Debug, Serialize, Clone, PartialEq, Eq, Hash)]
 pub struct GetLinksArgs {
-    pub entry_hash: HashString,
+    pub entry_address: Address,
     pub tag: String,
 }
 
 impl GetLinksArgs {
     pub fn to_attribute_name(&self) -> String {
-        format!("link:{}:{}", &self.entry_hash, &self.tag)
+        format!("link:{}:{}", &self.entry_address, &self.tag)
     }
 }
 

--- a/core/src/nucleus/state.rs
+++ b/core/src/nucleus/state.rs
@@ -1,5 +1,5 @@
+use cas::content::Address;
 use error::HolochainError;
-use hash::HashString;
 use holochain_dna::Dna;
 use nucleus::ZomeFnCall;
 use snowflake;
@@ -32,7 +32,7 @@ pub struct NucleusState {
     // @TODO should this use the standard ActionWrapper/ActionResponse format?
     // @see https://github.com/holochain/holochain-rust/issues/196
     pub zome_calls: HashMap<ZomeFnCall, Option<Result<String, HolochainError>>>,
-    pub validation_results: HashMap<(snowflake::ProcessUniqueId, HashString), ValidationResult>,
+    pub validation_results: HashMap<(snowflake::ProcessUniqueId, Address), ValidationResult>,
 }
 
 impl NucleusState {


### PR DESCRIPTION
merges a lot of concepts

- remove `key::Key` for `AddressableContent`
- remove ad-hoc `foo.hash()` fns for `foo.address()`
- use `Address` instead of `HashString` where it makes sense
- implements `AddressableContent` for `Header` and `EntryMeta` and `Pair` to facilitate the above