### PR TITLE
Rename AGENT_KEY_HASH to AGENT_ADDRESS

### DIFF
--- a/core/src/nucleus/ribosome/api/init_globals.rs
+++ b/core/src/nucleus/ribosome/api/init_globals.rs
@@ -19,7 +19,7 @@ pub fn invoke_init_globals(
         dna_hash: HashString::from(""),
         agent_id_str: runtime.context.agent.to_string(),
         // TODO #233 - Implement agent pub key hash
-        agent_key_hash: HashString::encode_from_str("FIXME-agent_key_hash", Multihash::SHA2256),
+        agent_address: HashString::encode_from_str("FIXME-agent_address", Multihash::SHA2256),
         agent_initial_hash: HashString::from(""),
         agent_latest_hash: HashString::from(""),
     };
@@ -44,7 +44,7 @@ pub fn invoke_init_globals(
             if found_entries.len() > 0 {
                 globals.agent_latest_hash = found_entries[0].clone();
                 globals.agent_initial_hash = found_entries.pop().unwrap();
-                globals.agent_key_hash = globals.agent_latest_hash.clone();
+                globals.agent_address = globals.agent_latest_hash.clone();
             }
         }
     };
@@ -71,8 +71,8 @@ pub mod tests {
         call_result.pop(); // Remove trailing character
         let globals: ZomeApiGlobals = serde_json::from_str(&call_result).unwrap();
         assert_eq!(globals.dna_name, "TestApp");
-        // TODO #233 - Implement agent pub key hash
-        // assert_eq!(obj.agent_key_hash, "QmScgMGDzP3d9kmePsXP7ZQ2MXis38BNRpCZBJEBveqLjD");
+        // TODO #233 - Implement agent address
+        // assert_eq!(obj.agent_address, "QmScgMGDzP3d9kmePsXP7ZQ2MXis38BNRpCZBJEBveqLjD");
         assert_eq!(globals.agent_id_str, "jane");
         assert_eq!(
             globals.agent_initial_hash,

--- a/core/src/nucleus/ribosome/api/init_globals.rs
+++ b/core/src/nucleus/ribosome/api/init_globals.rs
@@ -44,6 +44,7 @@ pub fn invoke_init_globals(
             if found_entries.len() > 0 {
                 globals.agent_latest_hash = found_entries[0].clone();
                 globals.agent_initial_hash = found_entries.pop().unwrap();
+                globals.agent_key_hash = globals.agent_latest_hash.clone();
             }
         }
     };

--- a/doc/holochain_101/src/writing_development_kit.md
+++ b/doc/holochain_101/src/writing_development_kit.md
@@ -86,12 +86,12 @@ TODO
 When writing Zome code, it is common to need to reference aspects of the context it runs in, such as the active user/agent, or the DNA hash of the app. Holochain exposes certain values through to the Zome, though it does so natively by way of the `hc_init_globals` function mentioned. Taking care to expose these values as constants will simplify the developer experience.
 
 This is done by calling `hc_init_globals` with an input value of 0. The result of calling the function is a 32 bit integer which represents the memory location of a serialized JSON object containing all the app global values. Fetch the result from memory, and deserialize the result back into an object. If appropriate, set those values as exports for the Development Kit. For example, in Rust, values become accessible in Zomes using `hdk::APP_NAME`. It's recommended to use all capital letters for the export of the constants, but as they are returned as keys on an object from `hc_init_globals` they are in lower case. The object has the following values:
-- app_name
-- app_dna_hash
-- app_agent_id_str
-- app_agent_key_hash
-- app_agent_initial_hash
-- app_agent_latest_hash
+- dna_name
+- dna_hash
+- agent_id_str
+- agent_address
+- agent_initial_hash
+- agent_latest_hash
 
 See the [API global variables](/zome/api_globals.html) page for details on what these are.
 

--- a/doc/holochain_101/src/zome/app_variables.md
+++ b/doc/holochain_101/src/zome/app_variables.md
@@ -5,9 +5,9 @@ Note: Full reference is available in language-specific API Reference documentati
 
 | Name        | Purpose           | 
 | ------------- |:-------------| 
-| APP_NAME | Name of the Holochain app taken from the DNA. |
-| APP_DNA_HASH | The hash of this Holochain's DNA |
-| APP_AGENT_ID_STR | The identity string used to initialize this Holochain with `hcadmin init`. |
-| APP_AGENT_KEY_HASH | The hash of local agent's public key. |
-| APP_AGENT_INITIAL_HASH | The hash of the first identity entry on the local chain. |
-| APP_AGENT_LATEST_HASH | The hash of the most recent identity entry that has been committed to the local chain. |
+| DNA_NAME | Name of the Holochain app taken from the DNA. |
+| DNA_HASH | The hash of this Holochain's DNA |
+| AGENT_ID_STR | The identity string used to initialize this Holochain with `hcadmin init`. |
+| AGENT_ADDRESS | The address (constructed from the public key) of this agent. |
+| AGENT_INITIAL_HASH | The hash of the first identity entry on the local chain. |
+| AGENT_LATEST_HASH | The hash of the most recent identity entry that has been committed to the local chain. |

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -33,7 +33,7 @@ lazy_static! {
   /// The hash of your public key.
   /// This is your node address on the DHT.
   /// It can be used for node-to-node messaging with `send` and `receive` functions.
-  pub static ref AGENT_KEY_HASH: &'static HashString = &GLOBALS.agent_key_hash;
+  pub static ref AGENT_ADDRESS: &'static HashString = &GLOBALS.agent_address;
 
   /// The hash of the first identity entry on your chain (The second entry on your chain).
   /// This is your peer's identity on the DHT.

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -31,7 +31,7 @@ pub extern "C" fn check_global(encoded_allocation_of_input: u32) -> u32 {
         hdk::debug(&hdk::DNA_NAME);
         hdk::debug(&hdk::DNA_HASH.to_string());
         hdk::debug(&hdk::AGENT_ID_STR);
-        hdk::debug(&hdk::AGENT_KEY_HASH.to_string());
+        hdk::debug(&hdk::AGENT_ADDRESS.to_string());
         hdk::debug(&hdk::AGENT_INITIAL_HASH.to_string());
         hdk::debug(&hdk::AGENT_LATEST_HASH.to_string());
     }

--- a/wasm_utils/src/api_serialization/zome_api_globals.rs
+++ b/wasm_utils/src/api_serialization/zome_api_globals.rs
@@ -5,7 +5,7 @@ pub struct ZomeApiGlobals {
     pub dna_name: String,
     pub dna_hash: HashString,
     pub agent_id_str: String,
-    pub agent_key_hash: HashString,
+    pub agent_address: HashString,
     pub agent_initial_hash: HashString,
     pub agent_latest_hash: HashString,
 }


### PR DESCRIPTION
*WAS: Fill `AGENT_KEY_HASH` with hash of agent entry.*

As we discussed today in our heartbeat, `AGENT_KEY_HASH` is the thing to hang an agent's entry off of. But, the name is misleading as we are also discussing to have a special treatment of public keys as to not hash them but have the key be its address.

These details are not relevant to the usage of this anchor from the perspective of the app developer. We just need something that is in the address space of all entries and that represents the agent. Be it the hash of a key or the key itself or something different in the future.. In all cases, it is the address used to talk about an agent. Hence `AGENT_ADDRESS`.