### PR TITLE
Link Api Functions

### DIFF
--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -141,8 +141,17 @@ Caller can request additional metadata on the entry such as type or sources
 
 Canonical name: `get_links`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.get_links.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.get_links.html)
+
+### Link Entries
+
+Canonical name: `link_entries`
+
+Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a relationship between them, called a `tag`. Later, lists of entries can be looked up by using `get_links`. Entries can only be looked up in the direction from the `base`, which is the first argument, to the `target`, which is the second.
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.link_entries.html)
 
 ### Remove Entry
 

--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -40,11 +40,6 @@ zome logic to Holochain core functionality and often has side effects. The
 return value of the Rust function is passed back to the zome code as the return
 of the zome API function.
 
-## Reference
-
-Note: Full reference is available in language-specific API Reference documentation.
-(TODO add links)
-
 ### Property
 
 Canonical name: `property`

--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -1,61 +1,61 @@
-# Zome API functions
+# Zome API Functions
 
 ## Overview
 
 A Zome API Function is any Holochain core functionality that is exposed as a
-callable function within zome code.
+callable function within Zome code.
 
-Compare this to a Zome Callback Function, which is implemented by the zome code 
+Compare this to a Zome Callback Function, which is implemented by the Zome code 
 and called by Holochain.
 
-So, zome functions (functions in the zome code) are called by Holochain, 
+So, Zome functions (functions in the Zome code) are called by Holochain, 
 which can optionally call Zome API Functions, and then finally return a
 value back to Holochain.
 
 ```
 Holochain blocks
-  -> calls zome function
-  -> executes WASM logic compiled from zome language
-  -> zome logic calls zome API function
-    -> Holochain natively executes zome API function
-    -> Holochain returns value to zome function
-  -> zome function returns some value
-  -> Holochain receives final value of zome function
+  -> calls Zome function
+  -> executes WASM logic compiled from Zome language
+  -> Zome logic calls zome API function
+    -> Holochain natively executes Zome API function
+    -> Holochain returns value to Zome function
+  -> Zome function returns some value
+  -> Holochain receives final value of Zome function
 ```
 
 Each Zome API Function has a canonical name used internally by Holochain.
 
 Zome code can be written in any language that compiles to WASM. This means the
-canonical function name and the function name in the zome language might be
-different. The zome language will closely mirror the canonical names, but naming
+canonical function name and the function name in the Zome language might be
+different. The Zome language will closely mirror the canonical names, but naming
 conventions such as capitalisation of the zome language are also respected.
 
 For example, the canonical `verify_signature` might become `verifySignature` in
-JavaScript.
+AssemblyScript.
 
-When a zome API function is called from within zome code a corresponding Rust
-function is called. The Rust function is passed the current zome runtime and the
+When a Zome API function is called from within Zome code a corresponding Rust
+function is called. The Rust function is passed the current Zome runtime and the
 arguments that the zome API function was called with. The Rust function connects
-zome logic to Holochain core functionality and often has side effects. The
-return value of the Rust function is passed back to the zome code as the return
-of the zome API function.
+Zome logic to Holochain core functionality and often has side effects. The
+return value of the Rust function is passed back to the Zome code as the return
+of the Zome API function.
 
 ### Property
 
 Canonical name: `property`
 
-Returns an application property, which are defined by the app developer in the DNA.
+Returns an application property, which are defined by the developer in the DNA.
 It returns values from the DNA file that you set as properties of your application (e.g. Name, Language, Description, Author, etc.).
 
-[LINK](https://holochain.github.io/rust-api/hdk/fn.property.html)
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.property.html)
 
-### Make Hash
+### Hash Entry
 
-Canonical name: `make_hash`
+Canonical name: `hash_entry`
 
-Not yet available, but you will see
-updates here:
-[LINK](https://holochain.github.io/rust-api/hdk/fn.make_hash.html)
+Reconstructs an address of the given entry data. This is the same value that would be returned if an entry type and entry value were passed to the `commit_entry` function and by which it would be retrievable from the DHT using `get_entry`. It is often used to reconstruct an address of a base argument when calling `get_links`. It was renamed `hash_entry` in this version from `make_hash` in the Go version of Holochain.
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.hash_entry.html)
 
 ### Debug
 
@@ -63,59 +63,63 @@ Canonical name: `debug`
 
 Debug sends the passed arguments to the log that was given to the Holochain instance and returns `None`.
 
-[LINK](https://holochain.github.io/rust-api/hdk/fn.debug.html)
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.debug.html)
 
 ### Call
 
 Canonical name: `call`
 
-Not yet available, but you will see
-updates here:
-[LINK](https://holochain.github.io/rust-api/hdk/fn.call.html)
+Perform a function call to an exposed function from another Zome.
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.call.html)
 
 ### Sign
 
 Canonical name: `sign`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.sign.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.sign.html)
 
 ### Verify Signature
 
 Canonical name: `verify_signature`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.verify_signature.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.verify_signature.html)
 
 ### Commit Entry
 
 Canonical name: `commit_entry`
 
