### PR TITLE
ValidationPackage callback (& prep. for autogen JSON)

### DIFF
--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -61,6 +61,7 @@ pub fn validate_entry(
                             "Validation callback not implemented for {:?}",
                             entry_type.clone()
                         )),
+                        _ => unreachable!(),
                     },
                     Err(error) => Err(error.to_string()),
                 };

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -189,6 +189,13 @@ pub fn get_dna(context: &Arc<Context>) -> Option<Dna> {
     dna
 }
 
+pub fn get_wasm(context: &Arc<Context>, zome: &str) -> Option<DnaWasm> {
+    let dna = get_dna(context).expect("Callback called without DNA set!");
+    dna.get_wasm_from_zome_name(zome).and_then(|wasm| {
+        Some(wasm.clone()).filter(|_| !wasm.code.is_empty())
+    })
+}
+
 pub fn call(
     context: Arc<Context>,
     zome: &str,

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -192,9 +192,8 @@ pub fn get_dna(context: &Arc<Context>) -> Option<Dna> {
 
 pub fn get_wasm(context: &Arc<Context>, zome: &str) -> Option<DnaWasm> {
     let dna = get_dna(context).expect("Callback called without DNA set!");
-    dna.get_wasm_from_zome_name(zome).and_then(|wasm| {
-        Some(wasm.clone()).filter(|_| !wasm.code.is_empty())
-    })
+    dna.get_wasm_from_zome_name(zome)
+        .and_then(|wasm| Some(wasm.clone()).filter(|_| !wasm.code.is_empty()))
 }
 
 pub fn call(

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -4,10 +4,12 @@
 pub mod genesis;
 pub mod receive;
 pub mod validate_entry;
+pub mod validation_package;
 
 use context::Context;
 use holochain_core_types::{entry::Entry, json::ToJson};
 use holochain_dna::{wasm::DnaWasm, zome::capabilities::ReservedCapabilityNames, Dna};
+use holochain_wasm_utils::api_serialization::validation::ValidationPackage;
 use nucleus::{
     ribosome::{
         self,
@@ -132,6 +134,7 @@ pub enum CallbackResult {
     Pass,
     Fail(String),
     NotImplemented,
+    ValidationPackage(ValidationPackage),
 }
 
 pub(crate) fn run_callback(

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -9,7 +9,7 @@ pub mod validation_package;
 use context::Context;
 use holochain_core_types::{entry::Entry, json::ToJson};
 use holochain_dna::{wasm::DnaWasm, zome::capabilities::ReservedCapabilityNames, Dna};
-use holochain_wasm_utils::api_serialization::validation::ValidationPackage;
+use holochain_wasm_utils::api_serialization::validation::ValidationPackageDefinition;
 use nucleus::{
     ribosome::{
         self,
@@ -134,7 +134,7 @@ pub enum CallbackResult {
     Pass,
     Fail(String),
     NotImplemented,
-    ValidationPackage(ValidationPackage),
+    ValidationPackage(ValidationPackageDefinition),
 }
 
 pub(crate) fn run_callback(

--- a/core/src/nucleus/ribosome/callback/validate_entry.rs
+++ b/core/src/nucleus/ribosome/callback/validate_entry.rs
@@ -6,7 +6,7 @@ use holochain_wasm_utils::api_serialization::validation::ValidationData;
 use nucleus::{
     ribosome::{
         self,
-        callback::{get_dna, CallbackResult},
+        callback::{get_dna, get_wasm, CallbackResult},
     },
     ZomeFnCall,
 };
@@ -116,13 +116,4 @@ fn run_validation_callback(
     }
 }
 
-fn get_wasm(context: &Arc<Context>, zome: &str) -> Option<DnaWasm> {
-    let dna = get_dna(context).expect("Callback called without DNA set!");
-    dna.get_wasm_from_zome_name(zome).and_then(|wasm| {
-        if wasm.code.len() > 0 {
-            Some(wasm.clone())
-        } else {
-            None
-        }
-    })
-}
+

--- a/core/src/nucleus/ribosome/callback/validate_entry.rs
+++ b/core/src/nucleus/ribosome/callback/validate_entry.rs
@@ -115,5 +115,3 @@ fn run_validation_callback(
         Err(_) => CallbackResult::NotImplemented,
     }
 }
-
-

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -10,7 +10,7 @@ use nucleus::{
 };
 use std::sync::Arc;
 
-pub fn validation_package(
+pub fn get_validation_package_definition(
     entry_type: EntryType,
     context: Arc<Context>,
 ) -> Result<CallbackResult, HolochainError> {

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -39,16 +39,14 @@ pub fn validation_package(
                         Some(app_entry_type.into_bytes()),
                     ) {
                         Err(error) => Err(HolochainError::ErrorGeneric(format!("wasmi error: {}", error))),
-                        Ok(runtime) => match runtime.result.is_empty() {
-                            true => Ok(CallbackResult::NotImplemented),
-                            false => {
-                                match serde_json::from_str(&runtime.result) {
-                                    Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
-                                    Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not deserialized as ValidationPackage")))
-                                }
-
+                        Ok(result) => if result.is_empty() {
+                            Ok(CallbackResult::NotImplemented)
+                        } else {
+                            match serde_json::from_str(&result) {
+                                Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
+                                Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not deserialized as ValidationPackage")))
                             }
-                        },
+                        }
                     }
                 }
             }

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -1,11 +1,10 @@
 extern crate serde_json;
 use context::Context;
 use holochain_core_types::{entry_type::EntryType, error::HolochainError};
-use holochain_dna::wasm::DnaWasm;
 use nucleus::{
     ribosome::{
         self,
-        callback::{get_dna, CallbackResult},
+        callback::{get_dna, get_wasm, CallbackResult},
     },
     ZomeFnCall,
 };
@@ -56,15 +55,4 @@ pub fn validation_package(
         }
         _ => Err(HolochainError::NotImplemented),
     }
-}
-
-fn get_wasm(context: &Arc<Context>, zome: &str) -> Option<DnaWasm> {
-    let dna = get_dna(context).expect("Callback called without DNA set!");
-    dna.get_wasm_from_zome_name(zome).and_then(|wasm| {
-        if wasm.code.len() > 0 {
-            Some(wasm.clone())
-        } else {
-            None
-        }
-    })
 }

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -25,7 +25,7 @@ pub fn get_validation_package_definition(
             let zome_name = zome_name.unwrap();
             match get_wasm(&context, &zome_name) {
                 None => Err(HolochainError::ErrorGeneric(String::from("no wasm found"))),
-                Some(wasm) => match ribosome::api::call(
+                Some(wasm) => match ribosome::run_dna(
                     &dna.name.clone(),
                     context,
                     wasm.code.clone(),

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -23,33 +23,31 @@ pub fn get_validation_package_definition(
             }
 
             let zome_name = zome_name.unwrap();
-            match get_wasm(&context, &zome_name) {
-                None => Err(HolochainError::ErrorGeneric(String::from("no wasm found"))),
-                Some(wasm) => match ribosome::run_dna(
-                    &dna.name.clone(),
-                    context,
-                    wasm.code.clone(),
-                    &ZomeFnCall::new(
-                        &zome_name,
-                        "no capability, since this is an entry validation call",
-                        "__hdk_get_validation_package_for_entry_type",
-                        &app_entry_type,
-                    ),
-                    Some(app_entry_type.into_bytes()),
-                ) {
-                    Err(error) => Err(HolochainError::ErrorGeneric(format!(
-                        "wasmi error: {}",
-                        error
-                    ))),
-                    Ok(result) => if result.is_empty() {
-                        Ok(CallbackResult::NotImplemented)
-                    } else {
-                        match serde_json::from_str(&result) {
-                                Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
-                                Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not deserialized as ValidationPackage")))
-                            }
-                    },
-                },
+            let wasm = get_wasm(&context, &zome_name)
+                .ok_or(HolochainError::ErrorGeneric(String::from("no wasm found")))?;
+
+            let result = ribosome::run_dna(
+                &dna.name.clone(),
+                context,
+                wasm.code.clone(),
+                &ZomeFnCall::new(
+                    &zome_name,
+                    "no capability, since this is an entry validation call",
+                    "__hdk_get_validation_package_for_entry_type",
+                    &app_entry_type,
+                ),
+                Some(app_entry_type.into_bytes())
+            )?;
+
+            if result.is_empty() {
+                Err(HolochainError::SerializationError(String::from(
+                    "__hdk_get_validation_package_for_entry_type returned empty result",
+                )))
+            } else {
+                match serde_json::from_str(&result) {
+                    Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
+                    Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not be deserialized as ValidationPackage")))
+                }
             }
         }
         _ => Err(HolochainError::NotImplemented),

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -33,7 +33,7 @@ pub fn validation_package(
                         &ZomeFnCall::new(
                             &zome_name,
                             "no capability, since this is an entry validation call",
-                            "validation_package",
+                            "__hdk_get_validation_package_for_entry_type",
                             &app_entry_type,
                         ),
                         Some(app_entry_type.into_bytes()),

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -1,0 +1,70 @@
+extern crate serde_json;
+use context::Context;
+use holochain_core_types::{entry_type::EntryType, error::HolochainError};
+use holochain_dna::wasm::DnaWasm;
+use nucleus::{
+    ribosome::{
+        self,
+        callback::{get_dna, CallbackResult},
+    },
+    ZomeFnCall,
+};
+use std::sync::Arc;
+
+pub fn validation_package(
+    entry_type: EntryType,
+    context: Arc<Context>,
+) -> Result<CallbackResult, HolochainError> {
+    match entry_type {
+        EntryType::App(app_entry_type) => {
+            let dna = get_dna(&context).expect("Callback called without DNA set!");
+            let zome_name = dna.get_zome_name_for_entry_type(&app_entry_type);
+            if zome_name.is_none() {
+                return Ok(CallbackResult::NotImplemented);
+            }
+
+            let zome_name = zome_name.unwrap();
+            match get_wasm(&context, &zome_name) {
+                None => Err(HolochainError::ErrorGeneric(String::from("no wasm found"))),
+                Some(wasm) => {
+                    match ribosome::api::call(
+                        &dna.name.clone(),
+                        context,
+                        wasm.code.clone(),
+                        &ZomeFnCall::new(
+                            &zome_name,
+                            "no capability, since this is an entry validation call",
+                            "validation_package",
+                            &app_entry_type,
+                        ),
+                        Some(app_entry_type.into_bytes()),
+                    ) {
+                        Err(error) => Err(HolochainError::ErrorGeneric(format!("wasmi error: {}", error))),
+                        Ok(runtime) => match runtime.result.is_empty() {
+                            true => Ok(CallbackResult::NotImplemented),
+                            false => {
+                                match serde_json::from_str(&runtime.result) {
+                                    Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
+                                    Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not deserialized as ValidationPackage")))
+                                }
+
+                            }
+                        },
+                    }
+                }
+            }
+        }
+        _ => Err(HolochainError::NotImplemented),
+    }
+}
+
+fn get_wasm(context: &Arc<Context>, zome: &str) -> Option<DnaWasm> {
+    let dna = get_dna(context).expect("Callback called without DNA set!");
+    dna.get_wasm_from_zome_name(zome).and_then(|wasm| {
+        if wasm.code.len() > 0 {
+            Some(wasm.clone())
+        } else {
+            None
+        }
+    })
+}

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -25,30 +25,31 @@ pub fn validation_package(
             let zome_name = zome_name.unwrap();
             match get_wasm(&context, &zome_name) {
                 None => Err(HolochainError::ErrorGeneric(String::from("no wasm found"))),
-                Some(wasm) => {
-                    match ribosome::api::call(
-                        &dna.name.clone(),
-                        context,
-                        wasm.code.clone(),
-                        &ZomeFnCall::new(
-                            &zome_name,
-                            "no capability, since this is an entry validation call",
-                            "__hdk_get_validation_package_for_entry_type",
-                            &app_entry_type,
-                        ),
-                        Some(app_entry_type.into_bytes()),
-                    ) {
-                        Err(error) => Err(HolochainError::ErrorGeneric(format!("wasmi error: {}", error))),
-                        Ok(result) => if result.is_empty() {
-                            Ok(CallbackResult::NotImplemented)
-                        } else {
-                            match serde_json::from_str(&result) {
+                Some(wasm) => match ribosome::api::call(
+                    &dna.name.clone(),
+                    context,
+                    wasm.code.clone(),
+                    &ZomeFnCall::new(
+                        &zome_name,
+                        "no capability, since this is an entry validation call",
+                        "__hdk_get_validation_package_for_entry_type",
+                        &app_entry_type,
+                    ),
+                    Some(app_entry_type.into_bytes()),
+                ) {
+                    Err(error) => Err(HolochainError::ErrorGeneric(format!(
+                        "wasmi error: {}",
+                        error
+                    ))),
+                    Ok(result) => if result.is_empty() {
+                        Ok(CallbackResult::NotImplemented)
+                    } else {
+                        match serde_json::from_str(&result) {
                                 Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
                                 Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not deserialized as ValidationPackage")))
                             }
-                        }
-                    }
-                }
+                    },
+                },
             }
         }
         _ => Err(HolochainError::NotImplemented),

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -36,7 +36,7 @@ pub fn get_validation_package_definition(
                     "__hdk_get_validation_package_for_entry_type",
                     &app_entry_type,
                 ),
-                Some(app_entry_type.into_bytes())
+                Some(app_entry_type.into_bytes()),
             )?;
 
             if result.is_empty() {
@@ -46,7 +46,9 @@ pub fn get_validation_package_definition(
             } else {
                 match serde_json::from_str(&result) {
                     Ok(package) => Ok(CallbackResult::ValidationPackage(package)),
-                    Err(_) => Err(HolochainError::SerializationError(String::from("validation_package result could not be deserialized as ValidationPackage")))
+                    Err(_) => Err(HolochainError::SerializationError(String::from(
+                        "validation_package result could not be deserialized as ValidationPackage",
+                    ))),
                 }
             }
         }

--- a/hdk-rust/Cargo.toml
+++ b/hdk-rust/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0"
 bitflags = "1.0"
 lazy_static = "1.1.0"
 holochain_wasm_utils = { path = "../wasm_utils" }
+holochain_dna = { path = "../dna" }
 
 [dev-dependencies]
 test_utils = { path = "../test_utils" }

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -1,11 +1,11 @@
 use holochain_dna::zome::entry_types::EntryTypeDef;
 use holochain_wasm_utils::{
-    api_serialization::validation::{ValidationData, ValidationPackage},
+    api_serialization::validation::{ValidationData, ValidationPackageDefinition},
     holochain_core_types::hash::HashString,
 };
 use std::collections::HashMap;
 
-pub type PackageCreator = Box<FnMut() -> ValidationPackage + Sync>;
+pub type PackageCreator = Box<FnMut() -> ValidationPackageDefinition + Sync>;
 pub type Validator = Box<FnMut(String, ValidationData) -> Result<(), String> + Sync>;
 pub type LinkValidator =
     Box<FnMut(HashString, String, HashString, ValidationData) -> Result<(), String> + Sync>;

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+use holochain_wasm_utils::{
+    api_serialization::validation::{
+        ValidationData, ValidationPackage,
+    },
+    holochain_core_types::hash::HashString,
+};
+use holochain_dna::zome::entry_types::{
+    EntryTypeDef,
+};
+
+pub type PackageCreator = Box<FnMut() -> ValidationPackage + Sync>;
+pub type Validator = Box<FnMut(String, ValidationData) -> Result<(), String> + Sync>;
+pub type LinkValidator = Box<FnMut(HashString, String, HashString, ValidationData) -> Result<(), String> + Sync>;
+
+pub struct ValidatingEntryType {
+    pub name: String,
+    pub entry_type_definition: EntryTypeDef,
+    pub package_creator: PackageCreator,
+    pub validator: Validator,
+    pub link_validators: HashMap<String, LinkValidator>,
+}
+
+
+#[macro_export]
+macro_rules! entry {
+    (
+        name: $name:expr,
+        description: $description:expr,
+        sharing: $sharing:expr,
+
+        validation_package: || $package_creator:expr,
+        validation_function: | $entry:ident : $entry_type:ty, $ctx:ident : hdk::ValidationData | $entry_validation:expr
+    ) => (
+
+        {
+            let mut entry_type = ::hdk::holochain_dna::zome::entry_types::EntryTypeDef::new();
+            entry_type.description = String::from($description);
+            entry_type.sharing = $sharing;
+
+            let package_creator = Box::new(|| {
+                $package_creator
+            });
+
+            let validator = Box::new(|raw_entry: String, ctx: ::hdk::holochain_wasm_utils::api_serialization::validation::ValidationData| {
+                let $ctx = ctx;
+                match serde_json::from_str(&raw_entry) {
+                    Ok(entry) => {
+                        let entry_struct : $entry_type = entry;
+                        let $entry = entry_struct;
+                        $entry_validation
+                    },
+                    Err(_) => {
+                        Err(String::from("Schema validation failed"))
+                    }
+                }
+            });
+
+
+            ::hdk::entry_definition::ValidatingEntryType {
+                name: String::from($name),
+                entry_type_definition: entry_type,
+                package_creator,
+                validator,
+                link_validators: std::collections::HashMap::new(),
+            }
+        }
+    );
+}

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -1,17 +1,14 @@
-use std::collections::HashMap;
+use holochain_dna::zome::entry_types::EntryTypeDef;
 use holochain_wasm_utils::{
-    api_serialization::validation::{
-        ValidationData, ValidationPackage,
-    },
+    api_serialization::validation::{ValidationData, ValidationPackage},
     holochain_core_types::hash::HashString,
 };
-use holochain_dna::zome::entry_types::{
-    EntryTypeDef,
-};
+use std::collections::HashMap;
 
 pub type PackageCreator = Box<FnMut() -> ValidationPackage + Sync>;
 pub type Validator = Box<FnMut(String, ValidationData) -> Result<(), String> + Sync>;
-pub type LinkValidator = Box<FnMut(HashString, String, HashString, ValidationData) -> Result<(), String> + Sync>;
+pub type LinkValidator =
+    Box<FnMut(HashString, String, HashString, ValidationData) -> Result<(), String> + Sync>;
 
 pub struct ValidatingEntryType {
     pub name: String,
@@ -20,7 +17,6 @@ pub struct ValidatingEntryType {
     pub validator: Validator,
     pub link_validators: HashMap<String, LinkValidator>,
 }
-
 
 #[macro_export]
 macro_rules! entry {

--- a/hdk-rust/src/lib.rs
+++ b/hdk-rust/src/lib.rs
@@ -11,11 +11,15 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
 pub extern crate holochain_wasm_utils;
+pub extern crate holochain_dna;
 
 mod api;
+pub mod entry_definition;
 pub mod global_fns;
 pub mod globals;
 pub mod init_globals;
 pub mod macros;
+pub mod meta;
 
 pub use api::*;
+pub use holochain_wasm_utils::api_serialization::validation::*;

--- a/hdk-rust/src/lib.rs
+++ b/hdk-rust/src/lib.rs
@@ -10,8 +10,8 @@ extern crate serde_derive;
 extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
-pub extern crate holochain_wasm_utils;
 pub extern crate holochain_dna;
+pub extern crate holochain_wasm_utils;
 
 mod api;
 pub mod entry_definition;

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -28,7 +28,7 @@ extern "C" {
 }
 
 #[no_mangle]
-pub extern "C" fn validation_package(encoded_allocation_of_input: u32) -> u32 {
+pub extern "C" fn __hdk_get_validation_package_for_entry_type(encoded_allocation_of_input: u32) -> u32 {
     ::global_fns::init_global_memory(encoded_allocation_of_input);
 
     let mut zd = ZomeDefinition::new();

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -1,21 +1,18 @@
 use entry_definition::ValidatingEntryType;
-use holochain_wasm_utils::{
-    error::RibosomeErrorCode,
-    memory_serialization::load_string,
-};
+use holochain_wasm_utils::{error::RibosomeErrorCode, memory_serialization::load_string};
 
 trait Ribosome {
     fn define_entry_type(&mut self, name: String, entry_type: ValidatingEntryType);
 }
 
 pub struct ZomeDefinition {
-    pub entry_types: Vec<ValidatingEntryType>
+    pub entry_types: Vec<ValidatingEntryType>,
 }
 
 impl ZomeDefinition {
     fn new() -> ZomeDefinition {
         ZomeDefinition {
-            entry_types: Vec::new()
+            entry_types: Vec::new(),
         }
     }
 
@@ -25,7 +22,7 @@ impl ZomeDefinition {
     }
 }
 
-extern {
+extern "C" {
     #[allow(improper_ctypes)]
     fn zome_setup(zd: &mut ZomeDefinition);
 }
@@ -47,7 +44,8 @@ pub extern "C" fn validation_package(encoded_allocation_of_input: u32) -> u32 {
     }
     let name: String = maybe_name.unwrap();
 
-    match zd.entry_types
+    match zd
+        .entry_types
         .into_iter()
         .find(|ref entry_type| entry_type.name == name)
     {

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -28,7 +28,9 @@ extern "C" {
 }
 
 #[no_mangle]
-pub extern "C" fn __hdk_get_validation_package_for_entry_type(encoded_allocation_of_input: u32) -> u32 {
+pub extern "C" fn __hdk_get_validation_package_for_entry_type(
+    encoded_allocation_of_input: u32,
+) -> u32 {
     ::global_fns::init_global_memory(encoded_allocation_of_input);
 
     let mut zd = ZomeDefinition::new();

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -5,6 +5,7 @@ trait Ribosome {
     fn define_entry_type(&mut self, name: String, entry_type: ValidatingEntryType);
 }
 
+#[allow(improper_ctypes)]
 pub struct ZomeDefinition {
     pub entry_types: Vec<ValidatingEntryType>,
 }
@@ -22,8 +23,8 @@ impl ZomeDefinition {
     }
 }
 
+#[allow(improper_ctypes)]
 extern "C" {
-    #[allow(improper_ctypes)]
     fn zome_setup(zd: &mut ZomeDefinition);
 }
 

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -1,0 +1,60 @@
+use entry_definition::ValidatingEntryType;
+use holochain_wasm_utils::{
+    error::RibosomeErrorCode,
+    memory_serialization::load_string,
+};
+
+trait Ribosome {
+    fn define_entry_type(&mut self, name: String, entry_type: ValidatingEntryType);
+}
+
+pub struct ZomeDefinition {
+    pub entry_types: Vec<ValidatingEntryType>
+}
+
+impl ZomeDefinition {
+    fn new() -> ZomeDefinition {
+        ZomeDefinition {
+            entry_types: Vec::new()
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn define(&mut self, entry_type: ValidatingEntryType) {
+        self.entry_types.push(entry_type);
+    }
+}
+
+extern {
+    #[allow(improper_ctypes)]
+    fn zome_setup(zd: &mut ZomeDefinition);
+}
+
+#[no_mangle]
+pub extern "C" fn validation_package(encoded_allocation_of_input: u32) -> u32 {
+    ::global_fns::init_global_memory(encoded_allocation_of_input);
+
+    let mut zd = ZomeDefinition::new();
+    unsafe {
+        zome_setup(&mut zd);
+    }
+
+    // Deserialize input
+    let maybe_name = load_string(encoded_allocation_of_input);
+    if let Err(_) = maybe_name {
+        return ::holochain_wasm_utils::error::RibosomeErrorCode::ArgumentDeserializationFailed
+            as u32;
+    }
+    let name: String = maybe_name.unwrap();
+
+    match zd.entry_types
+        .into_iter()
+        .find(|ref entry_type| entry_type.name == name)
+    {
+        None => RibosomeErrorCode::CallbackFailed as u32,
+        Some(mut entry_type_definition) => {
+            let package = (*entry_type_definition.package_creator)();
+            ::global_fns::store_and_return_output(package)
+        }
+    }
+}

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -38,7 +38,7 @@ pub extern "C" fn __hdk_get_validation_package_for_entry_type(encoded_allocation
 
     // Deserialize input
     let maybe_name = load_string(encoded_allocation_of_input);
-    if let Err(_) = maybe_name {
+    if maybe_name.is_err() {
         return ::holochain_wasm_utils::error::RibosomeErrorCode::ArgumentDeserializationFailed
             as u32;
     }

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -148,7 +148,7 @@ pub extern fn zome_setup(zd: &mut ZomeDefinition) {
         sharing: Sharing::Public,
 
         validation_package: || {
-            hdk::ValidationPackage::ChainFull
+            hdk::ValidationPackageDefinition::ChainFull
         },
 
         validation_function: |entry: TestEntryType, _ctx: hdk::ValidationData| {

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -17,6 +17,10 @@ use holochain_wasm_utils::{
 };
 use hdk::RibosomeError;
 
+use hdk::holochain_dna::zome::entry_types::Sharing;
+
+use hdk::meta::ZomeDefinition;
+
 #[no_mangle]
 pub extern "C" fn check_global(encoded_allocation_of_input: u32) -> u32 {
     hdk::global_fns::init_global_memory(encoded_allocation_of_input);
@@ -134,4 +138,22 @@ validations! {
                 .ok_or_else(|| "FAIL content is not allowed".to_string())
         }
     }
+}
+
+#[no_mangle]
+pub extern fn zome_setup(zd: &mut ZomeDefinition) {
+    zd.define(entry!(
+        name: "testEntryType",
+        description: "asdfda",
+        sharing: Sharing::Public,
+
+        validation_package: || {
+            hdk::ValidationPackage::ChainFull
+        },
+
+        validation_function: |entry: TestEntryType, _ctx: hdk::ValidationData| {
+            (entry.stuff != "FAIL")
+                .ok_or_else(|| "FAIL content is not allowed".to_string())
+        }
+    ));
 }

--- a/wasm_utils/src/api_serialization/validation.rs
+++ b/wasm_utils/src/api_serialization/validation.rs
@@ -2,6 +2,15 @@ use holochain_core_types::{chain_header::ChainHeader, hash::HashString};
 
 extern crate serde_json;
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum ValidationPackage {
+    Entry,           //sending only the entry
+    ChainEntries,    //sending all (public?) source chain entries
+    ChainHeaders,    //sending all source chain headers
+    ChainFull,       //sending the whole chain, entries and headers
+    Custom(String),  //sending something custom
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ValidationData {
     pub chain_header: Option<ChainHeader>,

--- a/wasm_utils/src/api_serialization/validation.rs
+++ b/wasm_utils/src/api_serialization/validation.rs
@@ -4,11 +4,11 @@ extern crate serde_json;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum ValidationPackage {
-    Entry,           //sending only the entry
-    ChainEntries,    //sending all (public?) source chain entries
-    ChainHeaders,    //sending all source chain headers
-    ChainFull,       //sending the whole chain, entries and headers
-    Custom(String),  //sending something custom
+    Entry,          //sending only the entry
+    ChainEntries,   //sending all (public?) source chain entries
+    ChainHeaders,   //sending all source chain headers
+    ChainFull,      //sending the whole chain, entries and headers
+    Custom(String), //sending something custom
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/wasm_utils/src/api_serialization/validation.rs
+++ b/wasm_utils/src/api_serialization/validation.rs
@@ -3,7 +3,7 @@ use holochain_core_types::{chain_header::ChainHeader, hash::HashString};
 extern crate serde_json;
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-pub enum ValidationPackage {
+pub enum ValidationPackageDefinition {
     Entry,          //sending only the entry
     ChainEntries,   //sending all (public?) source chain entries
     ChainHeaders,   //sending all source chain headers


### PR DESCRIPTION
# validation_package(entry_type:String) callback using new way of defining entries in Rust code

Squirrel outcome video: https://drive.google.com/file/d/1Ii7RBu9HnzLzZPRa5XMj_cKzRlL-RrRH/view?usp=sharing

Next step for making validation working is constructing the right validation package for the validation function. So far we don't have a callback or other way of retrieving the validation package (definition) form the zome. This PR adds that.

Just getting the validation package info without other constraints could have been done simpler, but I wanted to this to be already compatible with the projected possibility of creating the DNA JSON automatically.

## So what is happening here?
* HDK-rust defines the function that is called from the native ribosome: `validation_package()`. It expects a string as argument that is the entry type's name.
* That dispatch function then calls `zome_setup()` which has to be defined in the zome to get a full vector of all defined entry types with their validation package creation funcition
* The HDK function `validation_package()` then looks for an entry type definition for the given type and calls the according callback and returns the result

## The advantage of this way of doing it with a dispatch function is this:
The same `zome_setup()` function can be called from another dispatch function for the actual validation and then call the validation closure instead of the validation package closure.
What is even more important: a `build_zome_json()` function that we will include the HDK can also call the same `zome_setup()` and use the populated `ZomeDefinition`struct to create the zome's DNA JSON *from the exact same code the DNA developer has written*.

I've discussed this today with @sphinxc0re who already had a local version of `zome_functions!` that was creating JSON for the capabilities. We agreed on having just one macro in the end that creates this `zome_setup()` function and also the exported entry points for the ribosome (`validation_package()`, `validate_entry()`, `validate_link()`) from an invocation like this:

```rust
define_zome! {
    entries: {
        post: {
            description: "asdfda",
            sharing: Sharing::Public,

            validation_package: || {
                hdk::ValidationPackage::ChainFull
            },

            validation_function: |entry: TestEntryType, _ctx: hdk::ValidationData| {
                (entry.stuff != "FAIL")
                    .ok_or_else(|| "FAIL content is not allowed".to_string())
            }
        }
    }
    
    capabilities: {
        blog(zome): {
            create_post: {
                input: [content: String, in_reply_to: HashString]
                output: hash: HashString,
                func: some_function_name(post)
            }
        }
    }
}
```

This PR is a step in that direction, but I wanted to stop here as my Squirrel timebox is over and I have what I need to continue with building the valdiation package for validation now. Merging this in makes it possible for @sphinxc0re to take this code and merge it with his macro to make the JSON creation possible while I continue completing the validation.