### PR TITLE
Disable test_deadlock() on windows

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -133,6 +133,7 @@ mod tests {
 
     #[test]
     #[should_panic]
+    #[cfg(not(windows))] // RwLock does not panic on windows since mutexes are recursive
     fn test_deadlock() {
         let mut context = Context::new(
             holochain_agent::Agent::from("Terence".to_string()),


### PR DESCRIPTION
RwLock does not panic on windows since mutexes are recursive:

https://github.com/rust-lang/rust/issues/19962
https://stackoverflow.com/questions/33809005/when-does-rwlock-panic-instead-of-doing-a-deadlock