-Given an entry type and content, commits an entry to the local source chain.
-On success, returns the hash of the entry.
+Attempts to commit an entry to your local source chain. The entry will have to pass the defined validation rules for that entry type. If the entry type is defined as public, will also publish the entry to the DHT. Returns either an address of the committed entry as a string, or an error.
 
-[LINK](https://holochain.github.io/rust-api/hdk/fn.commit_entry.html)
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.commit_entry.html)
 
 ### Update Entry
 
 Canonical name: `update_entry`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.update_entry.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.update_entry.html)
 
 ### Update Agent
 
 Canonical name: `update_agent`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.update_agent.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.update_agent.html)
 
 ### Remove Entry
 
 Canonical name: `remove_entry`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.remove_entry.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.remove_entry.html)
 
 ### Get Entry
 
@@ -131,47 +135,52 @@ Entry lookup is done in the following order:
 Caller can request additional metadata on the entry such as type or sources
 (hashes of the agents that committed the entry).
 
-[LINK](https://holochain.github.io/rust-api/hdk/fn.get_entry.html)
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.get_entry.html)
 
 ### Get Links
 
 Canonical name: `get_links`
 
 Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.get_links.html)
+updates here: [LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.get_links.html)
 
 ### Remove Entry
 
 Canonical name: `remove_entry`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.remove_entry.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.remove_entry.html)
 
 ### Query
 
 Canonical name: `query`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.query.html)
+Returns a list of addresses of entries from your local source chain, that match a given type. You can optionally limit the number of results.
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.query.html)
 
 ### Send
 
 Canonical name: `send`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.send.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.send.html)
 
 ### Start Bundle
 
 Canonical name: `start_bundle`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.start_bundle.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.start_bundle.html)
 
 ### Close Bundle
 
 Canonical name: `close_bundle`
 
-Not yet available, but you will see
-updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.close_bundle.html)
+Not yet available, but you will see updates here:
+
+[LINK](https://holochain.github.io/rust-api/0.0.1/hdk/fn.close_bundle.html)
 

--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -52,11 +52,15 @@ Canonical name: `property`
 Returns an application property, which are defined by the app developer in the DNA.
 It returns values from the DNA file that you set as properties of your application (e.g. Name, Language, Description, Author, etc.).
 
+[LINK](https://holochain.github.io/rust-api/hdk/fn.property.html)
+
 ### Make Hash
 
 Canonical name: `make_hash`
 
-TODO
+Not yet available, but you will see
+updates here:
+[LINK](https://holochain.github.io/rust-api/hdk/fn.make_hash.html)
 
 ### Debug
 
@@ -64,24 +68,29 @@ Canonical name: `debug`
 
 Debug sends the passed arguments to the log that was given to the Holochain instance and returns `None`.
 
+[LINK](https://holochain.github.io/rust-api/hdk/fn.debug.html)
 
 ### Call
 
 Canonical name: `call`
 
-TODO
+Not yet available, but you will see
+updates here:
+[LINK](https://holochain.github.io/rust-api/hdk/fn.call.html)
 
 ### Sign
 
 Canonical name: `sign`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.sign.html)
 
 ### Verify Signature
 
 Canonical name: `verify_signature`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.verify_signature.html)
 
 ### Commit Entry
 
@@ -90,23 +99,28 @@ Canonical name: `commit_entry`
 Given an entry type and content, commits an entry to the local source chain.
 On success, returns the hash of the entry.
 
+[LINK](https://holochain.github.io/rust-api/hdk/fn.commit_entry.html)
+
 ### Update Entry
 
 Canonical name: `update_entry`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.update_entry.html)
 
 ### Update Agent
 
 Canonical name: `update_agent`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.update_agent.html)
 
 ### Remove Entry
 
 Canonical name: `remove_entry`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.remove_entry.html)
 
 ### Get Entry
 
@@ -122,38 +136,47 @@ Entry lookup is done in the following order:
 Caller can request additional metadata on the entry such as type or sources
 (hashes of the agents that committed the entry).
 
+[LINK](https://holochain.github.io/rust-api/hdk/fn.get_entry.html)
+
 ### Get Links
 
 Canonical name: `get_links`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.get_links.html)
 
 ### Remove Entry
 
 Canonical name: `remove_entry`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.remove_entry.html)
 
 ### Query
 
 Canonical name: `query`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.query.html)
 
 ### Send
 
 Canonical name: `send`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.send.html)
 
 ### Start Bundle
 
 Canonical name: `start_bundle`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.start_bundle.html)
 
 ### Close Bundle
 
 Canonical name: `close_bundle`
 
-TODO
+Not yet available, but you will see
+updates here: [LINK](https://holochain.github.io/rust-api/hdk/fn.close_bundle.html)
+


### PR DESCRIPTION
Updated all links... 

Im not sure if this is the best way to address other possible updates to this page.  

Based on the proto docs, this one appears to be missing:  
link_entries	Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a relationship between them, called a tag. Later, lists of entries can be looked up by using get_links. Entries can only be looked up in the direction from the base, which is the first argument, to the target.

Wondering if someone could confirm if that is intentional. 

Also, sensing it would help to add laymen's terms descriptions to these.  
Is that appropriate?  Since its the 'book' and intended for training, seems helpful.