### PR TITLE
Excluded test_utils from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ members = [
   "net_ipc",
   "hdk-rust",
 ]
+exclude = ["test_utils"]


### PR DESCRIPTION
this way that crate is not compiled when doing `cargo build`, which is not necessary since its for testing only.