### PR TITLE
Allow building c_binding_tests/hc_dna using homebrew Qt on Mojave.

### DIFF
--- a/c_binding_tests/hc_dna/qmake.pro
+++ b/c_binding_tests/hc_dna/qmake.pro
@@ -8,7 +8,7 @@ INCLUDEPATH += .
 LIBS += -L../../target/debug/ -lholochain_dna_c_binding -ldl
 QT += testlib
 QT -= gui
-CONFIG += console
+CONFIG += console c++11
 CONFIG -= app_bundle
 
 # Input


### PR DESCRIPTION
Otherwise, we get a complaint from `qcompilerdetection.h` that clang does not handle C++11