### PR TITLE
Get entry simple

### DIFF
--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -4,7 +4,7 @@ pub use holochain_wasm_utils::api_serialization::validation::*;
 use holochain_wasm_utils::{
     api_serialization::{
         commit::{CommitEntryArgs, CommitEntryResult},
-        get_entry::{GetEntryArgs, GetEntryOptions, GetEntryResult},
+        get_entry::{GetEntryArgs, GetEntryOptions, GetEntryResult, GetResultStatus},
         get_links::{GetLinksArgs, GetLinksResult},
         link_entries::{LinkEntriesArgs, LinkEntriesResult},
     },
@@ -12,6 +12,7 @@ use holochain_wasm_utils::{
     memory_allocation::*,
     memory_serialization::*,
 };
+use serde::de::DeserializeOwned;
 use serde_json;
 
 //--------------------------------------------------------------------------------------------------
@@ -215,7 +216,23 @@ pub fn commit_entry(
 
 /// Retrieves an entry from the local chain or the DHT, by looking it up using
 /// its address.
-pub fn get_entry(address: HashString, _options: GetEntryOptions) -> ZomeApiResult<GetEntryResult> {
+pub fn get_entry<T>(address: HashString) -> Option<T>
+where
+    T: DeserializeOwned,
+{
+    let res = get_entry_result(address, GetEntryOptions {});
+    res.ok().and_then(|result| match result.status {
+        GetResultStatus::Found => serde_json::from_str(&result.entry).ok(),
+        GetResultStatus::NotFound => None,
+    })
+}
+
+/// Retrieves an entry and meta data from the local chain or the DHT, by looking it up using
+/// its address, and a the full options to specify exactly what data to return
+pub fn get_entry_result(
+    address: HashString,
+    _options: GetEntryOptions,
+) -> ZomeApiResult<GetEntryResult> {
     let mut mem_stack: SinglePageStack;
     unsafe {
         mem_stack = G_MEM_STACK.unwrap();

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -117,44 +117,6 @@ fn can_round_trip() {
 }
 
 #[test]
-fn can_get_entry_result() {
-    let (mut hc, _) = start_holochain_instance();
-    // Call the exposed wasm function that calls the Commit API function
-    let result = hc.call(
-        "test_zome",
-        "test_cap",
-        "check_commit_entry_macro",
-        r#"{ "entry_type_name": "testEntryType", "entry_content": "{\"stuff\": \"non fail\"}" }"#,
-    );
-    assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(
-        result.unwrap(),
-        "{\"address\":\"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou\"}"
-    );
-
-    let result = hc.call(
-        "test_zome",
-        "test_cap",
-        "check_get_entry_result",
-        r#"{"entry_hash":"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou"}"#,
-    );
-    println!("\t can_get_entry result = {:?}", result);
-    assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(), "{\"stuff\":\"non fail\"}");
-
-    // test the case with a bad hash
-    let result = hc.call(
-        "test_zome",
-        "test_cap",
-        "check_get_entry_result",
-        r#"{"entry_hash":"QmbC71ggSaEa1oVPTeNN7ZoB93DYhxowhKSF6Yia2Vjxxx"}"#,
-    );
-    println!("\t can_get_entry result = {:?}", result);
-    assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(), "{\"got back no entry\":true}");
-}
-
-#[test]
 fn can_get_entry() {
     let (mut hc, _) = start_holochain_instance();
     // Call the exposed wasm function that calls the Commit API function
@@ -173,12 +135,33 @@ fn can_get_entry() {
     let result = hc.call(
         "test_zome",
         "test_cap",
+        "check_get_entry_result",
+        r#"{"entry_hash":"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou"}"#,
+    );
+    println!("\t can_get_entry_result result = {:?}", result);
+    assert!(result.is_ok(), "\t result = {:?}", result);
+    assert_eq!(result.unwrap(), "{\"stuff\":\"non fail\"}");
+
+    let result = hc.call(
+        "test_zome",
+        "test_cap",
         "check_get_entry",
         r#"{"entry_hash":"QmZi7c1G2qAN6Y5wxHDB9fLhSaSVBJe28ZVkiPraLEcvou"}"#,
     );
     println!("\t can_get_entry result = {:?}", result);
     assert!(result.is_ok(), "\t result = {:?}", result);
     assert_eq!(result.unwrap(), "{\"stuff\":\"non fail\"}");
+
+    // test the case with a bad hash
+    let result = hc.call(
+        "test_zome",
+        "test_cap",
+        "check_get_entry_result",
+        r#"{"entry_hash":"QmbC71ggSaEa1oVPTeNN7ZoB93DYhxowhKSF6Yia2Vjxxx"}"#,
+    );
+    println!("\t can_get_entry_result result = {:?}", result);
+    assert!(result.is_ok(), "\t result = {:?}", result);
+    assert_eq!(result.unwrap(), "{\"got back no entry\":true}");
 
     // test the case with a bad hash
     let result = hc.call(

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -98,7 +98,7 @@ fn handle_check_commit_entry_macro(entry_type_name: String, entry_content: Strin
 }
 
 fn handle_check_get_entry_result(entry_hash: HashString) -> serde_json::Value {
-    let res = hdk::get_entry(entry_hash,GetEntryOptions{});
+    let res = hdk::get_entry_result(entry_hash,GetEntryOptions{});
     match res {
         Ok(result) => match result.status {
             GetResultStatus::Found => {
@@ -243,6 +243,12 @@ define_zome! {
                 inputs: |entry_hash: HashString|,
                 outputs: |result: serde_json::Value|,
                 handler: handle_check_get_entry
+            }
+
+            check_get_entry_result: {
+                inputs: |entry_hash: HashString|,
+                outputs: |result: serde_json::Value|,
+                handler: handle_check_get_entry_result
             }
 
             commit_validation_package_tester: {

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -119,11 +119,13 @@ zome_functions! {
     }
 
     check_get_entry: |entry_hash: HashString| {
-        let result : Option<EntryStruct> = hdk::get_entry(entry_hash);
+        let result : Result<Option<EntryStruct>,ZomeApiError> = hdk::get_entry(entry_hash);
         match result {
-            Some(entry_value) =>json!(entry_value),
-            None => json!("null"),
-
+            Ok(e) => match e {
+                Some(entry_value) => json!(entry_value),
+                None => json!(null),
+            },
+            Err(err) => json!({"get entry Err": err.to_string()}),
         }
     }
 


### PR DESCRIPTION
get_entry() now simplified and returns  Result<Option<T>, ZomeApiError> so it can desalinize right into the type (T)  and you don't have to pass in the options.  The more complex version now called get_entry_result().