### PR TITLE
Make net_ipc work on windows

### DIFF
--- a/net_ipc/Cargo.toml
+++ b/net_ipc/Cargo.toml
@@ -10,7 +10,7 @@ rmp-serde = "0.13.7"
 serde = "1.0"
 serde_bytes = "0.10.4"
 serde_derive = "1.0"
-zmq = "0.8.2"
+zmq = { version = "0.8.2", default-features = false }
 
 [dev-dependencies]
 libc = "0.2.42"

--- a/net_ipc/Cargo.toml
+++ b/net_ipc/Cargo.toml
@@ -10,7 +10,7 @@ rmp-serde = "0.13.7"
 serde = "1.0"
 serde_bytes = "0.10.4"
 serde_derive = "1.0"
-zmq = { version = "0.8.2", default-features = false }
+zmq = "0.8.2"
 
 [dev-dependencies]
 libc = "0.2.42"

--- a/net_ipc/tests/echo_ipc_test.rs
+++ b/net_ipc/tests/echo_ipc_test.rs
@@ -153,7 +153,6 @@ impl TestFrame {
             cb_result, msg
         );
     }
-    
     /// cleanup both the nodejs echo-server and the ipc client connection
     #[cfg(not(windows))]
     fn destroy(mut self) {

--- a/net_ipc/tests/echo_ipc_test.rs
+++ b/net_ipc/tests/echo_ipc_test.rs
@@ -149,7 +149,13 @@ impl TestFrame {
         );
     }
 
+    #[cfg(windows)]
+    fn destroy(mut self) {
+        // TODO find a windows equivalent to kill()
+    }
+
     /// cleanup both the nodejs echo-server and the ipc client connection
+    #[cfg(not(windows))]
     fn destroy(mut self) {
         println!("attempting to kill echo server");
         unsafe {

--- a/net_ipc/tests/echo_ipc_test.rs
+++ b/net_ipc/tests/echo_ipc_test.rs
@@ -167,10 +167,18 @@ impl TestFrame {
         println!("attempting to kill zeromq context");
         self.cli.close().unwrap();
         ZmqIpcClient::destroy_context().unwrap();
-        println!("zemomq is off");
+        println!("zeromq is off");
     }
 }
 
+#[cfg(windows)]
+#[test]
+fn it_can_send_call_and_call_resp() {
+    // TODO make the test work for windows
+    // Currently this just makes sure net_ipc crate is linkable
+}
+
+#[cfg(not(windows))]
 #[test]
 fn it_can_send_call_and_call_resp() {
     let mut frame = TestFrame::new();

--- a/net_ipc/tests/echo_ipc_test.rs
+++ b/net_ipc/tests/echo_ipc_test.rs
@@ -4,9 +4,13 @@ extern crate failure;
 extern crate holochain_net_ipc as net_ipc;
 extern crate libc;
 
-use net_ipc::{errors::*, ZmqIpcClient};
+#[allow(dead_code)]
+use net_ipc::errors::*;
+use net_ipc::ZmqIpcClient;
+#[allow(dead_code)]
 use std::sync::{Arc, Mutex};
 
+#[allow(dead_code)]
 /// do prep work and run the nodejs example echo-server.js
 fn run_nodejs_echo_server() -> std::process::Child {
     // make sure the git submodule is initialized
@@ -38,11 +42,12 @@ fn run_nodejs_echo_server() -> std::process::Child {
 }
 
 /// struct to help hold context for the callbacks
+#[allow(dead_code)]
 struct TestFrame {
     srv: std::process::Child,
     cli: ZmqIpcClient,
 }
-
+#[allow(dead_code)]
 impl TestFrame {
     /// create a new test frame
     fn new() -> TestFrame {
@@ -148,17 +153,13 @@ impl TestFrame {
             cb_result, msg
         );
     }
-
-    #[cfg(windows)]
-    fn destroy(mut self) {
-        // TODO find a windows equivalent to kill()
-    }
-
+    
     /// cleanup both the nodejs echo-server and the ipc client connection
     #[cfg(not(windows))]
     fn destroy(mut self) {
         println!("attempting to kill echo server");
         unsafe {
+            // TODO find a windows equivalent to kill()
             libc::kill(self.srv.id() as i32, libc::SIGTERM);
         }
         self.srv.wait().unwrap();
@@ -171,13 +172,14 @@ impl TestFrame {
     }
 }
 
-#[cfg(windows)]
+// Test that just makes sure the net_ipc crate is linkable
 #[test]
-fn it_can_send_call_and_call_resp() {
-    // TODO make the test work for windows
-    // Currently this just makes sure net_ipc crate is linkable
+fn can_be_linked() {
+    let cli = ZmqIpcClient::new().unwrap();
+    cli.close().unwrap();
 }
 
+// TODO make the test work for windows
 #[cfg(not(windows))]
 #[test]
 fn it_can_send_call_and_call_resp() {


### PR DESCRIPTION
Disabled net_ipc tests for windows because:
- libc::kill() does not exist for windows
- npm and node commands don't work as-is.

### Instructions for building ZMQ on windows so `net_ipc` can build
Official ZMQ Installers for windows are outdated as we need a version > v4.1,  so we need to build it locally like rust-zmq does for windows with appVeyor
1. [Download and install libsodium for msvc](https://download.libsodium.org)
1. Create a folder for holding the compiled zeromq library, e.g. `C:\Program Files\libzmq`
1. Create new environment variable `LIBZMQ_PREFIX` that points to that folder.
1. add `LIBZMQ_PREFIX` to your `PATH`
1. clone and build [libzmq](https://github.com/zeromq/libzmq) locally with cmake + VS:
> cmake -D CMAKE_INCLUDE_PATH="C:\Program Files\libsodium-1.0.16-msvc\include" -D CMAKE_LIBRARY_PATH="C:\Program Files\libsodium-1.0.16-msvc\x64\Release\v140\dynamic" -D CMAKE_CXX_FLAGS_RELEASE="/MT" -D CMAKE_CXX_FLAGS_DEBUG="/MTd" -G "Visual Studio 14 2015 Win64" C:\github\libzmq
>
> msbuild /v:minimal /maxcpucount:%NUMBER_OF_PROCESSORS% /p:Configuration=release libzmq.vcxproj
1. Go to the `C:\github\libzmq\build\lib\Release` directory, rename and copy the ***.lib** file: `mv libzmq-v140-mt-4_2_0.lib %LIBZMQ_PREFIX"\zmq.lib`
1. Go to the `C:\github\libzmq\build\bin\Release` directory and copy the ***.dll** file to the compiled library folder, , e.g. `%LIBZMQ_PREFIX%\libzmq-v140-mt-4_2_0.dll`