### PR TITLE
Fix validation and commit

### DIFF
--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -54,11 +54,7 @@ pub fn validate_entry(
 
                 let result = match maybe_validation_result {
                     Ok(validation_result) => match validation_result {
-                        CallbackResult::Fail(error_string) => {
-                            let error_object: serde_json::Value =
-                                serde_json::from_str(&error_string).unwrap();
-                            Err(error_object["Err"].to_string())
-                        }
+                        CallbackResult::Fail(error_string) => Err(error_string),
                         CallbackResult::Pass => Ok(()),
                         CallbackResult::NotImplemented => Err(format!(
                             "Validation callback not implemented for {:?}",


### PR DESCRIPTION
The failure reason that we get from the validation callback is not necessarily a JSON object, just return the plain string.

This is needed to make the tests in https://github.com/holochain/hdk-rust/pull/20 pass.