### PR TITLE
removing pair from chain

### DIFF
--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,6 +1,6 @@
 use agent::keys::Keys;
 use cas::content::Address;
-use chain::pair::Pair;
+use chain::header::ChainHeader;
 use error::HolochainError;
 use futures::executor::block_on;
 use hash_table::{
@@ -18,13 +18,13 @@ use riker_patterns::ask::ask;
 /// currently this is flat but may be nested/namespaced in the future or multi-protocol riker
 /// @see https://github.com/riker-rs/riker/issues/17
 pub enum Protocol {
-    /// Chain::set_top_pair()
-    SetTopPair(Option<Pair>),
-    SetTopPairResult(Result<Option<Pair>, HolochainError>),
+    /// Chain::set_top_chain_header()
+    SetTopChainHeader(Option<ChainHeader>),
+    SetTopChainHeaderResult(Result<Option<ChainHeader>, HolochainError>),
 
-    /// Chain::top_pair()
-    GetTopPair,
-    GetTopPairResult(Option<Pair>),
+    /// Chain::top_chain_header()
+    GetTopChainHeader,
+    GetTopChainHeaderResult(Option<ChainHeader>),
 
     /// HashTable::setup()
     Setup,

--- a/core/src/actor.rs
+++ b/core/src/actor.rs
@@ -1,7 +1,6 @@
 use agent::keys::Keys;
-use cas::content::Address;
-use chain::header::ChainHeader;
 use cas::content::{Address, Content};
+use chain::header::ChainHeader;
 use error::HolochainError;
 use futures::executor::block_on;
 use hash_table::{

--- a/core/src/chain/actor.rs
+++ b/core/src/chain/actor.rs
@@ -1,5 +1,5 @@
 use actor::{AskSelf, Protocol, SYS};
-use chain::pair::Pair;
+use chain::header::ChainHeader;
 use error::HolochainError;
 use riker::actors::*;
 use snowflake;
@@ -7,33 +7,41 @@ use snowflake;
 /// anything that can be asked of Chain and block on responses
 /// needed to support implementing ask on upstream ActorRef from riker
 pub trait AskChain {
-    /// Protocol::SetTopPair -> Protocol::SetTopPairResult
-    fn set_top_pair(&self, &Option<Pair>) -> Result<Option<Pair>, HolochainError>;
-    /// Protocol::GetTopPair -> Protocol::GetTopPairResult
-    fn top_pair(&self) -> Result<Option<Pair>, HolochainError>;
+    /// Protocol::SetTopChainHeader -> Protocol::SetTopChainHeaderResult
+    fn set_top_chain_header(
+        &self,
+        &Option<ChainHeader>,
+    ) -> Result<Option<ChainHeader>, HolochainError>;
+    /// Protocol::GetTopChainHeader -> Protocol::GetTopChainHeaderResult
+    fn top_chain_header(&self) -> Result<Option<ChainHeader>, HolochainError>;
 }
 
 impl AskChain for ActorRef<Protocol> {
-    fn set_top_pair(&self, pair: &Option<Pair>) -> Result<Option<Pair>, HolochainError> {
-        let response = self.block_on_ask(Protocol::SetTopPair(pair.clone()))?;
-        unwrap_to!(response => Protocol::SetTopPairResult).clone()
+    fn set_top_chain_header(
+        &self,
+        chain_header: &Option<ChainHeader>,
+    ) -> Result<Option<ChainHeader>, HolochainError> {
+        let response = self.block_on_ask(Protocol::SetTopChainHeader(chain_header.clone()))?;
+        unwrap_to!(response => Protocol::SetTopChainHeaderResult).clone()
     }
 
-    fn top_pair(&self) -> Result<Option<Pair>, HolochainError> {
-        let response = self.block_on_ask(Protocol::GetTopPair)?;
-        Ok(unwrap_to!(response => Protocol::GetTopPairResult).clone())
+    fn top_chain_header(&self) -> Result<Option<ChainHeader>, HolochainError> {
+        let response = self.block_on_ask(Protocol::GetTopChainHeader)?;
+        Ok(unwrap_to!(response => Protocol::GetTopChainHeaderResult).clone())
     }
 }
 
 pub struct ChainActor {
-    top_pair: Option<Pair>,
+    top_chain_header: Option<ChainHeader>,
 }
 
 impl ChainActor {
     /// returns a new ChainActor struct
     /// internal use for riker, use new_ref instead
     fn new() -> ChainActor {
-        ChainActor { top_pair: None }
+        ChainActor {
+            top_chain_header: None,
+        }
     }
 
     /// actor() for riker
@@ -68,15 +76,15 @@ impl Actor for ChainActor {
             .try_tell(
                 match message {
                     // set the top pair to the value passed
-                    Protocol::SetTopPair(p) => {
-                        self.top_pair = p;
-                        Protocol::SetTopPairResult(Ok(self.top_pair.clone()))
+                    Protocol::SetTopChainHeader(chain_header) => {
+                        self.top_chain_header = chain_header;
+                        Protocol::SetTopChainHeaderResult(Ok(self.top_chain_header.clone()))
                     }
 
                     // evaluates to the current top pair
-                    Protocol::GetTopPair => {
-                        let ret = self.top_pair.clone();
-                        Protocol::GetTopPairResult(ret)
+                    Protocol::GetTopChainHeader => {
+                        let ret = self.top_chain_header.clone();
+                        Protocol::GetTopChainHeaderResult(ret)
                     }
 
                     _ => unreachable!(),
@@ -92,7 +100,7 @@ pub mod tests {
     use actor::Protocol;
     use chain::{
         actor::{AskChain, ChainActor},
-        pair::tests::{test_pair_a, test_pair_b},
+        header::tests::{test_chain_header_a, test_chain_header_b},
     };
     use riker::actors::*;
 
@@ -115,32 +123,32 @@ pub mod tests {
         assert_eq!(
             None,
             chain_actor
-                .top_pair()
+                .top_chain_header()
                 .expect("could not get top pair from chain actor")
         );
 
-        let pair_a = test_pair_a();
+        let chain_header_a = test_chain_header_a();
         chain_actor
-            .set_top_pair(&Some(pair_a.clone()))
-            .expect("could not set top pair a");
+            .set_top_chain_header(&Some(chain_header_a.clone()))
+            .expect("could not set top chain_header a");
 
         assert_eq!(
-            Some(pair_a.clone()),
+            Some(chain_header_a.clone()),
             chain_actor
-                .top_pair()
-                .expect("could not get top pair from chain actor")
+                .top_chain_header()
+                .expect("could not get top chain_header from chain actor")
         );
 
-        let pair_b = test_pair_b();
+        let chain_header_b = test_chain_header_b();
         chain_actor
-            .set_top_pair(&Some(pair_b.clone()))
-            .expect("could not set top pair b");
+            .set_top_chain_header(&Some(chain_header_b.clone()))
+            .expect("could not set top chain_header b");
 
         assert_eq!(
-            Some(pair_b.clone()),
+            Some(chain_header_b.clone()),
             chain_actor
-                .top_pair()
-                .expect("could not get top pair from chain actor")
+                .top_chain_header()
+                .expect("could not get top chain_header from chain actor")
         );
     }
 

--- a/core/src/chain/header.rs
+++ b/core/src/chain/header.rs
@@ -148,7 +148,12 @@ impl AddressableContent for ChainHeader {
 #[cfg(test)]
 pub mod tests {
     use cas::content::{Address, AddressableContent};
-    use chain::{header::ChainHeader, pair::tests::test_pair, tests::test_chain, SourceChain};
+    use chain::{
+        header::ChainHeader,
+        pair::tests::{test_pair, test_pair_b},
+        tests::test_chain,
+        SourceChain,
+    };
     use hash_table::{
         entry::tests::{
             test_entry, test_entry_a, test_entry_b, test_entry_type, test_entry_type_a,
@@ -158,8 +163,18 @@ pub mod tests {
     };
 
     /// returns a dummy header for use in tests
-    pub fn test_header() -> ChainHeader {
+    pub fn test_chain_header() -> ChainHeader {
         test_pair().header().clone()
+    }
+
+    /// returns a dummy header for use in tests
+    pub fn test_chain_header_a() -> ChainHeader {
+        test_chain_header()
+    }
+
+    /// returns a dummy header for use in tests. different from test_chain_header_a.
+    pub fn test_chain_header_b() -> ChainHeader {
+        test_pair_b().header().clone()
     }
 
     pub fn test_header_address() -> Address {
@@ -179,20 +194,20 @@ pub mod tests {
 
         // same content + chain state is equal
         assert_eq!(
-            chain_a.create_next_header(&entry_type_a, &entry_a),
-            chain_a.create_next_header(&entry_type_a, &entry_a),
+            chain_a.create_next_chain_header(&entry_type_a, &entry_a),
+            chain_a.create_next_chain_header(&entry_type_a, &entry_a),
         );
 
         // different content is different
         assert_ne!(
-            chain_a.create_next_header(&entry_type_a, &entry_a),
-            chain_a.create_next_header(&entry_type_a, &entry_b),
+            chain_a.create_next_chain_header(&entry_type_a, &entry_a),
+            chain_a.create_next_chain_header(&entry_type_a, &entry_b),
         );
 
         // different type is different
         assert_ne!(
-            chain_a.create_next_header(&entry_type_a, &entry_a),
-            chain_a.create_next_header(&entry_type_b, &entry_a),
+            chain_a.create_next_chain_header(&entry_type_a, &entry_a),
+            chain_a.create_next_chain_header(&entry_type_b, &entry_a),
         );
 
         // different state is different with same entry
@@ -202,8 +217,8 @@ pub mod tests {
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
 
         assert_ne!(
-            chain_a.create_next_header(&entry_type_a, &entry_a),
-            chain_b.create_next_header(&entry_type_a, &entry_a)
+            chain_a.create_next_chain_header(&entry_type_a, &entry_a),
+            chain_b.create_next_chain_header(&entry_type_a, &entry_a)
         );
     }
 
@@ -214,7 +229,7 @@ pub mod tests {
         let entry_type = test_entry_type();
         let entry = test_entry();
 
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         assert_eq!(header.entry_address(), &entry.address());
         assert_eq!(header.link(), None);
@@ -228,7 +243,7 @@ pub mod tests {
         let entry_type = test_entry_type();
         let entry = test_entry();
 
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         assert_eq!(header.entry_type(), &entry_type);
     }
@@ -240,7 +255,7 @@ pub mod tests {
         let entry_type = test_entry_type();
         let entry = test_entry();
 
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         assert_eq!(header.timestamp(), "");
     }
@@ -257,20 +272,21 @@ pub mod tests {
         let entry_b = test_entry_b();
 
         // first header is genesis so next should be None
-        let pair_a = chain
+        let chain_header_a = chain
             .push_entry(&entry_type_a, &entry_a)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
-        let header_a = pair_a.header();
 
-        assert_eq!(header_a.link(), None);
+        assert_eq!(chain_header_a.link(), None);
 
         // second header next should be first header hash
-        let pair_b = chain
+        let chain_header_b = chain
             .push_entry(&entry_type_b, &entry_b)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
-        let header_b = pair_b.header();
 
-        assert_eq!(header_b.link(), Some(header_a.to_entry().1.address()));
+        assert_eq!(
+            chain_header_b.link(),
+            Some(chain_header_a.to_entry().1.address())
+        );
     }
 
     #[test]
@@ -281,7 +297,7 @@ pub mod tests {
         let entry = test_entry();
 
         // header for an entry should contain the entry hash under entry()
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         assert_eq!(header.entry_address(), &entry.address());
     }
@@ -293,33 +309,35 @@ pub mod tests {
 
         let entry_type_a = test_entry_type_a();
         let entry_type_b = test_entry_type_b();
+        let entry_type_c = test_entry_type_a();
 
         let entry_a = test_entry_a();
         let entry_b = test_entry_b();
+        let entry_c = test_entry_b();
 
         // first header is genesis so next should be None
-        let pair_a = chain
+        let chain_header_a = chain
             .push_entry(&entry_type_a, &entry_a)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
-        let header_a = pair_a.header();
 
-        assert_eq!(header_a.link_same_type(), None);
+        assert_eq!(chain_header_a.link_same_type(), None);
 
         // second header is a different type so next should be None
-        let pair_b = chain
+        let chain_header_b = chain
             .push_entry(&entry_type_b, &entry_b)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
-        let header_b = pair_b.header();
 
-        assert_eq!(header_b.link_same_type(), None);
+        assert_eq!(chain_header_b.link_same_type(), None);
 
         // third header is same type as first header so next should be first header hash
-        let pair_c = chain
-            .push_entry(&entry_type_a, &entry_b)
+        let chain_header_c = chain
+            .push_entry(&entry_type_c, &entry_c)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
-        let header_c = pair_c.header();
 
-        assert_eq!(header_c.link_same_type(), Some(header_a.address()));
+        assert_eq!(
+            chain_header_c.link_same_type(),
+            Some(chain_header_a.address())
+        );
     }
 
     #[test]
@@ -329,7 +347,7 @@ pub mod tests {
         let entry_type = test_entry_type();
         let entry = test_entry();
 
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         assert_eq!("", header.entry_signature());
     }
@@ -342,7 +360,7 @@ pub mod tests {
         let entry = test_entry();
 
         // check a known hash
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         assert_eq!(test_header_address(), header.address());
     }
@@ -359,9 +377,9 @@ pub mod tests {
         let entry_b = test_entry_b();
 
         // different entries must return different hashes
-        let header_a = chain.create_next_header(&entry_type_a, &entry_a);
+        let header_a = chain.create_next_chain_header(&entry_type_a, &entry_a);
 
-        let header_b = chain.create_next_header(&entry_type_b, &entry_b);
+        let header_b = chain.create_next_chain_header(&entry_type_b, &entry_b);
 
         assert_ne!(header_a.address(), header_b.address());
 
@@ -369,7 +387,7 @@ pub mod tests {
         let entry_c = test_entry_a();
 
         // same entry must return same address
-        let header_c = chain.create_next_header(&entry_type_c, &entry_c);
+        let header_c = chain.create_next_chain_header(&entry_type_c, &entry_c);
 
         assert_eq!(header_a.address(), header_c.address());
     }
@@ -384,8 +402,8 @@ pub mod tests {
 
         let entry = test_entry();
 
-        let header_a = chain.create_next_header(&entry_type_a, &entry);
-        let header_b = chain.create_next_header(&entry_type_b, &entry);
+        let header_a = chain.create_next_chain_header(&entry_type_a, &entry);
+        let header_b = chain.create_next_chain_header(&entry_type_b, &entry);
 
         // different types must give different addresses
         assert_ne!(header_a.address(), header_b.address());
@@ -400,18 +418,18 @@ pub mod tests {
         let entry_type = test_entry_type();
         let entry = test_entry();
 
-        let header = chain.create_next_header(&entry_type, &entry);
+        let chain_header_control = chain.create_next_chain_header(&entry_type, &entry);
 
-        let pair_a = chain
+        let chain_header_a = chain
             .push_entry(&entry_type, &entry)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
         // p2 will have a different address to p1 with the same entry as the chain state is different
-        let pair_b = chain
+        let chain_header_b = chain
             .push_entry(&entry_type, &entry)
             .expect("pushing a valid entry to an exlusively owned chain shouldn't fail");
 
-        assert_eq!(header.address(), pair_a.header().address());
-        assert_ne!(header.address(), pair_b.header().address());
+        assert_eq!(chain_header_control.address(), chain_header_a.address());
+        assert_ne!(chain_header_control.address(), chain_header_b.address());
     }
 
     #[test]
@@ -428,7 +446,7 @@ pub mod tests {
         let entry_type = test_entry_type();
         let entry = test_entry();
 
-        let header = chain.create_next_header(&entry_type, &entry);
+        let header = chain.create_next_chain_header(&entry_type, &entry);
 
         let header_entry = header.to_entry().1;
         let header_trip = ChainHeader::from_entry(&header_entry);

--- a/core/src/dht/dht_reducers.rs
+++ b/core/src/dht/dht_reducers.rs
@@ -63,7 +63,7 @@ where
     EAVS: EntityAttributeValueStorage + Sized + Clone + PartialEq,
 {
     let action = action_wrapper.action();
-    let (entry_type, entry) = match action {
+    let (_, entry) = match action {
         Action::Commit(entry_type, entry) => (entry_type, entry),
         _ => unreachable!(),
     };

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -178,16 +178,16 @@ mod tests {
         let (context, _) = test_context_and_logger("joan");
         let context = instance.initialize_context(context);
 
-        println!("{:?}", instance.state().agent().chain().top_pair());
+        println!("{:?}", instance.state().agent().chain().top_chain_header());
         println!(
             "{:?}",
             instance
                 .state()
                 .agent()
                 .chain()
-                .top_pair()
-                .expect("could not get top pair")
-                .expect("top pair was None")
+                .top_chain_header()
+                .expect("could not get top chain_header")
+                .expect("top chain_header was None")
                 .address()
         );
 


### PR DESCRIPTION
## changes

- removes `Pair` from `Chain` state and methods
- removes `Pair` from actor protocol
- uses `ChainHeader` where `Pair` was removed
- uses `Address` in some places where `Entry` was used
- more consistent use of `chain_header` over `header`
- removes `create_next_pair` method from `Chain`
- removes `from_json` method from `Chain`
  - it doesn't make sense to try and restore a chain from a serialized `ChainHeader` list alone
  - the whole point of `Chain` is that it assumes _both_ `ChainHeader` and `Entry` data exists in some underlying storage and therefore it is possible to iterate through linked `Address` from a single `ChainHeader` starting point "top"
  - `Pair` has both `Entry` and `ChainHeader` so an import was possible until now
  - i'm not sure what the use-case for this method is anyway, i believe it was a direct port of functionality from golang