### PR TITLE
net_connection p2p abstraction - STEP 3

### DIFF
--- a/net_ipc/Cargo.toml
+++ b/net_ipc/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["neonphog <neonphog@gmail.com>"]
 
 [dependencies]
 failure = "0.1.1"
+holochain_net_connection = { path = "../net_connection" }
 lazy_static = "1.0"
 rmp-serde = "0.13.7"
 serde = "1.0"

--- a/net_ipc/src/ipc_client.rs
+++ b/net_ipc/src/ipc_client.rs
@@ -1,0 +1,233 @@
+//! implements a net_connection::NetWorker for messaging with an ipc p2p node
+
+use socket::IpcSocket;
+use util::get_millis;
+
+use std::{thread, time};
+
+use holochain_net_connection::{
+    net_connection::{NetHandler, NetWorker},
+    protocol::{NamedBinaryData, PingData, PongData, Protocol},
+    NetResult,
+};
+
+// with two zmq "ROUTER" sockets, one side must have a well-known id
+// for the holochain ipc protocol, the server is always 4 0x24 bytes
+static SRV_ID: &'static [u8] = &[0x24, 0x24, 0x24, 0x24];
+
+/// NetWorker for messaging with an ipc p2p node
+pub struct IpcClient {
+    handler: NetHandler,
+    socket: Box<IpcSocket>,
+    last_recv_millis: f64,
+    last_send_millis: f64,
+}
+
+impl NetWorker for IpcClient {
+    /// stop the worker
+    fn stop(self: Box<Self>) -> NetResult<()> {
+        self.socket.close()?;
+        Ok(())
+    }
+
+    /// handle messages sent to us from holochain_net
+    fn receive(&mut self, data: Protocol) -> NetResult<()> {
+        self.priv_send(&data)
+    }
+
+    /// perform upkeep (like ping/pong messages) on the underlying ipc socket
+    fn tick(&mut self) -> NetResult<bool> {
+        let mut did_something = false;
+
+        if let Some(msg) = self.priv_proc_message()? {
+            did_something = true;
+
+            if let Protocol::Ping(ref p) = msg {
+                self.priv_send(&Protocol::Pong(PongData {
+                    orig: p.sent,
+                    recv: get_millis(),
+                }))?;
+            }
+
+            (self.handler)(Ok(msg))?;
+        }
+
+        let now = get_millis();
+
+        if now - self.last_recv_millis > 2000.0 {
+            bail!("ipc connection timeout");
+        }
+
+        if now - self.last_send_millis > 500.0 {
+            self.priv_ping()?;
+            did_something = true;
+        }
+
+        Ok(did_something)
+    }
+}
+
+impl IpcClient {
+    /// establish a new ipc connection
+    /// for now, the api simplicity is worth blocking the thread on connection
+    pub fn new(handler: NetHandler, mut socket: Box<IpcSocket>) -> NetResult<Self> {
+        let start = get_millis();
+        let mut backoff = 1_u64;
+
+        loop {
+            // wait for any message from server to indicate connect success
+            if socket.poll(0)? {
+                break;
+            }
+
+            if get_millis() - start > 3000.0 {
+                bail!("connection init timeout");
+            }
+
+            let data = Protocol::Ping(PingData { sent: get_millis() });
+            let data: NamedBinaryData = data.into();
+            socket.send(&[SRV_ID, &[], &b"ping".to_vec(), &data.data])?;
+
+            backoff *= 2;
+            if backoff > 500 {
+                backoff = 500;
+            }
+
+            thread::sleep(time::Duration::from_millis(backoff));
+        }
+
+        Ok(Self {
+            handler,
+            socket,
+            last_recv_millis: get_millis(),
+            last_send_millis: 0.0,
+        })
+    }
+
+    // -- private -- //
+
+    /// monitor the ipc socket / handle messages
+    fn priv_proc_message(&mut self) -> NetResult<Option<Protocol>> {
+        if !self.socket.poll(0)? {
+            return Ok(None);
+        }
+
+        // we have data, let's fetch it
+        let res = self.socket.recv()?;
+        if res.len() != 4 {
+            bail!("bad msg len: {}", res.len());
+        }
+
+        // we got a message, update our timeout counter
+        self.last_recv_millis = get_millis();
+
+        let msg = NamedBinaryData {
+            name: res[2].to_vec(),
+            data: res[3].to_vec(),
+        };
+
+        let msg: Protocol = msg.into();
+
+        Ok(Some(msg))
+    }
+
+    /// Send a heartbeat message to the ipc server.
+    fn priv_ping(&mut self) -> NetResult<()> {
+        self.priv_send(&Protocol::Ping(PingData { sent: get_millis() }))
+    }
+
+    /// send a raw message to the ipc server
+    fn priv_send(&mut self, data: &Protocol) -> NetResult<()> {
+        let data: NamedBinaryData = data.into();
+
+        self.socket.send(&[SRV_ID, &[], &data.name, &data.data])?;
+
+        // sent message, update our ping timer
+        self.last_send_millis = get_millis();
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::mpsc;
+
+    use socket::MockIpcSocket;
+
+    #[test]
+    fn it_ipc_message_flow() {
+        let (sender, receiver) = mpsc::channel::<Protocol>();
+
+        let (s, stx, srx) = MockIpcSocket::new_test().unwrap();
+
+        let pong = Protocol::Pong(PongData {
+            orig: get_millis() - 4.0,
+            recv: get_millis() - 2.0,
+        });
+        let data: NamedBinaryData = (&pong).into();
+
+        stx.send(vec![vec![], vec![], b"pong".to_vec(), data.data])
+            .unwrap();
+
+        let mut cli = Box::new(
+            IpcClient::new(
+                Box::new(move |r| {
+                    sender.send(r?)?;
+                    Ok(())
+                }),
+                s,
+            ).unwrap(),
+        );
+
+        cli.tick().unwrap();
+
+        let res = receiver.recv().unwrap();
+
+        assert_eq!(pong, res);
+
+        stx.send(vec![]).unwrap();;
+
+        cli.tick().expect_err("expected bad arg count");
+
+        let ping = Protocol::Ping(PingData { sent: get_millis() });
+        let data: NamedBinaryData = (&ping).into();
+
+        stx.send(vec![vec![], vec![], b"ping".to_vec(), data.data])
+            .unwrap();
+
+        cli.tick().unwrap();
+
+        let res = receiver.recv().unwrap();
+
+        assert_eq!(ping, res);
+
+        cli.receive(Protocol::P2pReady).unwrap();
+
+        let mut out: Vec<String> = Vec::new();
+
+        loop {
+            thread::sleep(time::Duration::from_millis(2));
+
+            let res = srx.recv().unwrap();
+            if res[2].as_slice() == b"ping" {
+                continue;
+            } else {
+                out.push(String::from_utf8_lossy(&res[2]).to_string());
+                if out.len() >= 2 {
+                    break;
+                }
+            }
+        }
+
+        out.sort_unstable();
+
+        assert_eq!("p2pReady", &out[0]);
+        assert_eq!("pong", &out[1]);
+
+        cli.tick().unwrap();
+        cli.stop().unwrap();
+    }
+}

--- a/net_ipc/src/lib.rs
+++ b/net_ipc/src/lib.rs
@@ -10,6 +10,7 @@
 
 #[macro_use]
 extern crate failure;
+extern crate holochain_net_connection;
 #[macro_use]
 extern crate lazy_static;
 extern crate rmp_serde;
@@ -22,3 +23,5 @@ pub mod errors;
 pub mod context;
 pub mod socket;
 pub mod util;
+
+pub mod ipc_client;

--- a/net_ipc/src/socket.rs
+++ b/net_ipc/src/socket.rs
@@ -4,6 +4,7 @@
 
 use context;
 use errors::*;
+use std::sync::mpsc;
 use zmq;
 
 /// trait that allows zmq socket abstraction
@@ -70,28 +71,32 @@ impl IpcSocket for ZmqIpcSocket {
 /// This is a concrete implementation of the IpcSocket trait for use in testing
 pub struct MockIpcSocket {
     resp_queue: Vec<Vec<Vec<u8>>>,
-    sent_queue: Vec<Vec<Vec<u8>>>,
+    recv: mpsc::Receiver<Vec<Vec<u8>>>,
+    send: mpsc::SyncSender<Vec<Vec<u8>>>,
 }
 
 impl MockIpcSocket {
-    pub fn inject_response(&mut self, data: Vec<Vec<u8>>) {
-        self.resp_queue.push(data);
-    }
-
-    pub fn sent_count(&self) -> usize {
-        self.sent_queue.len()
-    }
-
-    pub fn next_sent(&mut self) -> Vec<Vec<u8>> {
-        self.sent_queue.remove(0)
+    pub fn new_test() -> Result<(
+        Box<Self>,
+        mpsc::SyncSender<Vec<Vec<u8>>>,
+        mpsc::Receiver<Vec<Vec<u8>>>,
+    )> {
+        let (tx_in, rx_in) = mpsc::sync_channel(10);
+        let (tx_out, rx_out) = mpsc::sync_channel(10);
+        let mut out = MockIpcSocket::new()?;
+        out.recv = rx_in;
+        out.send = tx_out;
+        Ok((out, tx_in, rx_out))
     }
 }
 
 impl IpcSocket for MockIpcSocket {
     fn new() -> Result<Box<Self>> {
+        let (tx, rx) = mpsc::sync_channel(10);
         Ok(Box::new(Self {
             resp_queue: Vec::new(),
-            sent_queue: Vec::new(),
+            recv: rx,
+            send: tx,
         }))
     }
 
@@ -104,11 +109,22 @@ impl IpcSocket for MockIpcSocket {
     }
 
     fn poll(&mut self, _millis: i64) -> Result<bool> {
+        self.recv
+            .try_recv()
+            .and_then(|r| {
+                self.resp_queue.push(r);
+                Ok(())
+            })
+            .unwrap_or(());
         Ok(!self.resp_queue.is_empty())
     }
 
     fn recv(&mut self) -> Result<Vec<Vec<u8>>> {
-        Ok(self.resp_queue.remove(0))
+        self.poll(0)?;
+        if !self.resp_queue.is_empty() {
+            return Ok(self.resp_queue.remove(0));
+        }
+        Ok(self.recv.recv()?)
     }
 
     fn send(&mut self, data: &[&[u8]]) -> Result<()> {
@@ -116,7 +132,7 @@ impl IpcSocket for MockIpcSocket {
         for item in data {
             tmp.push(item.to_vec());
         }
-        self.sent_queue.push(tmp);
+        self.send.send(tmp)?;
         Ok(())
     }
 }
@@ -136,18 +152,17 @@ mod tests {
 
     #[test]
     fn it_mock_cycle() {
-        let mut c = MockIpcSocket::new().unwrap();
+        let (mut c, tx, rx) = MockIpcSocket::new_test().unwrap();
         c.connect("").unwrap();
 
         assert_eq!(false, c.poll(0).unwrap());
-        assert_eq!(0, c.sent_count());
 
         c.send(&[&[1]]).unwrap();
 
-        assert_eq!(1, c.sent_count());
-        assert_eq!(1, c.next_sent()[0][0]);
+        let tmp = rx.recv();
+        assert_eq!(1, tmp.unwrap()[0][0]);
 
-        c.inject_response(vec![vec![2]]);
+        tx.send(vec![vec![2]]).unwrap();
 
         assert_eq!(true, c.poll(0).unwrap());
         assert_eq!(2, c.recv().unwrap()[0][0]);


### PR DESCRIPTION
Follow on to [STEP 2](https://github.com/holochain/holochain-rust/pull/604).

Implements the `net_connection` protocol for a zeromq ipc socket connection.

The next and final step will be the `net` abstraction integration, which you can preview [HERE](https://github.com/holochain/holochain-rust/compare/net-connection-step3...net-connector)