### PR TITLE
fixed bug where wasm serialization does not return error value

### DIFF
--- a/wasm_utils/src/memory_serialization.rs
+++ b/wasm_utils/src/memory_serialization.rs
@@ -75,6 +75,7 @@ pub fn serialize_into_encoded_allocation<T: Serialize>(
 }
 
 /*
+TODO: figure out a way to get tests to work for serialization, see #451
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/wasm_utils/src/memory_serialization.rs
+++ b/wasm_utils/src/memory_serialization.rs
@@ -19,7 +19,7 @@ pub fn deserialize<'s, T: Deserialize<'s>>(ptr_data: *mut c_char) -> Result<T, S
             let maybe_error_report: Result<RibosomeErrorReport, serde_json::Error> =
                 serde_json::from_str(actual_str);
             match maybe_error_report {
-                Err(_) => Err(actual_str.to_string()),
+                Err(err) => Err(err.to_string()),
                 Ok(error_report) => Err(error_report.description),
             }
         }
@@ -73,3 +73,30 @@ pub fn serialize_into_encoded_allocation<T: Serialize>(
     let allocation_of_output = serialize(stack, internal).unwrap();
     return allocation_of_output.encode() as i32;
 }
+
+/*
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[derive(Deserialize, Serialize, Default,Debug,PartialEq)]
+    struct TestStruct {
+        value: String,
+    }
+
+    #[test]
+    fn can_round_trip_allocation() {
+
+        let mut mem_stack = SinglePageStack::default();
+
+        let test_value = TestStruct{value:"fish".to_string()};
+
+        let encoded_allocation = serialize_into_encoded_allocation(&mut mem_stack,test_value);
+
+        assert_eq!(format!("{:?}", mem_stack),"dog");
+
+        let result : Result<TestStruct,String> = try_deserialize_allocation(encoded_allocation as u32);
+        assert_eq!(result.unwrap(),TestStruct{value:"fish".to_string()});
+    }
+}
+*/


### PR DESCRIPTION
I was unable to successfully write a test for this case, but the problem was that when an error occurred in the deserializing, it was putting the value of the memory, not the serde error into the returned Err()