### PR TITLE
net_connection p2p abstraction - STEP 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,10 @@ members = [
   "core",
   "dna",
   "dna_c_binding",
-  "net",
-  "test_bin",
-  "net_ipc",
   "hdk-rust",
+  "net",
+  "net_connection",
+  "net_ipc",
+  "test_bin",
 ]
 exclude = ["test_utils"]

--- a/core_types/src/json.rs
+++ b/core_types/src/json.rs
@@ -57,6 +57,12 @@ impl From<JsonString> for String {
     }
 }
 
+impl<'a> From<&'a JsonString> for &'a str {
+    fn from(json_string: &'a JsonString) -> &'a str {
+        &json_string.0
+    }
+}
+
 impl<'a> From<&'a JsonString> for String {
     fn from(json_string: &JsonString) -> String {
         String::from(json_string.to_owned())

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -154,8 +154,13 @@ wasm_build: ensure_wasm_target
 build: core_toolchain wasm_build
 	$(CARGO) build --all
 
+.PHONY: code_coverage
 code_coverage: core_toolchain wasm_build install_ci
 	$(CARGO) tarpaulin --timeout 600 --all --out Xml --skip-clean -v -e holochain_core_api_c_binding -e hdk
+
+.PHONY: code_coverage_crate
+code_coverage_crate: core_toolchain wasm_build install_ci
+	$(CARGO) tarpaulin --timeout 600 --skip-clean -v -p $(CRATE)
 
 fmt_check: install_rust_tools
 	$(CARGO_TOOLS) fmt -- --check

--- a/net_connection/Cargo.toml
+++ b/net_connection/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "holochain_net_connection"
+version = "0.1.0"
+authors = ["neonphog <neonphog@gmail.com>"]
+
+[dependencies]
+byteorder = "1"
+failure = "0.1.3"
+holochain_core_types = { path = "../core_types" }
+rmp = "0.8"
+rmp-serde = "0.13.7"
+serde = "1"
+serde_bytes = "0.10.4"
+serde_derive = "1"
+serde_json = "1"

--- a/net_connection/src/lib.rs
+++ b/net_connection/src/lib.rs
@@ -1,0 +1,26 @@
+//! Provides a lightweight concurrency abstraction for holochain
+//! networking / p2p layer
+//! see holochain_net_ipc for a specific implementation, and
+//! holochain_net for the crate that pulls the implementations together
+
+extern crate byteorder;
+#[macro_use]
+extern crate failure;
+extern crate holochain_core_types;
+extern crate rmp;
+extern crate rmp_serde;
+extern crate serde;
+extern crate serde_bytes;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
+
+use failure::Error;
+
+pub type NetResult<T> = Result<T, Error>;
+
+pub mod net_connection;
+pub mod net_connection_thread;
+pub mod protocol;
+pub mod protocol_wrapper;

--- a/net_connection/src/net_connection.rs
+++ b/net_connection/src/net_connection.rs
@@ -1,0 +1,145 @@
+use super::NetResult;
+use protocol::Protocol;
+
+/// closure for getting Protocol messages from the p2p abstraction system
+pub type NetHandler = Box<FnMut(NetResult<Protocol>) -> NetResult<()> + Send>;
+
+/// net connection - a worker manager can send Protocol messages
+pub trait NetConnection {
+    fn send(&mut self, data: Protocol) -> NetResult<()>;
+}
+
+/// represents a worker that handles protocol messages
+pub trait NetWorker {
+    /// stop the worker
+    fn stop(self: Box<Self>) -> NetResult<()> {
+        Ok(())
+    }
+
+    /// when somebody has called `send` to send this worker a message
+    fn receive(&mut self, _data: Protocol) -> NetResult<()> {
+        Ok(())
+    }
+
+    /// perform any upkeep return `false` if there was no upkeep to perform
+    fn tick(&mut self) -> NetResult<bool> {
+        Ok(false)
+    }
+}
+
+/// closure for instantiating a NetWorker
+pub type NetWorkerFactory = Box<FnMut(NetHandler) -> NetResult<Box<NetWorker>> + Send>;
+
+/// a simple pass-through NetConnection instance
+/// this struct can be use to compose one type of NetWorker into another
+pub struct NetConnectionRelay {
+    worker: Box<NetWorker>,
+}
+
+impl NetConnection for NetConnectionRelay {
+    /// send a message to the worker within this NetConnectionRelay instance
+    fn send(&mut self, data: Protocol) -> NetResult<()> {
+        self.worker.receive(data)?;
+        Ok(())
+    }
+}
+
+impl NetConnectionRelay {
+    /// stop this NetConnectionRelay instance
+    pub fn stop(self) -> NetResult<()> {
+        self.worker.stop()?;
+        Ok(())
+    }
+
+    /// call tick to perform any worker upkeep
+    pub fn tick(&mut self) -> NetResult<bool> {
+        self.worker.tick()
+    }
+
+    /// create a new NetConnectionRelay instance with give handler / factory
+    pub fn new(handler: NetHandler, mut worker_factory: NetWorkerFactory) -> NetResult<Self> {
+        Ok(NetConnectionRelay {
+            worker: worker_factory(handler)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::mpsc;
+
+    struct DefWorker;
+
+    impl NetWorker for DefWorker {}
+
+    #[test]
+    fn it_can_defaults() {
+        let mut con = NetConnectionRelay::new(
+            Box::new(move |_r| Ok(())),
+            Box::new(|_h| Ok(Box::new(DefWorker))),
+        ).unwrap();
+
+        con.send("test".into()).unwrap();
+        con.tick().unwrap();
+        con.stop().unwrap();
+    }
+
+    struct Worker {
+        handler: NetHandler,
+    }
+
+    impl NetWorker for Worker {
+        fn tick(&mut self) -> NetResult<bool> {
+            (self.handler)(Ok("tick".into()))?;
+            Ok(true)
+        }
+
+        fn receive(&mut self, data: Protocol) -> NetResult<()> {
+            (self.handler)(Ok(data))
+        }
+    }
+
+    #[test]
+    fn it_invokes_connection_relay() {
+        let (sender, receiver) = mpsc::channel();
+
+        let mut con = NetConnectionRelay::new(
+            Box::new(move |r| {
+                sender.send(r?)?;
+                Ok(())
+            }),
+            Box::new(|h| Ok(Box::new(Worker { handler: h }))),
+        ).unwrap();
+
+        con.send("test".into()).unwrap();
+
+        let res = receiver.recv().unwrap();
+
+        assert_eq!("test".to_string(), res.as_json_string());
+
+        con.stop().unwrap();
+    }
+
+    #[test]
+    fn it_can_tick() {
+        let (sender, receiver) = mpsc::channel();
+
+        let mut con = NetConnectionRelay::new(
+            Box::new(move |r| {
+                sender.send(r?)?;
+                Ok(())
+            }),
+            Box::new(|h| Ok(Box::new(Worker { handler: h }))),
+        ).unwrap();
+
+        con.tick().unwrap();
+
+        let res = receiver.recv().unwrap();
+
+        assert_eq!("tick".to_string(), res.as_json_string());
+
+        con.stop().unwrap();
+    }
+}

--- a/net_connection/src/net_connection_thread.rs
+++ b/net_connection/src/net_connection_thread.rs
@@ -1,0 +1,183 @@
+use super::NetResult;
+
+use super::{
+    net_connection::{NetConnection, NetHandler, NetWorkerFactory},
+    protocol::Protocol,
+};
+
+use std::{thread, time};
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    mpsc, Arc,
+};
+
+/// a NetConnection instance that is managed on another thread
+#[derive(Debug)]
+pub struct NetConnectionThread {
+    keep_running: Arc<AtomicBool>,
+    send_channel: mpsc::Sender<Protocol>,
+    thread: thread::JoinHandle<()>,
+}
+
+impl NetConnection for NetConnectionThread {
+    /// send a message to the worker within this NetConnectionThread instance
+    fn send(&mut self, data: Protocol) -> NetResult<()> {
+        self.send_channel.send(data)?;
+        Ok(())
+    }
+}
+
+impl NetConnectionThread {
+    /// stop (join) the worker thread
+    pub fn stop(self) -> NetResult<()> {
+        self.keep_running.store(false, Ordering::Relaxed);
+        match self.thread.join() {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                bail!("NetConnectionThread failed to join on stop() call");
+            }
+        }
+    }
+
+    /// create a new NetConnectionThread instance with given handler / worker
+    pub fn new(handler: NetHandler, mut worker_factory: NetWorkerFactory) -> NetResult<Self> {
+        let keep_running = Arc::new(AtomicBool::new(true));
+        let keep_running2 = keep_running.clone();
+
+        let (sender, receiver) = mpsc::channel();
+        Ok(NetConnectionThread {
+            keep_running,
+            send_channel: sender,
+            thread: thread::spawn(move || {
+                let mut us = 100_u64;
+                let mut worker = match worker_factory(handler) {
+                    Ok(w) => w,
+                    Err(e) => panic!("{:?}", e),
+                };
+
+                while keep_running2.load(Ordering::Relaxed) {
+                    let mut did_something = false;
+
+                    match receiver.try_recv() {
+                        Ok(data) => {
+                            did_something = true;
+                            match worker.receive(data) {
+                                Ok(_) => (),
+                                Err(e) => panic!("{:?}", e),
+                            };
+                        }
+                        Err(_) => (),
+                    };
+
+                    match worker.tick() {
+                        Ok(b) => {
+                            if b {
+                                did_something = true;
+                            }
+                        }
+                        Err(e) => panic!("{:?}", e),
+                    };
+
+                    if did_something {
+                        us = 100_u64;
+                    } else {
+                        us *= 2_u64;
+                        if us > 10_000_u64 {
+                            us = 10_000_u64;
+                        }
+                    }
+
+                    thread::sleep(time::Duration::from_micros(us));
+                }
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use super::super::net_connection::NetWorker;
+
+    struct DefWorker;
+
+    impl NetWorker for DefWorker {}
+
+    #[test]
+    fn it_can_defaults() {
+        let mut con = NetConnectionThread::new(
+            Box::new(move |_r| Ok(())),
+            Box::new(|_h| Ok(Box::new(DefWorker))),
+        ).unwrap();
+
+        con.send("test".into()).unwrap();
+        con.stop().unwrap();
+    }
+
+    struct Worker {
+        handler: NetHandler,
+    }
+
+    impl NetWorker for Worker {
+        fn tick(&mut self) -> NetResult<bool> {
+            (self.handler)(Ok("tick".into()))?;
+            Ok(true)
+        }
+
+        fn receive(&mut self, data: Protocol) -> NetResult<()> {
+            (self.handler)(Ok(data))
+        }
+    }
+
+    #[test]
+    fn it_invokes_connection_thread() {
+        let (sender, receiver) = mpsc::channel();
+
+        let mut con = NetConnectionThread::new(
+            Box::new(move |r| {
+                sender.send(r?)?;
+                Ok(())
+            }),
+            Box::new(|h| Ok(Box::new(Worker { handler: h }))),
+        ).unwrap();
+
+        con.send("test".into()).unwrap();
+
+        let res;
+        loop {
+            let tmp = receiver.recv().unwrap();
+
+            if &(tmp.as_json_string()) == "tick" {
+                continue;
+            } else {
+                res = tmp;
+                break;
+            }
+        }
+
+        assert_eq!("test".to_string(), res.as_json_string());
+
+        con.stop().unwrap();
+    }
+
+    #[test]
+    fn it_can_tick() {
+        let (sender, receiver) = mpsc::channel();
+
+        let con = NetConnectionThread::new(
+            Box::new(move |r| {
+                sender.send(r?)?;
+                Ok(())
+            }),
+            Box::new(|h| Ok(Box::new(Worker { handler: h }))),
+        ).unwrap();
+
+        let res = receiver.recv().unwrap();
+
+        assert_eq!("tick".to_string(), res.as_json_string());
+
+        con.stop().unwrap();
+    }
+}

--- a/net_connection/src/protocol.rs
+++ b/net_connection/src/protocol.rs
@@ -1,0 +1,276 @@
+//! This module provides the core low-level protocol enumeration
+//! for communications between holochain core and the p2p / networking
+//! process or library. See protocol_wrapper for a higher level interface.
+
+use rmp_serde;
+use serde_bytes;
+
+use holochain_core_types::json::JsonString;
+
+/// Low-level interface spec for communicating with the p2p abstraction
+/// notice this is not Serializable or Deserializable
+/// rmp_serde doesn't serialize enums very well... it uses indexes and arrays
+/// which are not (easily) compatible with other endpoints
+/// we use to/from NamedBinaryData to provide our own serialization wrapper
+#[derive(Debug, Clone, PartialEq)]
+pub enum Protocol {
+    /// send/recv binary data / i.e. encryption, signature messages
+    NamedBinary(NamedBinaryData),
+    /// send/recv generic json as utf8 strings
+    Json(JsonString),
+    /// send/recv a Ping message (ipc protocol spec)
+    Ping(PingData),
+    /// send/recv a Pong message (ipc protocol spec)
+    Pong(PongData),
+    /// we have connected / configured the connection, ready for messages
+    P2pReady,
+}
+
+/// provide utility for Protocol serialization
+impl<'a> From<&'a Protocol> for NamedBinaryData {
+    fn from(p: &'a Protocol) -> Self {
+        match p {
+            Protocol::NamedBinary(nb) => NamedBinaryData {
+                name: b"namedBinary".to_vec(),
+                data: rmp_serde::to_vec_named(nb).unwrap(),
+            },
+            Protocol::Json(j) => NamedBinaryData {
+                name: b"json".to_vec(),
+                data: String::from(j).as_bytes().to_vec(),
+            },
+            Protocol::Ping(p) => NamedBinaryData {
+                name: b"ping".to_vec(),
+                data: rmp_serde::to_vec_named(p).unwrap(),
+            },
+            Protocol::Pong(p) => NamedBinaryData {
+                name: b"pong".to_vec(),
+                data: rmp_serde::to_vec_named(p).unwrap(),
+            },
+            Protocol::P2pReady => NamedBinaryData {
+                name: b"p2pReady".to_vec(),
+                data: Vec::new(),
+            },
+        }
+    }
+}
+
+impl From<Protocol> for NamedBinaryData {
+    fn from(p: Protocol) -> Self {
+        (&p).into()
+    }
+}
+
+/// provide utility for Protocol deserialization
+impl<'a> From<&'a NamedBinaryData> for Protocol {
+    fn from(nb: &'a NamedBinaryData) -> Self {
+        match nb.name.as_slice() {
+            b"namedBinary" => {
+                let sub: NamedBinaryData = rmp_serde::from_slice(&nb.data).unwrap();
+                Protocol::NamedBinary(sub)
+            }
+            b"json" => Protocol::Json(String::from_utf8_lossy(&nb.data).to_string().into()),
+            b"ping" => {
+                let sub: PingData = rmp_serde::from_slice(&nb.data).unwrap();
+                Protocol::Ping(sub)
+            }
+            b"pong" => {
+                let sub: PongData = rmp_serde::from_slice(&nb.data).unwrap();
+                Protocol::Pong(sub)
+            }
+            b"p2pReady" => Protocol::P2pReady,
+            _ => panic!("bad Protocol type: {}", String::from_utf8_lossy(&nb.name)),
+        }
+    }
+}
+
+impl From<NamedBinaryData> for Protocol {
+    fn from(nb: NamedBinaryData) -> Self {
+        (&nb).into()
+    }
+}
+
+impl<'a> From<&'a str> for Protocol {
+    fn from(s: &'a str) -> Self {
+        Protocol::Json(s.to_string().into())
+    }
+}
+
+impl From<String> for Protocol {
+    fn from(s: String) -> Self {
+        s.as_str().into()
+    }
+}
+
+impl From<Protocol> for String {
+    fn from(p: Protocol) -> String {
+        p.as_json_string()
+    }
+}
+
+/// local macro for creating is_* and as_* functions on Protocol
+/// (DRY some boilerplate)
+macro_rules! simple_access {
+    ($($is:ident $as:ident $d:ident $t:ty)*) => {
+        $(
+            pub fn $is(&self) -> bool {
+                if let Protocol::$d(_) = self {
+                    true
+                } else {
+                    false
+                }
+            }
+
+            pub fn $as<'a>(&'a self) -> &'a $t {
+                if let Protocol::$d(data) = self {
+                    &data
+                } else {
+                    panic!(concat!(stringify!($as), " called with bad type"));
+                }
+            }
+        )*
+    }
+}
+
+impl Protocol {
+    simple_access! {
+        is_named_binary as_named_binary NamedBinary NamedBinaryData
+        is_json as_json Json JsonString
+        is_ping as_ping Ping PingData
+        is_pong as_pong Pong PongData
+    }
+
+    /// get a json string straight out of the Protocol enum
+    pub fn as_json_string(&self) -> String {
+        if let Protocol::Json(data) = self {
+            String::from(data)
+        } else {
+            panic!("as_json_string called with bad type");
+        }
+    }
+}
+
+/// send/recv binary data / i.e. encryption, signature messages
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct NamedBinaryData {
+    #[serde(with = "serde_bytes")]
+    pub name: Vec<u8>,
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}
+
+/// send/recv a Ping message (ipc protocol spec)
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PingData {
+    pub sent: f64,
+}
+
+/// send/recv a Pong message (ipc protocol spec)
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PongData {
+    pub orig: f64,
+    pub recv: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmp_serde;
+
+    #[test]
+    fn it_should_handle_bad_type() {
+        let p = Protocol::P2pReady;
+
+        assert_eq!(false, p.is_json());
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_should_panic_on_bad_as() {
+        let p = Protocol::P2pReady;
+        p.as_json();
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_should_panic_on_bad_as_json_string() {
+        let p = Protocol::P2pReady;
+        p.as_json_string();
+    }
+
+    /// serialize and deserialize $e
+    macro_rules! simple_convert {
+        ($e:expr) => {{
+            let wire: NamedBinaryData = $e.into();
+            let res: Protocol = wire.into();
+            res
+        }};
+    }
+
+    #[test]
+    fn it_can_convert_named_binary() {
+        let nb_src = Protocol::NamedBinary(NamedBinaryData {
+            name: b"test".to_vec(),
+            data: b"hello".to_vec(),
+        });
+
+        let res = simple_convert!(nb_src);
+
+        assert!(res.is_named_binary());
+
+        let res = res.as_named_binary();
+
+        assert_eq!(b"test".to_vec(), res.name);
+        assert_eq!(b"hello".to_vec(), res.data);
+    }
+
+    #[test]
+    fn it_can_convert_json() {
+        let json_str = "{\"test\": \"hello\"}";
+        let json: Protocol = json_str.to_string().into();
+
+        let res = simple_convert!(json);
+
+        assert!(res.is_json());
+
+        let res = String::from(res);
+
+        assert_eq!(json_str, res);
+    }
+
+    #[test]
+    fn it_can_convert_ping() {
+        let src = Protocol::Ping(PingData { sent: 42.0 });
+
+        let res = simple_convert!(&src);
+
+        assert!(res.is_ping());
+
+        let res = res.as_ping();
+
+        assert_eq!(42.0, res.sent);
+    }
+
+    #[test]
+    fn it_can_convert_pong() {
+        let src = Protocol::Pong(PongData {
+            orig: 42.0,
+            recv: 88.0,
+        });
+
+        let res = simple_convert!(&src);
+
+        assert!(res.is_pong());
+
+        let res = res.as_pong();
+
+        assert_eq!(42.0, res.orig);
+        assert_eq!(88.0, res.recv);
+    }
+
+    #[test]
+    fn it_can_convert_p2p_ready() {
+        let res = simple_convert!(&Protocol::P2pReady);
+
+        assert_eq!(Protocol::P2pReady, res);
+    }
+}

--- a/net_connection/src/protocol_wrapper.rs
+++ b/net_connection/src/protocol_wrapper.rs
@@ -1,0 +1,428 @@
+//! This module provides a higher level interface to p2p / network messaging
+//! basically handles serialization / deserialization from / to the core
+//! protocol message types (NamedBinary and Json).
+
+use serde_json;
+
+use super::protocol::Protocol;
+
+/// High level p2p / network message
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProtocolWrapper {
+    /// if we don't have a high-level repr, just store the base protocol
+    RawProtocol(Protocol),
+
+    /// [send] request the current state from the p2p module
+    RequestState,
+
+    /// [recv] p2p module is telling us the current state
+    State(StateData),
+
+    /// [send] request the default config from the p2p module
+    RequestDefaultConfig,
+
+    /// [recv] the default config from the p2p module
+    DefaultConfig(ConfigData),
+
+    /// [send] set the p2p config
+    SetConfig(ConfigData),
+
+    /// [send] connect to the specified multiaddr
+    Connect(ConnectData),
+
+    /// [recv] notification of a peer connected
+    PeerConnected(PeerConnectData),
+
+    /// [send] send a message to another node on the network
+    SendMessage(SendData),
+
+    /// [recv] recv the response back from a previous `SendMessage`
+    SendResult(SendResultData),
+
+    /// [recv] another node has sent us a message
+    HandleSend(HandleSendData),
+
+    /// [send] send our response to a previous `HandleSend`
+    HandleSendResult(SendResultData),
+}
+
+/// upgrade a Protocol reference to a ProtocolWrapper instance
+impl<'a> From<&'a Protocol> for ProtocolWrapper {
+    fn from(p: &'a Protocol) -> Self {
+        if let Protocol::Json(json) = p {
+            let json: serde_json::Value = serde_json::from_str(json.into()).unwrap();
+            let method = &json["method"];
+
+            if method == "requestState" {
+                return ProtocolWrapper::RequestState;
+            } else if method == "state" {
+                return ProtocolWrapper::State(StateData {
+                    state: match json["state"].as_str() {
+                        Some(s) => s.to_string(),
+                        None => "undefined".to_string(),
+                    },
+                    id: match json["id"].as_str() {
+                        Some(s) => s.to_string(),
+                        None => "undefined".to_string(),
+                    },
+                    bindings: match json["bindings"].as_array() {
+                        Some(arr) => arr
+                            .iter()
+                            .map(|i| match i.as_str() {
+                                Some(b) => b.to_string(),
+                                None => "undefined".to_string(),
+                            })
+                            .collect(),
+                        None => Vec::new(),
+                    },
+                });
+            } else if method == "requestDefaultConfig" {
+                return ProtocolWrapper::RequestDefaultConfig;
+            } else if method == "defaultConfig" {
+                assert!(json["config"].is_string());
+                return ProtocolWrapper::DefaultConfig(ConfigData {
+                    config: json["config"].as_str().unwrap().to_string(),
+                });
+            } else if method == "setConfig" {
+                assert!(json["config"].is_string());
+                return ProtocolWrapper::SetConfig(ConfigData {
+                    config: json["config"].as_str().unwrap().to_string(),
+                });
+            } else if method == "connect" {
+                assert!(json["address"].is_string());
+                return ProtocolWrapper::Connect(ConnectData {
+                    address: json["address"].as_str().unwrap().to_string(),
+                });
+            } else if method == "peerConnected" {
+                assert!(json["id"].is_string());
+                return ProtocolWrapper::PeerConnected(PeerConnectData {
+                    id: json["id"].as_str().unwrap().to_string(),
+                });
+            } else if method == "send" {
+                assert!(json["_id"].is_string());
+                assert!(json["toAddress"].is_string());
+                return ProtocolWrapper::SendMessage(SendData {
+                    msg_id: json["_id"].as_str().unwrap().to_string(),
+                    to_address: json["toAddress"].as_str().unwrap().to_string(),
+                    data: json["data"].clone(),
+                });
+            } else if method == "handleSend" {
+                assert!(json["_id"].is_string());
+                assert!(json["toAddress"].is_string());
+                assert!(json["fromAddress"].is_string());
+                return ProtocolWrapper::HandleSend(HandleSendData {
+                    msg_id: json["_id"].as_str().unwrap().to_string(),
+                    to_address: json["toAddress"].as_str().unwrap().to_string(),
+                    from_address: json["fromAddress"].as_str().unwrap().to_string(),
+                    data: json["data"].clone(),
+                });
+            } else if method == "handleSendResult" {
+                assert!(json["_id"].is_string());
+                return ProtocolWrapper::HandleSendResult(SendResultData {
+                    msg_id: json["_id"].as_str().unwrap().to_string(),
+                    data: json["data"].clone(),
+                });
+            } else if method == "sendResult" {
+                assert!(json["_id"].is_string());
+                return ProtocolWrapper::SendResult(SendResultData {
+                    msg_id: json["_id"].as_str().unwrap().to_string(),
+                    data: json["data"].clone(),
+                });
+            }
+        }
+
+        ProtocolWrapper::RawProtocol(p.clone())
+    }
+}
+
+impl From<Protocol> for ProtocolWrapper {
+    fn from(p: Protocol) -> Self {
+        ProtocolWrapper::from(&p)
+    }
+}
+
+/// downgrade a ProtocolWrapper instance back into a Protocol message
+impl<'a> From<&'a ProtocolWrapper> for Protocol {
+    // david.b (neonphog) - tarpaulin doesn't cover macros... skipping this fn
+    #[cfg_attr(tarpaulin, skip)]
+    fn from(w: &'a ProtocolWrapper) -> Self {
+        match w {
+            ProtocolWrapper::RawProtocol(p) => p.clone(),
+            ProtocolWrapper::RequestState => Protocol::Json(
+                json!({
+                    "method": "requestState",
+                }).into(),
+            ),
+            ProtocolWrapper::State(s) => Protocol::Json(
+                json!({
+                    "method": "state",
+                    "state": s.state,
+                    "id": s.id,
+                    "bindings": s.bindings,
+                }).into(),
+            ),
+            ProtocolWrapper::RequestDefaultConfig => Protocol::Json(
+                json!({
+                    "method": "requestDefaultConfig",
+                }).into(),
+            ),
+            ProtocolWrapper::DefaultConfig(c) => Protocol::Json(
+                json!({
+                    "method": "defaultConfig",
+                    "config": c.config,
+                }).into(),
+            ),
+            ProtocolWrapper::SetConfig(c) => Protocol::Json(
+                json!({
+                    "method": "setConfig",
+                    "config": c.config,
+                }).into(),
+            ),
+            ProtocolWrapper::Connect(c) => Protocol::Json(
+                json!({
+                    "method": "connect",
+                    "address": c.address,
+                }).into(),
+            ),
+            ProtocolWrapper::PeerConnected(c) => Protocol::Json(
+                json!({
+                    "method": "peerConnected",
+                    "id": c.id,
+                }).into(),
+            ),
+            ProtocolWrapper::SendMessage(m) => Protocol::Json(
+                json!({
+                    "method": "send",
+                    "_id": m.msg_id,
+                    "toAddress": m.to_address,
+                    "data": m.data,
+                }).into(),
+            ),
+            ProtocolWrapper::HandleSend(m) => Protocol::Json(
+                json!({
+                    "method": "handleSend",
+                    "_id": m.msg_id,
+                    "toAddress": m.to_address,
+                    "fromAddress": m.from_address,
+                    "data": m.data,
+                }).into(),
+            ),
+            ProtocolWrapper::HandleSendResult(m) => Protocol::Json(
+                json!({
+                    "method": "handleSendResult",
+                    "_id": m.msg_id,
+                    "data": m.data,
+                }).into(),
+            ),
+            ProtocolWrapper::SendResult(m) => Protocol::Json(
+                json!({
+                    "method": "sendResult",
+                    "_id": m.msg_id,
+                    "data": m.data,
+                }).into(),
+            ),
+        }
+    }
+}
+
+impl From<ProtocolWrapper> for Protocol {
+    fn from(w: ProtocolWrapper) -> Self {
+        Protocol::from(&w)
+    }
+}
+
+/// state of the p2p connection
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct StateData {
+    /// 'need_config' / 'pending' / 'ready'
+    pub state: String,
+    /// the transport identifier of this node
+    pub id: String,
+    /// the opaque transport bindings for bootstrapping others
+    pub bindings: Vec<String>,
+}
+
+/// configuration info
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ConfigData {
+    /// should be serialized in a human-readable format (e.g. json, toml, etc)
+    pub config: String,
+}
+
+/// multiaddr to connect to
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct ConnectData {
+    pub address: String,
+}
+
+/// node connection info
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PeerConnectData {
+    pub id: String,
+}
+
+/// send a message to another node
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SendData {
+    /// the `SendResultData` will contain the id you put here
+    pub msg_id: String,
+    /// the id of the node to message
+    pub to_address: String,
+    /// the data to send
+    pub data: serde_json::Value,
+}
+
+/// we need to handle a `send` from another node
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct HandleSendData {
+    /// when you pass back the `HandleSendResult`, use this id
+    pub msg_id: String,
+    /// this should be your id
+    pub to_address: String,
+    /// the id of the node sending this message
+    pub from_address: String,
+    /// the data they are sending
+    pub data: serde_json::Value,
+}
+
+/// when processing a SendResult or a HandleSendResult
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct SendResultData {
+    /// the id associated with this message
+    pub msg_id: String,
+    /// the data associated with this response
+    pub data: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_can_convert_request_state() {
+        let p: Protocol = ProtocolWrapper::RequestState.into();
+        assert_eq!("{\"method\":\"requestState\"}", &p.as_json_string());
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(ProtocolWrapper::RequestState, w);
+    }
+
+    #[test]
+    fn it_can_convert_state() {
+        let orig = ProtocolWrapper::State(StateData {
+            state: "test_state".to_string(),
+            id: "test_id".to_string(),
+            bindings: vec!["test_b1".to_string(), "test_b2".to_string()],
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_weird_state() {
+        let w: ProtocolWrapper = Protocol::Json(json!({
+            "method": "state",
+            "bindings": [null],
+        }).into()).into();
+        assert_eq!(w, ProtocolWrapper::State(StateData {
+            state: "undefined".to_string(),
+            id: "undefined".to_string(),
+            bindings: vec!["undefined".to_string()],
+        }));
+    }
+
+    #[test]
+    fn it_can_convert_request_default_config() {
+        let p: Protocol = ProtocolWrapper::RequestDefaultConfig.into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(ProtocolWrapper::RequestDefaultConfig, w);
+    }
+
+    #[test]
+    fn it_can_convert_default_config() {
+        let orig = ProtocolWrapper::DefaultConfig(ConfigData {
+            config: "test_config".to_string(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_set_config() {
+        let orig = ProtocolWrapper::SetConfig(ConfigData {
+            config: "test_config".to_string(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_connect() {
+        let orig = ProtocolWrapper::Connect(ConnectData {
+            address: "test_addr".to_string(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_peer_connected() {
+        let orig = ProtocolWrapper::PeerConnected(PeerConnectData {
+            id: "test_id".to_string(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_send_message() {
+        let orig = ProtocolWrapper::SendMessage(SendData {
+            msg_id: "test_id".to_string(),
+            to_address: "test_addr".to_string(),
+            data: "test_data".into(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_send_result() {
+        let orig = ProtocolWrapper::SendResult(SendResultData {
+            msg_id: "test_id".to_string(),
+            data: "test_data".into(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_handle_send() {
+        let orig = ProtocolWrapper::HandleSend(HandleSendData {
+            msg_id: "test_id".to_string(),
+            to_address: "test_addr".to_string(),
+            from_address: "test_addr2".to_string(),
+            data: "test_data".into(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+    #[test]
+    fn it_can_convert_handle_send_result() {
+        let orig = ProtocolWrapper::HandleSendResult(SendResultData {
+            msg_id: "test_id".to_string(),
+            data: "test_data".into(),
+        });
+        let p: Protocol = (&orig).into();
+        let w: ProtocolWrapper = p.into();
+        assert_eq!(orig, w);
+    }
+
+}


### PR DESCRIPTION
Don't be scared by the line count! It's mostly unit tests and `From` trait helpers.

The code submitted here replaces most of the functionality in the `net` and `net_ipc` crates. To see a more complete integration / usage, you can see my [net-connector](https://github.com/holochain/holochain-rust/compare/net-connection-step1...net-connector) branch + the [test_bin](https://github.com/holochain/holochain-rust/blob/net-connector/test_bin/src/test_bin_ipc.rs#L45).

We'll still need those crates, they'll just be much simpler because the message protocol for the abstraction is taken care of here.

Main Points:

- `Protocol` defines a simple low-level protocol for communicating with an abstract p2p module
- `ProtocolWrapper` defines a higher-level developer friendly wrapper around protocol
- `NetConnection / NetWorker` define a light-weight messaging strategy that can easily be integrated with Riker should we decide to in the future. For now, we just get `Protocol` messages sent to the closure passed in when the system is initialized.

Next Steps:

In an effort to have smaller pull requests, I broke this down into separate PRs, if this is merged, expect a quick follow on:

- `STEP 2` - will delete all the unused parts of the `net` and `net_ipc` crates.
- `STEP 3` - will add back in the ipc zmq socket management in the `net_ipc` crate, but using the `net_connection` abstraction
- `STEP 4` - will update the `net` crate with a `P2pNetwork` class that uses the `net_connection` abstraction, as well as a `test_bin` binary that exercises it.