### PR TITLE
added fix to install recent version of nodejs on xenial docker

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -15,9 +15,11 @@ RUN apt-get update && apt-get install --yes\
   python2.7 \
   gosu \
   libzmq3-dev \
-  git \
-  nodejs \
-  npm
+  git
+
+# install nodejs
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash
+RUN apt-get install -y nodejs
 
 # Set the internal user for the docker container (non-root)
 ENV DOCKER_BUILD_USER holochain


### PR DESCRIPTION
app-spec-rust and holochain-cmd failing because of bad nodejs version in xenial.