### PR TITLE
update dockerfile to use cosmic and fix makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# WARNING, this Makefile must be updated in two places: the repo root, and docker subdirectory.
+
 # holochain-rust Makefile
 # currently only supports 'debug' builds
 
@@ -155,8 +157,13 @@ wasm_build: ensure_wasm_target
 build: core_toolchain wasm_build
 	$(CARGO) build --all
 
+.PHONY: code_coverage
 code_coverage: core_toolchain wasm_build install_ci
 	$(CARGO) tarpaulin --timeout 600 --all --out Xml --skip-clean -v -e holochain_core_api_c_binding -e hdk
+
+.PHONY: code_coverage_crate
+code_coverage_crate: core_toolchain wasm_build install_ci
+	$(CARGO) tarpaulin --timeout 600 --skip-clean -v -p $(CRATE)
 
 fmt_check: install_rust_tools
 	$(CARGO_TOOLS) fmt -- --check

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,23 +1,30 @@
-# WARNING, this file must be updated in two places: the repo root, and docker subdirectory.
-
-FROM ubuntu:xenial
+FROM ubuntu:cosmic
 
 # This removes some warning when installing packages when there is no X
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get install --yes\
+USER root
+
+# setup for install and get basics
+RUN apt-get update && apt-get install --yes \
   libssl-dev \
   pkg-config \
   cmake\
   zlib1g-dev \
   curl \
-  qt5-default \
   python2.7 \
   gosu \
   libzmq3-dev \
-  git \
-  nodejs \
-  npm
+  git
+
+# install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash
+RUN apt-get install -y nodejs
+
+# install qt
+RUN apt-get install --yes\
+  qt5-default
+
 
 # Set the internal user for the docker container (non-root)
 ENV DOCKER_BUILD_USER holochain

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -21,11 +21,6 @@ RUN apt-get update && apt-get install --yes \
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash
 RUN apt-get install -y nodejs
 
-# install qt
-RUN apt-get install --yes\
-  qt5-default
-
-
 # Set the internal user for the docker container (non-root)
 ENV DOCKER_BUILD_USER holochain
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,3 +1,5 @@
+# WARNING, this Makefile must be updated in two places: the repo root, and docker subdirectory.
+
 # holochain-rust Makefile
 # currently only supports 'debug' builds
 


### PR DESCRIPTION
Here is a docker file that uses cosmic (18.10) and thus allows us to install Qt 5.11 (in the holochain-cmd and app-spec-rust docker-fiels) without special build. 

This docker file also includes necessary weirdness for installing nodejs on cosmic which doesn't work the usual way (apt-get install) on 18.10.