### PR TITLE
[ERROR] Step 1: Moved hdk error to its own file.

### DIFF
--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -1,6 +1,5 @@
 use serde_json;
-
-use self::RibosomeError::*;
+use error::{ZomeApiError, ZomeApiResult};
 use globals::*;
 pub use holochain_wasm_utils::api_serialization::validation::*;
 use holochain_wasm_utils::{
@@ -48,27 +47,6 @@ lazy_static! {
 //--------------------------------------------------------------------------------------------------
 // SYSTEM CONSTS
 //--------------------------------------------------------------------------------------------------
-
-// HC.HashNotFound
-#[derive(Debug)]
-pub enum RibosomeError {
-    RibosomeFailed(String),
-    FunctionNotImplemented,
-    HashNotFound,
-    ValidationFailed(String),
-}
-
-impl RibosomeError {
-    pub fn to_json(&self) -> serde_json::Value {
-        let err_str = match self {
-            RibosomeFailed(error_desc) => error_desc.clone(),
-            FunctionNotImplemented => "Function not implemented".to_string(),
-            HashNotFound => "Hash not found".to_string(),
-            ValidationFailed(msg) => format!("Validation failed: {}", msg),
-        };
-        json!({ "error": err_str })
-    }
-}
 
 // HC.Status
 // WARNING keep in sync with CRUDStatus
@@ -161,26 +139,26 @@ pub enum BundleOnClose {
 /// Returns an application property, which are defined by the app developer.
 /// It returns values from the DNA file that you set as properties of your application
 /// (e.g. Name, Language, Description, Author, etc.).
-pub fn property<S: Into<String>>(_name: S) -> Result<String, RibosomeError> {
+pub fn property<S: Into<String>>(_name: S) -> ZomeApiResult<String> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
 pub fn make_hash<S: Into<String>>(
     _entry_type: S,
     _entry_data: serde_json::Value,
-) -> Result<HashString, RibosomeError> {
+) -> Result<HashString, ZomeApiError> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
-pub fn debug(msg: &str) -> Result<(), RibosomeError> {
+pub fn debug(msg: &str) -> Result<(), ZomeApiError> {
     let mut mem_stack = unsafe { G_MEM_STACK.unwrap() };
     let maybe_allocation_of_input = store_as_json(&mut mem_stack, msg);
     if let Err(err_code) = maybe_allocation_of_input {
-        return Err(RibosomeError::RibosomeFailed(err_code.to_string()));
+        return Err(ZomeApiError::Internal(err_code.to_string()));
     }
     let allocation_of_input = maybe_allocation_of_input.unwrap();
     unsafe {
@@ -198,15 +176,15 @@ pub fn call<S: Into<String>>(
     _cap_name: S,
     _function_name: S,
     _arguments: serde_json::Value,
-) -> Result<serde_json::Value, RibosomeError> {
+) -> ZomeApiResult<serde_json::Value> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
-pub fn sign<S: Into<String>>(_doc: S) -> Result<String, RibosomeError> {
+pub fn sign<S: Into<String>>(_doc: S) -> ZomeApiResult<String> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
@@ -214,16 +192,16 @@ pub fn verify_signature<S: Into<String>>(
     _signature: S,
     _data: S,
     _pub_key: S,
-) -> Result<bool, RibosomeError> {
+) -> ZomeApiResult<bool> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
 pub fn commit_entry(
     entry_type_name: &str,
     entry_content: serde_json::Value,
-) -> Result<HashString, RibosomeError> {
+) -> ZomeApiResult<HashString> {
     let mut mem_stack: SinglePageStack;
     unsafe {
         mem_stack = G_MEM_STACK.unwrap();
@@ -236,7 +214,7 @@ pub fn commit_entry(
     };
     let maybe_allocation_of_input = store_as_json(&mut mem_stack, input);
     if let Err(err_code) = maybe_allocation_of_input {
-        return Err(RibosomeError::RibosomeFailed(err_code.to_string()));
+        return Err(ZomeApiError::Internal(err_code.to_string()));
     }
     let allocation_of_input = maybe_allocation_of_input.unwrap();
 
@@ -249,7 +227,7 @@ pub fn commit_entry(
     let result = load_json(encoded_allocation_of_result as u32);
 
     if let Err(err_str) = result {
-        return Err(RibosomeError::RibosomeFailed(err_str));
+        return Err(ZomeApiError::Internal(err_str));
     }
     let output: CommitEntryResult = result.unwrap();
 
@@ -259,7 +237,7 @@ pub fn commit_entry(
         .expect("deallocate failed");
 
     if output.validation_failure.len() > 0 {
-        Err(RibosomeError::ValidationFailed(output.validation_failure))
+        Err(ZomeApiError::ValidationFailed(output.validation_failure))
     } else {
         Ok(HashString::from(output.address))
     }
@@ -270,15 +248,15 @@ pub fn update_entry<S: Into<String>>(
     _entry_type: S,
     _entry: serde_json::Value,
     _replaces: HashString,
-) -> Result<HashString, RibosomeError> {
+) -> ZomeApiResult<HashString> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
-pub fn update_agent() -> Result<HashString, RibosomeError> {
+pub fn update_agent() -> ZomeApiResult<HashString> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
@@ -286,16 +264,16 @@ pub fn update_agent() -> Result<HashString, RibosomeError> {
 pub fn remove_entry<S: Into<String>>(
     _entry: HashString,
     _message: S,
-) -> Result<HashString, RibosomeError> {
+) -> ZomeApiResult<HashString> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// implements access to low-level WASM hc_get_entry
 pub fn get_entry(
     entry_hash: HashString,
     _options: GetEntryOptions,
-) -> Result<GetEntryResult, RibosomeError> {
+) -> ZomeApiResult<GetEntryResult> {
     let mut mem_stack: SinglePageStack;
     unsafe {
         mem_stack = G_MEM_STACK.unwrap();
@@ -307,7 +285,7 @@ pub fn get_entry(
     };
     let maybe_allocation_of_input = store_as_json(&mut mem_stack, input);
     if let Err(err_code) = maybe_allocation_of_input {
-        return Err(RibosomeError::RibosomeFailed(err_code.to_string()));
+        return Err(ZomeApiError::Internal(err_code.to_string()));
     }
     let allocation_of_input = maybe_allocation_of_input.unwrap();
 
@@ -319,7 +297,7 @@ pub fn get_entry(
     // Deserialize complex result stored in memory and check for ERROR in encoding
     let result = load_json(encoded_allocation_of_result as u32);
     if let Err(err_str) = result {
-        return Err(RibosomeError::RibosomeFailed(err_str));
+        return Err(ZomeApiError::Internal(err_str));
     }
     let result: GetEntryResult = result.unwrap();
 
@@ -336,43 +314,43 @@ pub fn link_entries<S: Into<String>>(
     _base: HashString,
     _target: HashString,
     _tag: S,
-) -> Result<(), RibosomeError> {
+) -> Result<(), ZomeApiError> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
 pub fn get_links<S: Into<String>>(
     _base: HashString,
     _tag: S,
-) -> Result<Vec<HashString>, RibosomeError> {
+) -> ZomeApiResult<Vec<HashString>> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
-pub fn query() -> Result<Vec<String>, RibosomeError> {
+pub fn query() -> ZomeApiResult<Vec<String>> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
 pub fn send(
     _to: HashString,
     _message: serde_json::Value,
-) -> Result<serde_json::Value, RibosomeError> {
+) -> ZomeApiResult<serde_json::Value> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
-pub fn start_bundle(_timeout: usize, _user_param: serde_json::Value) -> Result<(), RibosomeError> {
+pub fn start_bundle(_timeout: usize, _user_param: serde_json::Value) -> Result<(), ZomeApiError> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }
 
 /// FIXME DOC
-pub fn close_bundle(_action: BundleOnClose) -> Result<(), RibosomeError> {
+pub fn close_bundle(_action: BundleOnClose) -> Result<(), ZomeApiError> {
     // FIXME
-    Err(RibosomeError::FunctionNotImplemented)
+    Err(ZomeApiError::FunctionNotImplemented)
 }

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -1,4 +1,3 @@
-use serde_json;
 use error::{ZomeApiError, ZomeApiResult};
 use globals::*;
 pub use holochain_wasm_utils::api_serialization::validation::*;
@@ -11,6 +10,7 @@ use holochain_wasm_utils::{
     memory_allocation::*,
     memory_serialization::*,
 };
+use serde_json;
 
 //--------------------------------------------------------------------------------------------------
 // APP GLOBAL VARIABLES
@@ -261,10 +261,7 @@ pub fn update_agent() -> ZomeApiResult<HashString> {
 
 /// FIXME DOC
 /// Commit a Deletion System Entry
-pub fn remove_entry<S: Into<String>>(
-    _entry: HashString,
-    _message: S,
-) -> ZomeApiResult<HashString> {
+pub fn remove_entry<S: Into<String>>(_entry: HashString, _message: S) -> ZomeApiResult<HashString> {
     // FIXME
     Err(ZomeApiError::FunctionNotImplemented)
 }
@@ -320,10 +317,7 @@ pub fn link_entries<S: Into<String>>(
 }
 
 /// FIXME DOC
-pub fn get_links<S: Into<String>>(
-    _base: HashString,
-    _tag: S,
-) -> ZomeApiResult<Vec<HashString>> {
+pub fn get_links<S: Into<String>>(_base: HashString, _tag: S) -> ZomeApiResult<Vec<HashString>> {
     // FIXME
     Err(ZomeApiError::FunctionNotImplemented)
 }
@@ -335,10 +329,7 @@ pub fn query() -> ZomeApiResult<Vec<String>> {
 }
 
 /// FIXME DOC
-pub fn send(
-    _to: HashString,
-    _message: serde_json::Value,
-) -> ZomeApiResult<serde_json::Value> {
+pub fn send(_to: HashString, _message: serde_json::Value) -> ZomeApiResult<serde_json::Value> {
     // FIXME
     Err(ZomeApiError::FunctionNotImplemented)
 }

--- a/hdk-rust/src/error.rs
+++ b/hdk-rust/src/error.rs
@@ -1,6 +1,6 @@
-use serde_json;
-use std::{fmt, error::Error};
 use self::ZomeApiError::*;
+use serde_json;
+use std::{error::Error, fmt};
 
 pub type ZomeApiResult<T> = Result<T, ZomeApiError>;
 

--- a/hdk-rust/src/error.rs
+++ b/hdk-rust/src/error.rs
@@ -1,0 +1,43 @@
+use serde_json;
+use std::{fmt, error::Error};
+use self::ZomeApiError::*;
+
+pub type ZomeApiResult<T> = Result<T, ZomeApiError>;
+
+/// Error for DNA developers to use in their zome code.
+/// They do not have to send this error back to Ribosome unless its an InternalError.
+#[derive(Debug, Serialize)]
+pub enum ZomeApiError {
+    Internal(String),
+    FunctionNotImplemented,
+    HashNotFound,
+    ValidationFailed(String),
+}
+
+impl ZomeApiError {
+    pub fn to_json(&self) -> serde_json::Value {
+        json!({ "error": self })
+    }
+}
+
+impl Error for ZomeApiError {
+    #[cfg_attr(rustfmt, rustfmt_skip)]
+    fn description(&self) -> &str {
+        match self {
+            Internal(msg)           => &msg,
+            FunctionNotImplemented  => "Function not implemented",
+            HashNotFound            => "Hash not found",
+            ValidationFailed(msg)   => &msg,
+        }
+    }
+}
+
+impl fmt::Display for ZomeApiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // @TODO seems weird to use debug for display
+        // replacing {:?} with {} gives a stack overflow on to_string() (there's a test for this)
+        // what is the right way to do this?
+        // @see https://github.com/holochain/holochain-rust/issues/223
+        write!(f, "{:?}", self)
+    }
+}

--- a/hdk-rust/src/lib.rs
+++ b/hdk-rust/src/lib.rs
@@ -13,6 +13,7 @@ extern crate lazy_static;
 pub extern crate holochain_wasm_utils;
 
 mod api;
+pub mod error;
 pub mod global_fns;
 pub mod globals;
 pub mod init_globals;

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -9,7 +9,7 @@ extern crate serde_derive;
 extern crate boolinator;
 
 use boolinator::Boolinator;
-use hdk::{globals::G_MEM_STACK, RibosomeError};
+use hdk::{globals::G_MEM_STACK, error::ZomeApiError};
 use holochain_wasm_utils::{
     error::RibosomeErrorCode, holochain_core_types::hash::HashString, memory_allocation::*,
     memory_serialization::*,
@@ -52,8 +52,8 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
 
     // Deserialize and check for an encoded error
     let result = load_json(encoded_allocation_of_input as u32);
-    if let Err(e) = result {
-        hdk::debug(&format!("ERROR: {:?}", e)).expect("debug() must work");
+    if let Err(err_str) = result {
+        hdk::debug(&format!("ERROR: {:?}", err_str)).expect("debug() must work");
         return RibosomeErrorCode::ArgumentDeserializationFailed as u32;
     }
 
@@ -66,7 +66,7 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: u32) -> u32 {
         Ok(hash_str) => CommitOutputStruct {
             address: hash_str.to_string(),
         },
-        Err(RibosomeError::RibosomeFailed(err_str)) => unsafe {
+        Err(ZomeApiError::Internal(err_str)) => unsafe {
             return store_json_into_encoded_allocation(&mut G_MEM_STACK.unwrap(), err_str) as u32;
         },
         Err(_) => unreachable!(),
@@ -83,8 +83,8 @@ zome_functions! {
         let res = hdk::commit_entry(&entry_type_name, entry_content.unwrap());
         match res {
             Ok(hash_str) => json!({ "address": hash_str }),
-            Err(RibosomeError::ValidationFailed(msg)) => json!({ "validation failed": msg}),
-            Err(RibosomeError::RibosomeFailed(err_str)) => json!({ "error": err_str}),
+            Err(ZomeApiError::ValidationFailed(msg)) => json!({ "validation failed": msg}),
+            Err(ZomeApiError::Internal(err_str)) => json!({ "error": err_str}),
             Err(_) => unreachable!(),
         }
     }
@@ -102,7 +102,7 @@ zome_functions! {
                 },
                 GetResultStatus::NotFound => json!({"got back no entry": true}),
             }
-            Err(RibosomeError::RibosomeFailed(err_str)) => json!({"get entry Err": err_str}),
+            Err(ZomeApiError::Internal(err_str)) => json!({"get entry Err": err_str}),
             Err(_) => unreachable!(),
         }
     }


### PR DESCRIPTION
and renamed RibosomeError to ZomeApiError, as well as RibosomeFailed to Internal.

ZomeApiError now implements standard Error trait.

This changes the hdk rust api  @Connoropolous 

Had to to rename RibosomeError because I need this name for upcoming changes in core for error system.