### PR TITLE
reinstate useful if, to limit build time

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -118,7 +118,9 @@ install_ci: core_toolchain
 
 .PHONY: install_mdbook
 install_mdbook: tools_toolchain
-	$(CARGO_TOOLS) install mdbook --force --vers "0.2.2";
+	if ! $(CARGO_TOOLS) install --list | grep 'mdbook'; then \
+		$(CARGO_TOOLS) install mdbook --vers "^0.2.2"; \
+	fi
 
 # list all our found "C" binding tests
 c_binding_tests: ${C_BINDING_DIRS}


### PR DESCRIPTION
sorry folks...

this is because the MDBOOK build on travis DOESN"T run on docker, so the build is cached, and I needed to overwrite the cached config

so it's all fixed now and shouldn't have to mess with this again