### PR TITLE
implements get with options as per app-spec pr #32

### DIFF
--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -6,7 +6,7 @@ pub use holochain_wasm_utils::api_serialization::validation::*;
 use holochain_wasm_utils::{
     api_serialization::{
         commit::{CommitEntryArgs, CommitEntryResult},
-        get_entry::{GetEntryArgs, GetEntryResult, GetResultStatus},
+        get_entry::{GetEntryArgs, GetEntryOptions, GetEntryResult},
     },
     holochain_core_types::hash::HashString,
     memory_allocation::*,
@@ -292,7 +292,10 @@ pub fn remove_entry<S: Into<String>>(
 }
 
 /// implements access to low-level WASM hc_get_entry
-pub fn get_entry(entry_hash: HashString) -> Result<Option<String>, RibosomeError> {
+pub fn get_entry(
+    entry_hash: HashString,
+    _options: GetEntryOptions,
+) -> Result<GetEntryResult, RibosomeError> {
     let mut mem_stack: SinglePageStack;
     unsafe {
         mem_stack = G_MEM_STACK.unwrap();
@@ -325,10 +328,7 @@ pub fn get_entry(entry_hash: HashString) -> Result<Option<String>, RibosomeError
         .deallocate(allocation_of_input)
         .expect("deallocate failed");
 
-    match result.status {
-        GetResultStatus::Found => Ok(Some(result.entry)),
-        GetResultStatus::NotFound => Ok(None),
-    }
+    Ok(result)
 }
 
 /// FIXME DOC

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -9,13 +9,13 @@ extern crate serde_derive;
 extern crate boolinator;
 
 use boolinator::Boolinator;
-use hdk::globals::G_MEM_STACK;
+use hdk::{globals::G_MEM_STACK, RibosomeError};
 use holochain_wasm_utils::{
-    error::RibosomeErrorCode,
-    holochain_core_types::hash::HashString,
-    memory_serialization::*, memory_allocation::*
+    error::RibosomeErrorCode, holochain_core_types::hash::HashString, memory_allocation::*,
+    memory_serialization::*,
 };
-use hdk::RibosomeError;
+
+use holochain_wasm_utils::api_serialization::get_entry::{GetEntryOptions, GetResultStatus};
 
 #[no_mangle]
 pub extern "C" fn check_global(encoded_allocation_of_input: u32) -> u32 {
@@ -32,7 +32,6 @@ pub extern "C" fn check_global(encoded_allocation_of_input: u32) -> u32 {
     return 0;
 }
 
-
 #[derive(Deserialize, Serialize, Default)]
 struct CommitOutputStruct {
     address: String,
@@ -40,7 +39,6 @@ struct CommitOutputStruct {
 
 #[no_mangle]
 pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
-
     #[derive(Deserialize, Default)]
     struct CommitInputStruct {
         entry_type_name: String,
@@ -48,7 +46,8 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
     }
 
     unsafe {
-        G_MEM_STACK = Some(SinglePageStack::from_encoded_allocation(encoded_allocation_of_input).unwrap());
+        G_MEM_STACK =
+            Some(SinglePageStack::from_encoded_allocation(encoded_allocation_of_input).unwrap());
     }
 
     // Deserialize and check for an encoded error
@@ -64,13 +63,13 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
     let res = hdk::commit_entry(&input.entry_type_name, entry_content);
 
     let res_obj = match res {
-        Ok(hash_str) => CommitOutputStruct {address: hash_str.to_string()},
-        Err(RibosomeError::RibosomeFailed(err_str)) => {
-            unsafe {
-                return store_json_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), err_str) as u32;
-            }
+        Ok(hash_str) => CommitOutputStruct {
+            address: hash_str.to_string(),
         },
-       Err(_) => unreachable!(),
+        Err(RibosomeError::RibosomeFailed(err_str)) => unsafe {
+            return store_json_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), err_str) as u32;
+        },
+        Err(_) => unreachable!(),
     };
     unsafe {
         return store_json_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), res_obj) as u32;
@@ -91,22 +90,23 @@ zome_functions! {
     }
 
     check_get_entry: |entry_hash: HashString| {
-        let res = hdk::get_entry(entry_hash);
+        let res = hdk::get_entry(entry_hash,GetEntryOptions{});
         match res {
-            Ok(Some(entry)) => {
-                let maybe_entry_value : Result<serde_json::Value, _> = serde_json::from_str(&entry);
-                match maybe_entry_value {
-                    Ok(entry_value) => entry_value,
-                    Err(err) => json!({"error trying deserialize entry": err.to_string()}),
-                }
-            },
-            Ok(None) => json!({"got back no entry": true}),
+            Ok(result) => match result.status {
+                GetResultStatus::Found => {
+                    let maybe_entry_value : Result<serde_json::Value, _> = serde_json::from_str(&result.entry);
+                    match maybe_entry_value {
+                        Ok(entry_value) => entry_value,
+                        Err(err) => json!({"error trying deserialize entry": err.to_string()}),
+                    }
+                },
+                GetResultStatus::NotFound => json!({"got back no entry": true}),
+            }
             Err(RibosomeError::RibosomeFailed(err_str)) => json!({"get entry Err": err_str}),
             Err(_) => unreachable!(),
         }
     }
 }
-
 
 #[derive(Serialize, Deserialize)]
 struct TweetResponse {

--- a/wasm_utils/src/api_serialization/get_entry.rs
+++ b/wasm_utils/src/api_serialization/get_entry.rs
@@ -13,10 +13,7 @@ pub enum GetResultStatus {
 
 // empty for now, need to implement get options
 #[derive(Deserialize, Debug, Serialize)]
-pub struct GetEntryOptions {
-
-}
-
+pub struct GetEntryOptions {}
 
 #[derive(Deserialize, Debug, Serialize)]
 pub struct GetEntryResult {

--- a/wasm_utils/src/api_serialization/get_entry.rs
+++ b/wasm_utils/src/api_serialization/get_entry.rs
@@ -11,6 +11,13 @@ pub enum GetResultStatus {
     NotFound,
 }
 
+// empty for now, need to implement get options
+#[derive(Deserialize, Debug, Serialize)]
+pub struct GetEntryOptions {
+
+}
+
+
 #[derive(Deserialize, Debug, Serialize)]
 pub struct GetEntryResult {
     pub status: GetResultStatus,


### PR DESCRIPTION
This PR implements passing in an Options argument to get_entry and it's returning the GetEntryResult itself instead of the Option<String> where the string is the json entry.

This PR does not implement any of the Options themselves, that'll be for a separate PR, it just sets up the structure.