### PR TITLE
spike: run_dna() with optional context 

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,9 +26,8 @@ config = "0.8"
 regex = "1"
 holochain_core_types = { path = "../core_types" }
 holochain_cas_implementations = { path = "../cas_implementations" }
-
+tempfile="3"
 
 [dev-dependencies]
 wabt = { git = 'https://github.com/ddd-mtl/wabt-rs.git'  }
 test_utils = { path = "../test_utils"}
-tempfile="3"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,6 +12,7 @@ extern crate futures;
 extern crate snowflake;
 #[cfg(test)]
 extern crate test_utils;
+extern crate tempfile;
 extern crate wasmi;
 #[macro_use]
 extern crate unwrap_to;

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -214,7 +214,7 @@ pub(crate) fn launch_zome_fn_call(
         // Have Ribosome spin up DNA and call the zome function
         let call_result = ribosome::run_dna(
             &dna_name,
-            context.clone(),
+            Some(context.clone()),
             code,
             &zome_call,
             Some(zome_call.clone().parameters.into_bytes()),

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -191,7 +191,7 @@ mod tests {
         );
         let call_result = ribosome::run_dna(
             &dna.name.to_string(),
-            Arc::clone(&context),
+            Some(Arc::clone(&context)),
             wasm.clone(),
             &commit_call,
             Some(test_commit_args_bytes()),
@@ -210,7 +210,7 @@ mod tests {
         );
         let call_result = ribosome::run_dna(
             &dna.name.to_string(),
-            Arc::clone(&context),
+            Some(Arc::clone(&context)),
             wasm.clone(),
             &get_call,
             Some(test_get_args_bytes()),
@@ -254,7 +254,7 @@ mod tests {
         );
         let call_result = ribosome::run_dna(
             &dna.name.to_string(),
-            Arc::clone(&context),
+            Some(Arc::clone(&context)),
             wasm.clone(),
             &get_call,
             Some(test_get_args_unknown()),

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -333,7 +333,7 @@ pub mod tests {
         );
         ribosome::run_dna(
             &dna_name,
-            context,
+            Some(context),
             wasm.clone(),
             &zome_call,
             Some(args_bytes),

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -144,7 +144,7 @@ pub(crate) fn run_callback(
 ) -> CallbackResult {
     match ribosome::run_dna(
         &dna_name,
-        context,
+        Some(context),
         wasm.code.clone(),
         &fc,
         Some(fc.clone().parameters.into_bytes()),

--- a/core/src/nucleus/ribosome/callback/validate_entry.rs
+++ b/core/src/nucleus/ribosome/callback/validate_entry.rs
@@ -88,7 +88,7 @@ fn run_validation_callback(
 ) -> CallbackResult {
     match ribosome::run_dna(
         &dna_name,
-        context,
+        Some(context),
         wasm.code.clone(),
         &fc,
         Some(fc.clone().parameters.into_bytes()),

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -28,7 +28,7 @@ pub fn get_validation_package_definition(
 
             let result = ribosome::run_dna(
                 &dna.name.clone(),
-                context,
+                Some(context),
                 wasm.code.clone(),
                 &ZomeFnCall::new(
                     &zome_name,

--- a/core/src/nucleus/ribosome/run_dna.rs
+++ b/core/src/nucleus/ribosome/run_dna.rs
@@ -3,6 +3,7 @@ use holochain_core_types::error::{
     HcResult, HolochainError, RibosomeErrorCode, RibosomeReturnCode,
 };
 use holochain_wasm_utils::memory_allocation::decode_encoded_allocation;
+use instance::test_context;
 use nucleus::{
     ribosome::{api::ZomeApiFunction, memory::SinglePageManager, Runtime},
     ZomeFnCall, ZomeFnResult,
@@ -18,7 +19,7 @@ use wasmi::{
 /// panics if wasm binary isn't valid.
 pub fn run_dna(
     dna_name: &str,
-    context: Arc<Context>,
+    context: Option<Arc<Context>>,
     wasm: Vec<u8>,
     zome_call: &ZomeFnCall,
     parameters: Option<Vec<u8>>,
@@ -86,6 +87,7 @@ pub fn run_dna(
     // write input arguments for module call in memory Buffer
     let input_parameters: Vec<_> = parameters.unwrap_or_default();
 
+    let context = context.unwrap_or(test_context("<unknown>"));
     // instantiate runtime struct for passing external state data over wasm but not to wasm
     let mut runtime = Runtime {
         memory_manager: SinglePageManager::new(&wasm_instance),


### PR DESCRIPTION
and test_context if non provided.

With this we could remove the [test_context module](https://github.com/holochain/holochain-cmd/blob/develop/src/cli/test_context.rs) in [holochain-cmd](https://github.com/holochain/holochain-cmd)

But after doing this, I would actually prefer to leave it the way it is.. what do you think?