### PR TITLE
FilesystemStorageActor a.k.a. thread safety for file CAS

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,5 +1,5 @@
 use agent::keys::Keys;
-use cas::content::Address;
+use cas::content::{Address, Content};
 use chain::pair::Pair;
 use error::HolochainError;
 use futures::executor::block_on;
@@ -18,6 +18,15 @@ use riker_patterns::ask::ask;
 /// currently this is flat but may be nested/namespaced in the future or multi-protocol riker
 /// @see https://github.com/riker-rs/riker/issues/17
 pub enum Protocol {
+    CasAdd(Address, Content),
+    CasAddResult(Result<(), HolochainError>),
+
+    CasFetch(Address),
+    CasFetchResult(Result<Option<Content>, HolochainError>),
+
+    CasContains(Address),
+    CasContainsResult(Result<bool, HolochainError>),
+
     /// Chain::set_top_pair()
     SetTopPair(Option<Pair>),
     SetTopPairResult(Result<Option<Pair>, HolochainError>),

--- a/core/src/cas/file/actor.rs
+++ b/core/src/cas/file/actor.rs
@@ -63,7 +63,7 @@ impl FilesystemStorageActor {
     }
 
     /// filesystem CAS add. NOT thread safe.
-    fn unsafe_add(&self, address: &Address, content: &Content) -> Result<(), HolochainError> {
+    fn unthreadable_add(&self, address: &Address, content: &Content) -> Result<(), HolochainError> {
         // @TODO be more efficient here
         // @see https://github.com/holochain/holochain-rust/issues/248
         create_dir_all(&self.dir_path)?;
@@ -71,13 +71,13 @@ impl FilesystemStorageActor {
     }
 
     /// filesystem CAS contains. NOT thread safe.
-    fn unsafe_contains(&self, address: &Address) -> Result<bool, HolochainError> {
+    fn unthreadable_contains(&self, address: &Address) -> Result<bool, HolochainError> {
         Ok(Path::new(&self.address_to_path(address)).is_file())
     }
 
     /// filesystem CAS fetch. NOT thread safe.
-    fn unsafe_fetch(&self, address: &Address) -> Result<Option<Content>, HolochainError> {
-        if self.unsafe_contains(&address)? {
+    fn unthreadable_fetch(&self, address: &Address) -> Result<Option<Content>, HolochainError> {
+        if self.unthreadable_contains(&address)? {
             Ok(Some(read_to_string(self.address_to_path(address))?))
         } else {
             Ok(None)
@@ -98,13 +98,13 @@ impl Actor for FilesystemStorageActor {
             .try_tell(
                 match message {
                     Protocol::CasAdd(address, content) => {
-                        Protocol::CasAddResult(self.unsafe_add(&address, &content))
+                        Protocol::CasAddResult(self.unthreadable_add(&address, &content))
                     }
                     Protocol::CasContains(address) => {
-                        Protocol::CasContainsResult(self.unsafe_contains(&address))
+                        Protocol::CasContainsResult(self.unthreadable_contains(&address))
                     }
                     Protocol::CasFetch(address) => {
-                        Protocol::CasFetchResult(self.unsafe_fetch(&address))
+                        Protocol::CasFetchResult(self.unthreadable_fetch(&address))
                     }
                     _ => unreachable!(),
                 },

--- a/core/src/cas/file/actor.rs
+++ b/core/src/cas/file/actor.rs
@@ -6,6 +6,7 @@ use cas::file::FilesystemStorage;
 use cas::content::Address;
 use cas::content::Content;
 use std::fs::create_dir_all;
+use std::fs::write;
 
 pub struct FilesystemStorageActor {
     /// path to the directory where content will be saved to disk
@@ -30,7 +31,7 @@ impl FilesystemStorageActor {
         })
     }
 
-    fn unsafe_add(address: &Address, content: &Content) -> Result<(), HolochainError> {
+    fn unsafe_add(&self, address: &Address, content: &Content) -> Result<(), HolochainError> {
         // @TODO be more efficient here
         // @see https://github.com/holochain/holochain-rust/issues/248
         create_dir_all(&self.dir_path)?;

--- a/core/src/cas/file/actor.rs
+++ b/core/src/cas/file/actor.rs
@@ -1,12 +1,11 @@
-use std::fs::Path;
+use actor::{Protocol, SYS};
+use cas::content::{Address, Content};
 use error::HolochainError;
-use actor::Protocol;
 use riker::actors::*;
-use cas::file::FilesystemStorage;
-use cas::content::Address;
-use cas::content::Content;
-use std::fs::create_dir_all;
-use std::fs::write;
+use std::{
+    fs::{create_dir_all, read_to_string, write},
+    path::{Path, MAIN_SEPARATOR},
+};
 
 pub struct FilesystemStorageActor {
     /// path to the directory where content will be saved to disk
@@ -14,30 +13,94 @@ pub struct FilesystemStorageActor {
 }
 
 impl FilesystemStorageActor {
-    fn new_ref(dir_path: String) -> Result<ActorRef<Protocol>, HolochainError> {
-        let canonical = Path::new(dir_path).canonicalize()?;
+    pub fn new(dir_path: String) -> FilesystemStorageActor {
+        FilesystemStorageActor { dir_path }
+    }
+
+    /// actor() for riker
+    fn actor(dir_path: String) -> BoxActor<Protocol> {
+        Box::new(FilesystemStorageActor::new(dir_path))
+    }
+
+    /// props() for riker
+    fn props(dir_path: String) -> BoxActorProd<Protocol> {
+        Props::new_args(Box::new(FilesystemStorageActor::actor), dir_path)
+    }
+
+    pub fn new_ref(dir_path: String) -> Result<ActorRef<Protocol>, HolochainError> {
+        let canonical = Path::new(&dir_path).canonicalize()?;
         if !canonical.is_dir() {
             return Err(HolochainError::IoError(
                 "path is not a directory or permissions don't allow access".to_string(),
             ));
         }
-        Ok(FilesystemStorage {
-            dir_path: canonical
-                .to_str()
-                .ok_or_else(|| {
-                    HolochainError::IoError("could not convert path to string".to_string())
-                })?
-                .to_string(),
-        })
+        let dir_path = canonical
+            .to_str()
+            .ok_or_else(|| HolochainError::IoError("could not convert path to string".to_string()))?
+            .to_string();
+        Ok(SYS.actor_of(
+            FilesystemStorageActor::props(dir_path.clone()),
+            // always return the same reference to the same actor for the same path
+            // consistency here provides safety for CAS methods
+            &format!("filesystem_storage_actor/{}", dir_path),
+        )?)
     }
 
+    /// builds an absolute path for an AddressableContent address
+    fn address_to_path(&self, address: &Address) -> String {
+        // using .txt extension because content is arbitrary and controlled by the
+        // AddressableContent trait implementation
+        format!("{}{}{}.txt", self.dir_path, MAIN_SEPARATOR, address)
+    }
+
+    /// filesystem CAS add. NOT thread safe.
     fn unsafe_add(&self, address: &Address, content: &Content) -> Result<(), HolochainError> {
         // @TODO be more efficient here
         // @see https://github.com/holochain/holochain-rust/issues/248
         create_dir_all(&self.dir_path)?;
-        Ok(write(
-            self.address_to_path(address),
-            content,
-        )?)
+        Ok(write(self.address_to_path(address), content)?)
+    }
+
+    /// filesystem CAS contains. NOT thread safe.
+    fn unsafe_contains(&self, address: &Address) -> Result<bool, HolochainError> {
+        Ok(Path::new(&self.address_to_path(address)).is_file())
+    }
+
+    /// filesystem CAS fetch. NOT thread safe.
+    fn unsafe_fetch(&self, address: &Address) -> Result<Option<Content>, HolochainError> {
+        if self.unsafe_contains(&address)? {
+            Ok(Some(read_to_string(self.address_to_path(address))?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Actor for FilesystemStorageActor {
+    type Msg = Protocol;
+
+    fn receive(
+        &mut self,
+        context: &Context<Self::Msg>,
+        message: Self::Msg,
+        sender: Option<ActorRef<Self::Msg>>,
+    ) {
+        sender
+            .try_tell(
+                match message {
+                    Protocol::CasAdd(address, content) => {
+                        Protocol::CasAddResult(self.unsafe_add(&address, &content))
+                    }
+                    Protocol::CasContains(address) => {
+                        Protocol::CasContainsResult(self.unsafe_contains(&address))
+                    }
+                    Protocol::CasFetch(address) => {
+                        Protocol::CasFetchResult(self.unsafe_fetch(&address))
+                    }
+                    _ => unreachable!(),
+                },
+                Some(context.myself()),
+            )
+            .expect("failed to tell FilesystemStorage sender");
     }
 }

--- a/core/src/cas/file/actor.rs
+++ b/core/src/cas/file/actor.rs
@@ -1,0 +1,42 @@
+use std::fs::Path;
+use error::HolochainError;
+use actor::Protocol;
+use riker::actors::*;
+use cas::file::FilesystemStorage;
+use cas::content::Address;
+use cas::content::Content;
+use std::fs::create_dir_all;
+
+pub struct FilesystemStorageActor {
+    /// path to the directory where content will be saved to disk
+    dir_path: String,
+}
+
+impl FilesystemStorageActor {
+    fn new_ref(dir_path: String) -> Result<ActorRef<Protocol>, HolochainError> {
+        let canonical = Path::new(dir_path).canonicalize()?;
+        if !canonical.is_dir() {
+            return Err(HolochainError::IoError(
+                "path is not a directory or permissions don't allow access".to_string(),
+            ));
+        }
+        Ok(FilesystemStorage {
+            dir_path: canonical
+                .to_str()
+                .ok_or_else(|| {
+                    HolochainError::IoError("could not convert path to string".to_string())
+                })?
+                .to_string(),
+        })
+    }
+
+    fn unsafe_add(address: &Address, content: &Content) -> Result<(), HolochainError> {
+        // @TODO be more efficient here
+        // @see https://github.com/holochain/holochain-rust/issues/248
+        create_dir_all(&self.dir_path)?;
+        Ok(write(
+            self.address_to_path(address),
+            content,
+        )?)
+    }
+}

--- a/core/src/cas/file/mod.rs
+++ b/core/src/cas/file/mod.rs
@@ -16,7 +16,7 @@ pub struct FilesystemStorage {
 impl FilesystemStorage {
     pub fn new(dir_path: &str) -> Result<FilesystemStorage, HolochainError> {
         Ok(FilesystemStorage {
-            dir_actor: FilesystemStorageActor::new_ref(dir_path.to_string())?,
+            dir_actor: FilesystemStorageActor::new_ref(dir_path)?,
         })
     }
 }

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -2,6 +2,7 @@ use self::HolochainError::*;
 use futures::channel::oneshot::Canceled as FutureCanceled;
 use holochain_dna::DnaError;
 use json::ToJson;
+use riker::actor::CreateError as RikerCreateError;
 use serde_json::Error as SerdeError;
 use std::{
     error::Error,
@@ -103,6 +104,12 @@ impl From<SerdeError> for HolochainError {
 impl From<FutureCanceled> for HolochainError {
     fn from(_: FutureCanceled) -> Self {
         HolochainError::ErrorGeneric("Failed future".to_string())
+    }
+}
+
+impl From<RikerCreateError> for HolochainError {
+    fn from(_: RikerCreateError) -> Self {
+        HolochainError::ErrorGeneric(String::from("Failed to create actor in system"))
     }
 }
 


### PR DESCRIPTION
i believe this _should_ make the file backed CAS safe to use across threads

there is an actor under the hood
the actor reference re-uses existing actor reference paths in riker if the same dir is called
the actor reference is the new internal state of `FilesystemStorage` rather than the path