### PR TITLE
ribosome::api::call()  => ribosome::run_dna()

### DIFF
--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -212,7 +212,7 @@ pub(crate) fn launch_zome_fn_call(
 
     thread::spawn(move || {
         // Have Ribosome spin up DNA and call the zome function
-        let call_result = ribosome::api::call(
+        let call_result = ribosome::run_dna(
             &app_name,
             context.clone(),
             code,

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -4,7 +4,7 @@ use holochain_core_types::error::HolochainError;
 use holochain_dna::zome::capabilities::Membrane;
 use instance::RECV_DEFAULT_TIMEOUT_MS;
 use nucleus::{
-    get_capability_with_zome_call, launch_zome_fn_call, ribosome::api::Runtime,
+    get_capability_with_zome_call, launch_zome_fn_call, ribosome::runtime::Runtime,
     state::NucleusState, ZomeFnCall,
 };
 use serde_json;

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -4,8 +4,8 @@ use holochain_core_types::error::HolochainError;
 use holochain_dna::zome::capabilities::Membrane;
 use instance::RECV_DEFAULT_TIMEOUT_MS;
 use nucleus::{
-    get_capability_with_zome_call, launch_zome_fn_call, ribosome::runtime::Runtime,
-    state::NucleusState, ZomeFnCall,
+    get_capability_with_zome_call, launch_zome_fn_call, ribosome::Runtime, state::NucleusState,
+    ZomeFnCall,
 };
 use serde_json;
 use std::sync::{mpsc::channel, Arc};

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -9,7 +9,7 @@ use holochain_wasm_utils::api_serialization::{
     commit::{CommitEntryArgs, CommitEntryResult},
     validation::{EntryAction, EntryLifecycle, ValidationData},
 };
-use nucleus::{actions::validate::*, ribosome::runtime::Runtime};
+use nucleus::{actions::validate::*, ribosome::Runtime};
 use serde_json;
 use std::str::FromStr;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -9,7 +9,7 @@ use holochain_wasm_utils::api_serialization::{
     commit::{CommitEntryArgs, CommitEntryResult},
     validation::{EntryAction, EntryLifecycle, ValidationData},
 };
-use nucleus::{actions::validate::*, ribosome::api::Runtime};
+use nucleus::{actions::validate::*, ribosome::runtime::Runtime};
 use serde_json;
 use std::str::FromStr;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};

--- a/core/src/nucleus/ribosome/api/debug.rs
+++ b/core/src/nucleus/ribosome/api/debug.rs
@@ -1,4 +1,4 @@
-use nucleus::ribosome::runtime::Runtime;
+use nucleus::ribosome::Runtime;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 /// ZomeApiFunction::Debug function code

--- a/core/src/nucleus/ribosome/api/debug.rs
+++ b/core/src/nucleus/ribosome/api/debug.rs
@@ -1,4 +1,4 @@
-use nucleus::ribosome::api::Runtime;
+use nucleus::ribosome::runtime::Runtime;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 /// ZomeApiFunction::Debug function code

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -1,6 +1,6 @@
 use futures::executor::block_on;
 use holochain_wasm_utils::api_serialization::get_entry::{GetEntryArgs, GetEntryResult};
-use nucleus::{actions::get_entry::get_entry, ribosome::runtime::Runtime};
+use nucleus::{actions::get_entry::get_entry, ribosome::Runtime};
 use serde_json;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
@@ -54,10 +54,12 @@ mod tests {
     };
     use instance::tests::{test_context_and_logger, test_instance};
     use nucleus::{
-        ribosome,
-        ribosome::api::{
-            commit::tests::test_commit_args_bytes,
-            tests::{test_capability, test_parameters, test_zome_name},
+        ribosome::{
+            self,
+            api::{
+                commit::tests::test_commit_args_bytes,
+                tests::{test_capability, test_parameters, test_zome_name},
+            },
         },
         ZomeFnCall,
     };

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -1,6 +1,6 @@
 use futures::executor::block_on;
 use holochain_wasm_utils::api_serialization::get_entry::{GetEntryArgs, GetEntryResult};
-use nucleus::{actions::get_entry::get_entry, ribosome::api::Runtime};
+use nucleus::{actions::get_entry::get_entry, ribosome::runtime::Runtime};
 use serde_json;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
@@ -54,8 +54,8 @@ mod tests {
     };
     use instance::tests::{test_context_and_logger, test_instance};
     use nucleus::{
+        ribosome,
         ribosome::api::{
-            call,
             commit::tests::test_commit_args_bytes,
             tests::{test_capability, test_parameters, test_zome_name},
         },
@@ -172,7 +172,7 @@ mod tests {
             "commit_dispatch",
             &test_parameters(),
         );
-        let call_result = call(
+        let call_result = ribosome::run_dna(
             &dna.name.to_string(),
             Arc::clone(&context),
             wasm.clone(),
@@ -194,7 +194,7 @@ mod tests {
             "get_dispatch",
             &test_parameters(),
         );
-        let call_result = call(
+        let call_result = ribosome::run_dna(
             &dna.name.to_string(),
             Arc::clone(&context),
             wasm.clone(),
@@ -238,7 +238,7 @@ mod tests {
             "get_dispatch",
             &test_parameters(),
         );
-        let call_result = call(
+        let call_result = ribosome::run_dna(
             &dna.name.to_string(),
             Arc::clone(&context),
             wasm.clone(),

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -1,7 +1,7 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
 use holochain_core_types::get_links_args::GetLinksArgs;
-use nucleus::ribosome::api::Runtime;
+use nucleus::ribosome::runtime::Runtime;
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -1,7 +1,7 @@
 use action::{Action, ActionWrapper};
 use agent::state::ActionResponse;
 use holochain_core_types::get_links_args::GetLinksArgs;
-use nucleus::ribosome::runtime::Runtime;
+use nucleus::ribosome::Runtime;
 use serde_json;
 use std::sync::mpsc::channel;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};

--- a/core/src/nucleus/ribosome/api/init_globals.rs
+++ b/core/src/nucleus/ribosome/api/init_globals.rs
@@ -1,4 +1,4 @@
-use nucleus::ribosome::api::Runtime;
+use nucleus::ribosome::runtime::Runtime;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 use serde_json;

--- a/core/src/nucleus/ribosome/api/init_globals.rs
+++ b/core/src/nucleus/ribosome/api/init_globals.rs
@@ -1,4 +1,4 @@
-use nucleus::ribosome::runtime::Runtime;
+use nucleus::ribosome::Runtime;
 use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 use serde_json;

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -9,15 +9,12 @@ pub mod get_links;
 pub mod init_globals;
 
 use holochain_dna::zome::capabilities::ReservedCapabilityNames;
-use nucleus::{
-    ribosome::{
-        api::{
-            call::invoke_call, commit::invoke_commit_app_entry, debug::invoke_debug,
-            get_entry::invoke_get_entry, init_globals::invoke_init_globals,
-        },
-        Defn,
-        runtime::Runtime,
+use nucleus::ribosome::{
+    api::{
+        call::invoke_call, commit::invoke_commit_app_entry, debug::invoke_debug,
+        get_entry::invoke_get_entry, init_globals::invoke_init_globals,
     },
+    Defn, Runtime,
 };
 use num_traits::FromPrimitive;
 use std::str::FromStr;

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -8,31 +8,21 @@ pub mod get_entry;
 pub mod get_links;
 pub mod init_globals;
 
-use context::Context;
-use holochain_core_types::error::{HcResult, HolochainError};
 use holochain_dna::zome::capabilities::ReservedCapabilityNames;
-use holochain_wasm_utils::{
-    error::{RibosomeErrorCode, RibosomeReturnCode},
-    memory_allocation::decode_encoded_allocation,
-};
 use nucleus::{
     ribosome::{
         api::{
             call::invoke_call, commit::invoke_commit_app_entry, debug::invoke_debug,
             get_entry::invoke_get_entry, init_globals::invoke_init_globals,
         },
-        memory::SinglePageManager,
         Defn,
+        runtime::Runtime,
     },
-    ZomeFnCall, ZomeFnResult,
 };
 use num_traits::FromPrimitive;
-use std::{str::FromStr, sync::Arc};
-use wasmi::{
-    self, Error as InterpreterError, Externals, FuncInstance, FuncRef, ImportsBuilder,
-    ModuleImportResolver, ModuleInstance, NopExternals, RuntimeArgs, RuntimeValue, Signature, Trap,
-    TrapKind, ValueType,
-};
+use std::str::FromStr;
+
+use wasmi::{RuntimeArgs, RuntimeValue, Trap};
 
 //--------------------------------------------------------------------------------------------------
 // ZOME API FUNCTION DEFINITIONS
@@ -152,250 +142,6 @@ impl ZomeApiFunction {
     }
 }
 
-//--------------------------------------------------------------------------------------------------
-// Wasm call
-//--------------------------------------------------------------------------------------------------
-
-/// Object holding data to pass around to invoked Zome API functions
-#[derive(Clone)]
-pub struct Runtime {
-    // Memory state tracker between ribosome and wasm.
-    memory_manager: SinglePageManager,
-    // Context of Holochain. Required for operating.
-    pub context: Arc<Context>,
-    // Name of the DNA that is being hosted.
-    pub dna_name: String,
-    // The zome function call that initiated the Ribosome.
-    pub zome_call: ZomeFnCall,
-}
-
-impl Runtime {
-    /// Load a string stored in wasm memory.
-    /// Input RuntimeArgs should only have one input which is the encoded allocation holding
-    /// the complex data as an utf8 string.
-    /// Returns the utf8 string.
-    pub fn load_utf8_from_args(&self, args: &RuntimeArgs) -> String {
-        // @TODO don't panic in WASM
-        // @see https://github.com/holochain/holochain-rust/issues/159
-        assert_eq!(1, args.len());
-
-        // Read complex argument serialized in memory
-        let encoded_allocation: u32 = args.nth(0);
-        let maybe_allocation = decode_encoded_allocation(encoded_allocation);
-        let allocation = match maybe_allocation {
-            // Handle empty allocation edge case
-            Err(RibosomeReturnCode::Success) => return String::new(),
-            // Handle error code
-            Err(_) => panic!("received error code instead of valid encoded allocation"),
-            // Handle normal allocation
-            Ok(allocation) => allocation,
-        };
-        let bin_arg = self.memory_manager.read(allocation);
-
-        // convert complex argument
-        String::from_utf8(bin_arg)
-            // @TODO don't panic in WASM
-            // @see https://github.com/holochain/holochain-rust/issues/159
-            .unwrap()
-    }
-
-    /// Store a string in wasm memory.
-    /// Input should be a a json string.
-    /// Returns a Result suitable to return directly from a zome API function, i.e. an encoded allocation
-    pub fn store_utf8(&mut self, json_str: &str) -> Result<Option<RuntimeValue>, Trap> {
-        // write str to runtime memory
-        let mut s_bytes: Vec<_> = json_str.to_string().into_bytes();
-        s_bytes.push(0); // Add string terminate character (important)
-
-        let allocation_of_result = self.memory_manager.write(&s_bytes);
-        if allocation_of_result.is_err() {
-            return Err(Trap::new(TrapKind::MemoryAccessOutOfBounds));
-        }
-        let encoded_allocation = allocation_of_result.unwrap().encode();
-
-        // Return success in i32 format
-        Ok(Some(RuntimeValue::I32(encoded_allocation as i32)))
-    }
-}
-
-/// Executes an exposed zome function in a wasm binary.
-/// Multithreaded function
-/// panics if wasm binary isn't valid.
-pub fn call(
-    dna_name: &str,
-    context: Arc<Context>,
-    wasm: Vec<u8>,
-    zome_call: &ZomeFnCall,
-    parameters: Option<Vec<u8>>,
-) -> ZomeFnResult {
-    // Create wasm module from wasm binary
-    let module = wasmi::Module::from_buffer(wasm).expect("wasm binary should be valid");
-
-    // invoke_index and resolve_func work together to enable callable host functions
-    // within WASM modules, which is how the core API functions
-    // read about the Externals trait for more detail
-
-    // Correlate the indexes of core API functions with a call to the actual function
-    // by implementing the Externals wasmi trait for Runtime
-    impl Externals for Runtime {
-        fn invoke_index(
-            &mut self,
-            index: usize,
-            args: RuntimeArgs,
-        ) -> Result<Option<RuntimeValue>, Trap> {
-            let zf = ZomeApiFunction::from_index(index);
-            match zf {
-                ZomeApiFunction::MissingNo => panic!("unknown function index"),
-                // convert the function to its callable form and call it with the given arguments
-                _ => zf.as_fn()(self, &args),
-            }
-        }
-    }
-
-    // Correlate the names of the core ZomeApiFunction's with their indexes
-    // and declare its function signature (which is always the same)
-    struct RuntimeModuleImportResolver;
-    impl ModuleImportResolver for RuntimeModuleImportResolver {
-        fn resolve_func(
-            &self,
-            field_name: &str,
-            _signature: &Signature,
-        ) -> Result<FuncRef, InterpreterError> {
-            let api_fn = match ZomeApiFunction::from_str(&field_name) {
-                Ok(api_fn) => api_fn,
-                Err(_) => {
-                    return Err(InterpreterError::Function(format!(
-                        "host module doesn't export function with name {}",
-                        field_name
-                    )));
-                }
-            };
-
-            match api_fn {
-                // Abort is a way to receive useful debug info from
-                // assemblyscript memory allocators, see enum definition for function signature
-                ZomeApiFunction::Abort => Ok(FuncInstance::alloc_host(
-                    Signature::new(
-                        &[
-                            ValueType::I32,
-                            ValueType::I32,
-                            ValueType::I32,
-                            ValueType::I32,
-                        ][..],
-                        None,
-                    ),
-                    api_fn as usize,
-                )),
-                // All of our Zome API Functions have the same signature
-                _ => Ok(FuncInstance::alloc_host(
-                    Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
-                    api_fn as usize,
-                )),
-            }
-        }
-    }
-
-    // Create Imports with previously described Resolver
-    let mut imports = ImportsBuilder::new();
-    imports.push_resolver("env", &RuntimeModuleImportResolver);
-
-    // Create module instance from wasm module, and start it if start is defined
-    let wasm_instance = ModuleInstance::new(&module, &imports)
-        .expect("Failed to instantiate module")
-        .run_start(&mut NopExternals)
-        .map_err(|_| HolochainError::RibosomeFailed("Module failed to start".to_string()))?;
-
-    // write input arguments for module call in memory Buffer
-    let input_parameters: Vec<_> = parameters.unwrap_or_default();
-
-    // instantiate runtime struct for passing external state data over wasm but not to wasm
-    let mut runtime = Runtime {
-        memory_manager: SinglePageManager::new(&wasm_instance),
-        context,
-        zome_call: zome_call.clone(),
-        dna_name: dna_name.to_string(),
-    };
-
-    // Write input arguments in wasm memory
-    // scope for mutable borrow of runtime
-    let encoded_allocation_of_input: u32;
-    {
-        let mut_runtime = &mut runtime;
-        let maybe_allocation_of_input = mut_runtime.memory_manager.write(&input_parameters);
-        encoded_allocation_of_input = match maybe_allocation_of_input {
-            // No allocation to write is ok
-            Err(RibosomeErrorCode::ZeroSizedAllocation) => 0,
-            // Any other error is memory related
-            Err(err) => {
-                return Err(HolochainError::RibosomeFailed(err.to_string()));
-            }
-            // Write successful, encode allocation
-            Ok(allocation_of_input) => allocation_of_input.encode(),
-        }
-    }
-
-    // scope for mutable borrow of runtime
-    let returned_encoded_allocation: u32;
-    {
-        let mut_runtime = &mut runtime;
-
-        // invoke function in wasm instance
-        // arguments are info for wasm on how to retrieve complex input arguments
-        // which have been set in memory module
-        returned_encoded_allocation = wasm_instance
-            .invoke_export(
-                zome_call.fn_name.clone().as_str(),
-                &[RuntimeValue::I32(encoded_allocation_of_input as i32)],
-                mut_runtime,
-            )
-            .map_err(|err| HolochainError::RibosomeFailed(err.to_string()))?
-            .unwrap()
-            .try_into()
-            .unwrap();
-    }
-
-    // Handle result returned by called zome function
-    let maybe_allocation = decode_encoded_allocation(returned_encoded_allocation);
-    let return_log_msg: String;
-    let return_result: HcResult<String>;
-    match maybe_allocation {
-        // Nothing in memory, return result depending on return_code received.
-        Err(return_code) => {
-            return_log_msg = return_code.to_string();
-            return_result = match return_code {
-                RibosomeReturnCode::Success => Ok(String::new()),
-                RibosomeReturnCode::Failure(err_code) => {
-                    Err(HolochainError::RibosomeFailed(err_code.to_string()))
-                }
-            };
-        }
-        // Something in memory, try to read and return it
-        Ok(valid_allocation) => {
-            let result = runtime.memory_manager.read(valid_allocation);
-            let maybe_zome_result = String::from_utf8(result);
-            match maybe_zome_result {
-                Err(err) => {
-                    return_log_msg = err.to_string();
-                    return_result = Err(HolochainError::RibosomeFailed(err.to_string()));
-                }
-                Ok(json_str) => {
-                    return_log_msg = json_str.clone();
-                    return_result = Ok(json_str);
-                }
-            }
-        }
-    };
-    // Log & done
-    runtime
-        .context
-        .log(&format!(
-            "Zome Function '{}' returned: {}",
-            zome_call.fn_name, return_log_msg,
-        ))
-        .expect("Logger should work");
-    return return_result;
-}
-
 #[cfg(test)]
 pub mod tests {
     extern crate holochain_agent;
@@ -409,7 +155,7 @@ pub mod tests {
         Instance,
     };
     use nucleus::{
-        ribosome::{api::call, Defn},
+        ribosome::{self, Defn},
         ZomeFnCall,
     };
     use std::{
@@ -548,7 +294,7 @@ pub mod tests {
             &test_parameters(),
         );
         (
-            call(
+            ribosome::run_dna(
                 &dna_name,
                 context,
                 wasm.clone(),

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -140,7 +140,7 @@ pub(crate) fn run_callback(
     wasm: &DnaWasm,
     app_name: String,
 ) -> CallbackResult {
-    match ribosome::api::call(
+    match ribosome::run_dna(
         &app_name,
         context,
         wasm.code.clone(),

--- a/core/src/nucleus/ribosome/callback/validate_entry.rs
+++ b/core/src/nucleus/ribosome/callback/validate_entry.rs
@@ -101,7 +101,7 @@ fn run_validation_callback(
     wasm: &DnaWasm,
     dna_name: String,
 ) -> CallbackResult {
-    match ribosome::api::call(
+    match ribosome::run_dna(
         &dna_name,
         context,
         wasm.code.clone(),

--- a/core/src/nucleus/ribosome/mod.rs
+++ b/core/src/nucleus/ribosome/mod.rs
@@ -4,9 +4,9 @@ pub mod api;
 pub mod callback;
 pub mod memory;
 mod run_dna;
-pub mod runtime;
+mod runtime;
 
-pub use self::run_dna::*;
+pub use self::{run_dna::*, runtime::*};
 
 use holochain_dna::zome::capabilities::ReservedCapabilityNames;
 

--- a/core/src/nucleus/ribosome/mod.rs
+++ b/core/src/nucleus/ribosome/mod.rs
@@ -3,6 +3,10 @@
 pub mod api;
 pub mod callback;
 pub mod memory;
+mod run_dna;
+pub mod runtime;
+
+pub use self::run_dna::*;
 
 use holochain_dna::zome::capabilities::ReservedCapabilityNames;
 

--- a/core/src/nucleus/ribosome/run_dna.rs
+++ b/core/src/nucleus/ribosome/run_dna.rs
@@ -1,4 +1,3 @@
-
 use context::Context;
 use holochain_core_types::error::{HcResult, HolochainError};
 use holochain_wasm_utils::{
@@ -6,19 +5,13 @@ use holochain_wasm_utils::{
     memory_allocation::decode_encoded_allocation,
 };
 use nucleus::{
-    ribosome::{
-        api::{
-            ZomeApiFunction,
-        },
-        memory::SinglePageManager,
-        runtime::Runtime,
-    },
+    ribosome::{api::ZomeApiFunction, memory::SinglePageManager, Runtime},
     ZomeFnCall, ZomeFnResult,
 };
 use std::{str::FromStr, sync::Arc};
 use wasmi::{
-    self, Error as InterpreterError, FuncInstance, FuncRef, ImportsBuilder,
-    ModuleImportResolver, ModuleInstance, NopExternals, RuntimeValue, Signature, ValueType,
+    self, Error as InterpreterError, FuncInstance, FuncRef, ImportsBuilder, ModuleImportResolver,
+    ModuleInstance, NopExternals, RuntimeValue, Signature, ValueType,
 };
 
 /// Executes an exposed zome function in a wasm binary.

--- a/core/src/nucleus/ribosome/run_dna.rs
+++ b/core/src/nucleus/ribosome/run_dna.rs
@@ -1,0 +1,183 @@
+
+use context::Context;
+use holochain_core_types::error::{HcResult, HolochainError};
+use holochain_wasm_utils::{
+    error::{RibosomeErrorCode, RibosomeReturnCode},
+    memory_allocation::decode_encoded_allocation,
+};
+use nucleus::{
+    ribosome::{
+        api::{
+            ZomeApiFunction,
+        },
+        memory::SinglePageManager,
+        runtime::Runtime,
+    },
+    ZomeFnCall, ZomeFnResult,
+};
+use std::{str::FromStr, sync::Arc};
+use wasmi::{
+    self, Error as InterpreterError, FuncInstance, FuncRef, ImportsBuilder,
+    ModuleImportResolver, ModuleInstance, NopExternals, RuntimeValue, Signature, ValueType,
+};
+
+/// Executes an exposed zome function in a wasm binary.
+/// Multithreaded function
+/// panics if wasm binary isn't valid.
+pub fn run_dna(
+    dna_name: &str,
+    context: Arc<Context>,
+    wasm: Vec<u8>,
+    zome_call: &ZomeFnCall,
+    parameters: Option<Vec<u8>>,
+) -> ZomeFnResult {
+    // Create wasm module from wasm binary
+    let module = wasmi::Module::from_buffer(wasm).expect("wasm binary should be valid");
+
+    // invoke_index and resolve_func work together to enable callable host functions
+    // within WASM modules, which is how the core API functions
+    // read about the Externals trait for more detail
+
+    // Correlate the names of the core ZomeApiFunction's with their indexes
+    // and declare its function signature (which is always the same)
+    struct RuntimeModuleImportResolver;
+    impl ModuleImportResolver for RuntimeModuleImportResolver {
+        fn resolve_func(
+            &self,
+            field_name: &str,
+            _signature: &Signature,
+        ) -> Result<FuncRef, InterpreterError> {
+            let api_fn = match ZomeApiFunction::from_str(&field_name) {
+                Ok(api_fn) => api_fn,
+                Err(_) => {
+                    return Err(InterpreterError::Function(format!(
+                        "host module doesn't export function with name {}",
+                        field_name
+                    )));
+                }
+            };
+
+            match api_fn {
+                // Abort is a way to receive useful debug info from
+                // assemblyscript memory allocators, see enum definition for function signature
+                ZomeApiFunction::Abort => Ok(FuncInstance::alloc_host(
+                    Signature::new(
+                        &[
+                            ValueType::I32,
+                            ValueType::I32,
+                            ValueType::I32,
+                            ValueType::I32,
+                        ][..],
+                        None,
+                    ),
+                    api_fn as usize,
+                )),
+                // All of our Zome API Functions have the same signature
+                _ => Ok(FuncInstance::alloc_host(
+                    Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
+                    api_fn as usize,
+                )),
+            }
+        }
+    }
+
+    // Create Imports with previously described Resolver
+    let mut imports = ImportsBuilder::new();
+    imports.push_resolver("env", &RuntimeModuleImportResolver);
+
+    // Create module instance from wasm module, and start it if start is defined
+    let wasm_instance = ModuleInstance::new(&module, &imports)
+        .expect("Failed to instantiate module")
+        .run_start(&mut NopExternals)
+        .map_err(|_| HolochainError::RibosomeFailed("Module failed to start".to_string()))?;
+
+    // write input arguments for module call in memory Buffer
+    let input_parameters: Vec<_> = parameters.unwrap_or_default();
+
+    // instantiate runtime struct for passing external state data over wasm but not to wasm
+    let mut runtime = Runtime {
+        memory_manager: SinglePageManager::new(&wasm_instance),
+        context,
+        zome_call: zome_call.clone(),
+        dna_name: dna_name.to_string(),
+    };
+
+    // Write input arguments in wasm memory
+    // scope for mutable borrow of runtime
+    let encoded_allocation_of_input: u32;
+    {
+        let mut_runtime = &mut runtime;
+        let maybe_allocation_of_input = mut_runtime.memory_manager.write(&input_parameters);
+        encoded_allocation_of_input = match maybe_allocation_of_input {
+            // No allocation to write is ok
+            Err(RibosomeErrorCode::ZeroSizedAllocation) => 0,
+            // Any other error is memory related
+            Err(err) => {
+                return Err(HolochainError::RibosomeFailed(err.to_string()));
+            }
+            // Write successful, encode allocation
+            Ok(allocation_of_input) => allocation_of_input.encode(),
+        }
+    }
+
+    // scope for mutable borrow of runtime
+    let returned_encoded_allocation: u32;
+    {
+        let mut_runtime = &mut runtime;
+
+        // invoke function in wasm instance
+        // arguments are info for wasm on how to retrieve complex input arguments
+        // which have been set in memory module
+        returned_encoded_allocation = wasm_instance
+            .invoke_export(
+                zome_call.fn_name.clone().as_str(),
+                &[RuntimeValue::I32(encoded_allocation_of_input as i32)],
+                mut_runtime,
+            )
+            .map_err(|err| HolochainError::RibosomeFailed(err.to_string()))?
+            .unwrap()
+            .try_into()
+            .unwrap();
+    }
+
+    // Handle result returned by called zome function
+    let maybe_allocation = decode_encoded_allocation(returned_encoded_allocation);
+    let return_log_msg: String;
+    let return_result: HcResult<String>;
+    match maybe_allocation {
+        // Nothing in memory, return result depending on return_code received.
+        Err(return_code) => {
+            return_log_msg = return_code.to_string();
+            return_result = match return_code {
+                RibosomeReturnCode::Success => Ok(String::new()),
+                RibosomeReturnCode::Failure(err_code) => {
+                    Err(HolochainError::RibosomeFailed(err_code.to_string()))
+                }
+            };
+        }
+        // Something in memory, try to read and return it
+        Ok(valid_allocation) => {
+            let result = runtime.memory_manager.read(valid_allocation);
+            let maybe_zome_result = String::from_utf8(result);
+            match maybe_zome_result {
+                Err(err) => {
+                    return_log_msg = err.to_string();
+                    return_result = Err(HolochainError::RibosomeFailed(err.to_string()));
+                }
+                Ok(json_str) => {
+                    return_log_msg = json_str.clone();
+                    return_result = Ok(json_str);
+                }
+            }
+        }
+    };
+    // Log & done
+    runtime
+        .context
+        .log(&format!(
+            "Zome Function '{}' returned: {}",
+            zome_call.fn_name, return_log_msg,
+        ))
+        .expect("Logger should work");
+    return return_result;
+}

--- a/core/src/nucleus/ribosome/runtime.rs
+++ b/core/src/nucleus/ribosome/runtime.rs
@@ -1,0 +1,97 @@
+
+use context::Context;
+use holochain_wasm_utils::{
+    error::RibosomeReturnCode,
+    memory_allocation::decode_encoded_allocation,
+};
+use nucleus::{
+    ribosome::{
+        api::{
+            ZomeApiFunction,
+        },
+        memory::SinglePageManager,
+        Defn,
+    },
+    ZomeFnCall,
+};
+use std::sync::Arc;
+use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap, TrapKind};
+
+/// Object holding data to pass around to invoked Zome API functions
+#[derive(Clone)]
+pub struct Runtime {
+    // Memory state tracker between ribosome and wasm.
+    pub memory_manager: SinglePageManager,
+    // Context of Holochain. Required for operating.
+    pub context: Arc<Context>,
+    // Name of the DNA that is being hosted.
+    pub dna_name: String,
+    // The zome function call that initiated the Ribosome.
+    pub zome_call: ZomeFnCall,
+}
+
+impl Runtime {
+    /// Load a string stored in wasm memory.
+    /// Input RuntimeArgs should only have one input which is the encoded allocation holding
+    /// the complex data as an utf8 string.
+    /// Returns the utf8 string.
+    pub fn load_utf8_from_args(&self, args: &RuntimeArgs) -> String {
+        // @TODO don't panic in WASM
+        // @see https://github.com/holochain/holochain-rust/issues/159
+        assert_eq!(1, args.len());
+
+        // Read complex argument serialized in memory
+        let encoded_allocation: u32 = args.nth(0);
+        let maybe_allocation = decode_encoded_allocation(encoded_allocation);
+        let allocation = match maybe_allocation {
+            // Handle empty allocation edge case
+            Err(RibosomeReturnCode::Success) => return String::new(),
+            // Handle error code
+            Err(_) => panic!("received error code instead of valid encoded allocation"),
+            // Handle normal allocation
+            Ok(allocation) => allocation,
+        };
+        let bin_arg = self.memory_manager.read(allocation);
+
+        // convert complex argument
+        String::from_utf8(bin_arg)
+            // @TODO don't panic in WASM
+            // @see https://github.com/holochain/holochain-rust/issues/159
+            .unwrap()
+    }
+
+    /// Store a string in wasm memory.
+    /// Input should be a a json string.
+    /// Returns a Result suitable to return directly from a zome API function, i.e. an encoded allocation
+    pub fn store_utf8(&mut self, json_str: &str) -> Result<Option<RuntimeValue>, Trap> {
+        // write str to runtime memory
+        let mut s_bytes: Vec<_> = json_str.to_string().into_bytes();
+        s_bytes.push(0); // Add string terminate character (important)
+
+        let allocation_of_result = self.memory_manager.write(&s_bytes);
+        if allocation_of_result.is_err() {
+            return Err(Trap::new(TrapKind::MemoryAccessOutOfBounds));
+        }
+        let encoded_allocation = allocation_of_result.unwrap().encode();
+
+        // Return success in i32 format
+        Ok(Some(RuntimeValue::I32(encoded_allocation as i32)))
+    }
+}
+
+// Correlate the indexes of core API functions with a call to the actual function
+// by implementing the Externals trait from Wasmi.
+impl Externals for Runtime {
+    fn invoke_index(
+        &mut self,
+        index: usize,
+        args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, Trap> {
+        let zf = ZomeApiFunction::from_index(index);
+        match zf {
+            ZomeApiFunction::MissingNo => panic!("unknown function index"),
+            // convert the function to its callable form and call it with the given arguments
+            _ => zf.as_fn()(self, &args),
+        }
+    }
+}

--- a/core/src/nucleus/ribosome/runtime.rs
+++ b/core/src/nucleus/ribosome/runtime.rs
@@ -1,17 +1,9 @@
-
 use context::Context;
 use holochain_wasm_utils::{
-    error::RibosomeReturnCode,
-    memory_allocation::decode_encoded_allocation,
+    error::RibosomeReturnCode, memory_allocation::decode_encoded_allocation,
 };
 use nucleus::{
-    ribosome::{
-        api::{
-            ZomeApiFunction,
-        },
-        memory::SinglePageManager,
-        Defn,
-    },
+    ribosome::{api::ZomeApiFunction, memory::SinglePageManager, Defn},
     ZomeFnCall,
 };
 use std::sync::Arc;


### PR DESCRIPTION
and moved it in its own file out of 'api' folder.
Move runtime to its own file as well.

There was too much confusion with call() of the hdk api.