### PR TITLE
Changed Link EAV attribute name from 'link:{}' to 'link__{}'

### DIFF
--- a/core/src/dht/dht_reducers.rs
+++ b/core/src/dht/dht_reducers.rs
@@ -215,7 +215,7 @@ where
     }
 
     let eav =
-        EntityAttributeValue::new(link.base(), &format!("link:{}", link.tag()), link.target());
+        EntityAttributeValue::new(link.base(), &format!("link__{}", link.tag()), link.target());
 
     let result = new_store.meta_storage_mut().add_eav(&eav);
     new_store
@@ -334,7 +334,7 @@ pub mod tests {
         let eav = hash_set.iter().nth(0).unwrap();
         assert_eq!(eav.entity(), *link.base());
         assert_eq!(eav.value(), *link.target());
-        assert_eq!(eav.attribute(), format!("link:{}", link.tag()));
+        assert_eq!(eav.attribute(), format!("link__{}", link.tag()));
     }
 
     #[test]

--- a/core/src/dht/dht_store.rs
+++ b/core/src/dht/dht_store.rs
@@ -81,7 +81,7 @@ where
         tag: String,
     ) -> Result<HashSet<EntityAttributeValue>, HolochainError> {
         self.meta_storage
-            .fetch_eav(Some(address), Some(format!("link:{}", tag)), None)
+            .fetch_eav(Some(address), Some(format!("link__{}", tag)), None)
     }
 
     // Getters (for reducers)


### PR DESCRIPTION
because ':' is not allowed for filesystem paths on windows and currently eav file storage is using the attribute name as a folder name.