### PR TITLE
Persistence fix: Load DNA from source chain

### DIFF
--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -187,6 +187,16 @@ impl Instance {
         }
     }
 
+    pub fn from_state(state: State) -> Self {
+        let (tx_action, _) = sync_channel(1);
+        let (tx_observer, _) = sync_channel(1);
+        Instance {
+            state: Arc::new(RwLock::new(state)),
+            action_channel: tx_action,
+            observer_channel: tx_observer,
+        }
+    }
+
     pub fn state(&self) -> RwLockReadGuard<State> {
         self.state
             .read()

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -64,8 +64,10 @@ impl State {
                 .expect("Could not fetch from storage while loading state")
                 .expect("Could not find a DNA entry in storage while loading state")
         );
+        let mut nucleus_state = NucleusState::new();
+        nucleus_state.dna = Some(dna);
         State {
-            nucleus: Arc::new(NucleusState::new()),
+            nucleus: Arc::new(nucleus_state),
             agent: agent_state,
             dht: Arc::new(DhtStore::new(cas.clone(), eav.clone())),
             history: HashSet::new(),

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -7,10 +7,7 @@ use context::Context;
 use dht::dht_store::DhtStore;
 use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
 use holochain_core_types::{
-    cas::{
-        content::*,
-        storage::ContentAddressableStorage,
-    },
+    cas::{content::*, storage::ContentAddressableStorage},
     entry::*,
     entry_type::EntryType,
     error::{HcResult, HolochainError},
@@ -55,16 +52,24 @@ impl State {
         let cas = &(*context).file_storage;
         let eav = &(*context).eav_storage;
 
-        fn get_dna(agent_state: &Arc<AgentState>, cas: &FilesystemStorage) -> Result<Dna, HolochainError> {
-            let dna_entry_header = agent_state.chain()
-                .iter_type(&agent_state.top_chain_header(),
-                           &EntryType::Dna)
+        fn get_dna(
+            agent_state: &Arc<AgentState>,
+            cas: &FilesystemStorage,
+        ) -> Result<Dna, HolochainError> {
+            let dna_entry_header = agent_state
+                .chain()
+                .iter_type(&agent_state.top_chain_header(), &EntryType::Dna)
                 .last()
-                .ok_or(HolochainError::ErrorGeneric("No DNA entry found in source chain while creating state from agent".to_string()))?;
+                .ok_or(HolochainError::ErrorGeneric(
+                    "No DNA entry found in source chain while creating state from agent"
+                        .to_string(),
+                ))?;
 
             Ok(Dna::from_entry(
                 &cas.fetch(dna_entry_header.entry_address())?
-                    .ok_or(HolochainError::ErrorGeneric("No DNA entry found in storage while creating state from agent".to_string()))?
+                    .ok_or(HolochainError::ErrorGeneric(
+                        "No DNA entry found in storage while creating state from agent".to_string(),
+                    ))?,
             ))
         }
 

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -33,7 +33,7 @@
 //! let context = Context::new(
 //!     agent,
 //!     Arc::new(Mutex::new(SimpleLogger {})),
-//!     Arc::new(Mutex::new(SimplePersister::new())),
+//!     Arc::new(Mutex::new(SimplePersister::new(String::from("Agent Name")))),
 //!     FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap(),
 //!     EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string()).unwrap(),
 //!  ).unwrap();

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -120,13 +120,11 @@ impl Holochain {
             .load(context.clone())
             .unwrap_or(Some(State::new(context.clone())))
             .unwrap();
-        new_context.set_state(Arc::new(RwLock::new(loaded_state)));
-        let arc_context = Arc::new(new_context);
-        let mut instance = Instance::new(arc_context.clone());
+        let mut instance = Instance::from_state(loaded_state);
         instance.start_action_loop(context.clone());
         Ok(Holochain {
             instance,
-            context: arc_context.clone(),
+            context: context.clone(),
             active: false,
         })
     }

--- a/core_api/src/lib.rs
+++ b/core_api/src/lib.rs
@@ -115,7 +115,7 @@ impl Holochain {
 
     pub fn load(path: String, context: Arc<Context>) -> Result<Self, HolochainError> {
         let mut new_context = (*context).clone();
-        let persister = SimplePersister::new(path);
+        let persister = SimplePersister::new(format!("{}/state", path));
         let loaded_state = persister
             .load(context.clone())
             .unwrap_or(Some(State::new(context.clone())))

--- a/dna/src/lib.rs
+++ b/dna/src/lib.rs
@@ -264,7 +264,7 @@ impl ToEntry for Dna {
     }
 
     fn from_entry(entry: &Entry) -> Self {
-        return Dna::from_json_str(&entry.value()).expect("entry is not a valid Dna Entry");
+        Dna::from_json_str(&entry.value()).expect("entry is not a valid Dna Entry")
     }
 }
 

--- a/dna/src/lib.rs
+++ b/dna/src/lib.rs
@@ -264,7 +264,7 @@ impl ToEntry for Dna {
     }
 
     fn from_entry(entry: &Entry) -> Self {
-        return Dna::from_json_str(&entry.content()).expect("entry is not a valid Dna Entry");
+        return Dna::from_json_str(&entry.value()).expect("entry is not a valid Dna Entry");
     }
 }
 


### PR DESCRIPTION
For holochain_load() to really work we need to construct a state with everything a running Instance needs. And that means: the DNA.

* retrieving the DNA from the source chain on load
* putting it into the state and making sure that state is used in the newly created instance