### PR TITLE
Functional mock net/p2p module

### DIFF
--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -9,4 +9,5 @@ failure = "0.1.1"
 holochain_core_types = { path = "../core_types" }
 holochain_net_connection = { path = "../net_connection" }
 holochain_net_ipc = { path = "../net_ipc" }
+lazy_static = "1.2"
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/net/src/lib.rs
+++ b/net/src/lib.rs
@@ -11,8 +11,11 @@ extern crate holochain_core_types;
 extern crate holochain_net_connection;
 extern crate holochain_net_ipc;
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate serde_json;
 
 pub mod error;
 pub mod ipc_net_worker;
+pub mod mock_worker;
 pub mod p2p_network;

--- a/net/src/mock_worker.rs
+++ b/net/src/mock_worker.rs
@@ -1,0 +1,260 @@
+//! provides fake in-memory p2p worker for use in scenario testing
+
+use holochain_core_types::json::JsonString;
+
+use holochain_net_connection::{
+    net_connection::{NetHandler, NetWorker},
+    protocol::Protocol,
+    protocol_wrapper::{MessageData, ProtocolWrapper},
+    NetResult,
+};
+
+use std::{
+    collections::HashMap,
+    convert::TryFrom,
+    sync::{mpsc, Mutex, MutexGuard},
+};
+
+use serde_json;
+
+/// hash connections by dna::agent_id
+fn cat_dna_agent(dna_hash: &str, agent_id: &str) -> String {
+    format!("{}::{}", dna_hash, agent_id)
+}
+
+/// a lazy_static! singleton for routing messages in-memory
+struct MockSingleton {
+    pub access_count: u64,
+    senders: HashMap<String, mpsc::Sender<Protocol>>,
+}
+
+impl MockSingleton {
+    /// create a new mock singleton
+    pub fn new() -> Self {
+        Self {
+            access_count: 0,
+            senders: HashMap::new(),
+        }
+    }
+
+    /// register a data handler with the singleton (for message routing)
+    pub fn register(
+        &mut self,
+        dna_hash: &str,
+        agent_id: &str,
+        sender: mpsc::Sender<Protocol>,
+    ) -> NetResult<()> {
+        self.senders
+            .insert(cat_dna_agent(dna_hash, agent_id), sender);
+        Ok(())
+    }
+
+    /// process a message
+    pub fn handle(&mut self, data: Protocol) -> NetResult<()> {
+        if let Ok(wrap) = ProtocolWrapper::try_from(&data) {
+            match wrap {
+                ProtocolWrapper::SendMessage(msg) => {
+                    self.priv_handle_send(&msg)?;
+                }
+                ProtocolWrapper::HandleSendResult(msg) => {
+                    self.priv_handle_send_result(&msg)?;
+                }
+                _ => (),
+            }
+        }
+        Ok(())
+    }
+
+    // -- private -- //
+
+    /// send a message to the appropriate channel based on dna_hash::agent_id
+    fn priv_send_one(&mut self, dna_hash: &str, agent_id: &str, data: Protocol) -> NetResult<()> {
+        if let Some(sender) = self.senders.get_mut(&cat_dna_agent(dna_hash, agent_id)) {
+            sender.send(data)?;
+        }
+        Ok(())
+    }
+
+    /// we received a SendMessage message...
+    /// normally this would travel over the network, then
+    /// show up as a HandleSend message, fabricate that message && deliver
+    fn priv_handle_send(&mut self, msg: &MessageData) -> NetResult<()> {
+        self.priv_send_one(
+            &msg.dna_hash,
+            &msg.to_agent_id,
+            ProtocolWrapper::HandleSend(msg.clone()).into(),
+        )?;
+        Ok(())
+    }
+
+    /// we received a SendResult message...
+    /// normally this would travel over the network, then
+    /// show up as a SendResult message, fabricate that message && deliver
+    fn priv_handle_send_result(&mut self, msg: &MessageData) -> NetResult<()> {
+        self.priv_send_one(
+            &msg.dna_hash,
+            &msg.to_agent_id,
+            ProtocolWrapper::SendResult(msg.clone()).into(),
+        )?;
+        Ok(())
+    }
+}
+
+/// this is the actual memory space for our mock singleton
+lazy_static! {
+    static ref MOCK: Mutex<MockSingleton> = Mutex::new(MockSingleton::new());
+}
+
+/// make fetching the singleton a little easier
+fn get_mock<'a>() -> NetResult<MutexGuard<'a, MockSingleton>> {
+    match MOCK.lock() {
+        Ok(s) => Ok(s),
+        Err(_) => bail!("mock singleton mutex fail"),
+    }
+}
+
+/// a p2p worker for mocking in-memory scenario tests
+pub struct MockWorker {
+    handler: NetHandler,
+    mock_msgs: Vec<mpsc::Receiver<Protocol>>,
+}
+
+impl NetWorker for MockWorker {
+    /// stop the net worker
+    fn stop(self: Box<Self>) -> NetResult<()> {
+        Ok(())
+    }
+
+    /// we got a message from holochain core
+    /// forward to our mock singleton
+    fn receive(&mut self, data: Protocol) -> NetResult<()> {
+        let mut mock = get_mock()?;
+
+        if let Ok(wrap) = ProtocolWrapper::try_from(&data) {
+            if let ProtocolWrapper::TrackApp(app) = wrap {
+                let (tx, rx) = mpsc::channel();
+                self.mock_msgs.push(rx);
+                mock.register(&app.dna_hash, &app.agent_id, tx)?;
+                return Ok(());
+            }
+        }
+
+        mock.handle(data)?;
+        Ok(())
+    }
+
+    /// check for messages from our mock singleton
+    fn tick(&mut self) -> NetResult<bool> {
+        let mut did_something = false;
+
+        for msg in self.mock_msgs.iter_mut() {
+            if let Ok(data) = msg.try_recv() {
+                did_something = true;
+                (self.handler)(Ok(data))?;
+            }
+        }
+
+        let mut mock = get_mock()?;
+        mock.access_count += 1;
+        println!("mock tick ({})", mock.access_count);
+
+        Ok(did_something)
+    }
+}
+
+impl MockWorker {
+    /// create a new mock worker... no configuration required
+    pub fn new(handler: NetHandler) -> NetResult<Self> {
+        Ok(MockWorker {
+            handler,
+            mock_msgs: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use holochain_net_connection::protocol_wrapper::TrackAppData;
+
+    static DNA_HASH: &'static str = "blabladnahash";
+    static AGENT_ID_1: &'static str = "agent-hash-test-1";
+    static AGENT_ID_2: &'static str = "agent-hash-test-2";
+
+    #[test]
+    #[cfg_attr(tarpaulin, skip)]
+    fn it_mock_networker_flow() {
+        let (handler_send_1, handler_recv_1) = mpsc::channel::<Protocol>();
+        let (handler_send_2, handler_recv_2) = mpsc::channel::<Protocol>();
+
+        let mut cli1 = Box::new(
+            MockWorker::new(Box::new(move |r| {
+                handler_send_1.send(r?)?;
+                Ok(())
+            })).unwrap(),
+        );
+
+        cli1.receive(
+            ProtocolWrapper::TrackApp(TrackAppData {
+                dna_hash: DNA_HASH.to_string(),
+                agent_id: AGENT_ID_1.to_string(),
+            }).into(),
+        ).unwrap();
+
+        let mut cli2 = Box::new(
+            MockWorker::new(Box::new(move |r| {
+                handler_send_2.send(r?)?;
+                Ok(())
+            })).unwrap(),
+        );
+
+        cli2.receive(
+            ProtocolWrapper::TrackApp(TrackAppData {
+                dna_hash: DNA_HASH.to_string(),
+                agent_id: AGENT_ID_2.to_string(),
+            }).into(),
+        ).unwrap();
+
+        cli1.receive(
+            ProtocolWrapper::SendMessage(MessageData {
+                dna_hash: DNA_HASH.to_string(),
+                to_agent_id: AGENT_ID_2.to_string(),
+                from_agent_id: AGENT_ID_1.to_string(),
+                msg_id: "yada".to_string(),
+                data: json!("hello"),
+            }).into(),
+        ).unwrap();
+
+        cli2.tick().unwrap();
+
+        let res = ProtocolWrapper::try_from(handler_recv_2.recv().unwrap()).unwrap();
+
+        if let ProtocolWrapper::HandleSend(msg) = res {
+            cli2.receive(
+                ProtocolWrapper::HandleSendResult(MessageData {
+                    dna_hash: msg.dna_hash,
+                    to_agent_id: msg.from_agent_id,
+                    from_agent_id: AGENT_ID_2.to_string(),
+                    msg_id: msg.msg_id,
+                    data: json!(format!("echo: {}", msg.data.to_string())),
+                }).into(),
+            ).unwrap();
+        } else {
+            panic!("bad msg");
+        }
+
+        cli1.tick().unwrap();
+
+        let res = ProtocolWrapper::try_from(handler_recv_1.recv().unwrap()).unwrap();
+
+        if let ProtocolWrapper::SendResult(msg) = res {
+            assert_eq!("\"echo: \\\"hello\\\"\"".to_string(), msg.data.to_string());
+        } else {
+            panic!("bad msg");
+        }
+
+        cli1.stop().unwrap();
+        cli2.stop().unwrap();
+    }
+}

--- a/net/src/p2p_network.rs
+++ b/net/src/p2p_network.rs
@@ -11,7 +11,7 @@ use holochain_net_connection::{
     NetResult,
 };
 
-use super::ipc_net_worker::IpcNetWorker;
+use super::{ipc_net_worker::IpcNetWorker, mock_worker::MockWorker};
 
 use serde_json;
 
@@ -34,23 +34,30 @@ impl P2pNetwork {
         let config: serde_json::Value = serde_json::from_str(config.into())?;
 
         // so far, we have only implemented the "ipc" backend type
-        if &config["backend"] == "ipc" {
-            // create a new ipc backend with the passed sub "config" info
-            return Ok(P2pNetwork {
+        match config["backend"].to_string().as_str() {
+            "\"ipc\"" => {
+                // create a new ipc backend with the passed sub "config" info
+                Ok(P2pNetwork {
+                    con: NetConnectionThread::new(
+                        handler,
+                        Box::new(move |h| {
+                            let out: Box<NetWorker> = Box::new(IpcNetWorker::new(
+                                h,
+                                &(config["config"].to_string().into()),
+                            )?);
+                            Ok(out)
+                        }),
+                    )?,
+                })
+            }
+            "\"mock\"" => Ok(P2pNetwork {
                 con: NetConnectionThread::new(
                     handler,
-                    Box::new(move |h| {
-                        let out: Box<NetWorker> = Box::new(IpcNetWorker::new(
-                            h,
-                            &(config["config"].to_string().into()),
-                        )?);
-                        Ok(out)
-                    }),
+                    Box::new(move |h| Ok(Box::new(MockWorker::new(h)?) as Box<NetWorker>)),
                 )?,
-            });
+            }),
+            _ => bail!("unknown p2p_network backend: {}", config["backend"]),
         }
-
-        bail!("unknown p2p_network backend: {}", config["backend"]);
     }
 
     /// stop the network module (disconnect any sockets, join any threads, etc)
@@ -87,6 +94,18 @@ mod tests {
                     "ipcUri": "tcp://127.0.0.1:0",
                     "blockConnect": false
                 }
+            }).into(),
+        ).unwrap();
+        res.send(Protocol::P2pReady).unwrap();
+        res.stop().unwrap();
+    }
+
+    #[test]
+    fn it_should_create_mock() {
+        let mut res = P2pNetwork::new(
+            Box::new(|_r| Ok(())),
+            &json!({
+                "backend": "mock"
             }).into(),
         ).unwrap();
         res.send(Protocol::P2pReady).unwrap();

--- a/net_connection/src/protocol_wrapper.rs
+++ b/net_connection/src/protocol_wrapper.rs
@@ -43,36 +43,29 @@ pub struct PeerData {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, DefaultJson)]
-pub struct SendMessageData {
+pub struct MessageData {
+    #[serde(rename = "dnaHash")]
+    pub dna_hash: String,
+
+    #[serde(rename = "toAgentId")]
+    pub to_agent_id: String,
+
+    #[serde(rename = "fromAgentId")]
+    pub from_agent_id: String,
+
     #[serde(rename = "_id")]
     pub msg_id: String,
-
-    #[serde(rename = "toAddress")]
-    pub to_address: String,
 
     pub data: serde_json::Value,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, DefaultJson)]
-pub struct SendResultData {
-    #[serde(rename = "_id")]
-    pub msg_id: String,
+pub struct TrackAppData {
+    #[serde(rename = "dnaHash")]
+    pub dna_hash: String,
 
-    pub data: serde_json::Value,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, DefaultJson)]
-pub struct HandleSendData {
-    #[serde(rename = "_id")]
-    pub msg_id: String,
-
-    #[serde(rename = "toAddress")]
-    pub to_address: String,
-
-    #[serde(rename = "fromAddress")]
-    pub from_address: String,
-
-    pub data: serde_json::Value,
+    #[serde(rename = "agentId")]
+    pub agent_id: String,
 }
 
 /// High level p2p / network message
@@ -109,19 +102,23 @@ pub enum ProtocolWrapper {
 
     /// [send] send a message to another node on the network
     #[serde(rename = "send")]
-    SendMessage(SendMessageData),
+    SendMessage(MessageData),
 
     /// [recv] recv the response back from a previous `SendMessage`
     #[serde(rename = "sendResult")]
-    SendResult(SendResultData),
+    SendResult(MessageData),
 
     /// [recv] another node has sent us a message
     #[serde(rename = "handleSend")]
-    HandleSend(HandleSendData),
+    HandleSend(MessageData),
 
     /// [send] send our response to a previous `HandleSend`
     #[serde(rename = "handleSendResult")]
-    HandleSendResult(SendResultData),
+    HandleSendResult(MessageData),
+
+    /// [send] send out a "trackApp" request
+    #[serde(rename = "trackApp")]
+    TrackApp(TrackAppData),
 }
 
 impl<'a> TryFrom<&'a Protocol> for ProtocolWrapper {
@@ -236,16 +233,21 @@ mod tests {
 
     #[test]
     fn it_can_convert_send_message() {
-        test_convert!(ProtocolWrapper::SendMessage(SendMessageData {
+        test_convert!(ProtocolWrapper::SendMessage(MessageData {
+            dna_hash: "test_dna".to_string(),
+            to_agent_id: "test_to".to_string(),
+            from_agent_id: "test_from".to_string(),
             msg_id: "test_id".to_string(),
-            to_address: "test_addr".to_string(),
             data: json!("hello"),
         }));
     }
 
     #[test]
     fn it_can_convert_send_result() {
-        test_convert!(ProtocolWrapper::SendResult(SendResultData {
+        test_convert!(ProtocolWrapper::SendResult(MessageData {
+            dna_hash: "test_dna".to_string(),
+            to_agent_id: "test_to".to_string(),
+            from_agent_id: "test_from".to_string(),
             msg_id: "test_id".to_string(),
             data: json!("hello"),
         }));
@@ -253,20 +255,31 @@ mod tests {
 
     #[test]
     fn it_can_convert_handle_send() {
-        test_convert!(ProtocolWrapper::HandleSend(HandleSendData {
+        test_convert!(ProtocolWrapper::HandleSend(MessageData {
+            dna_hash: "test_dna".to_string(),
+            to_agent_id: "test_to".to_string(),
+            from_agent_id: "test_from".to_string(),
             msg_id: "test_id".to_string(),
-            to_address: "test_addr".to_string(),
-            from_address: "test_addr2".to_string(),
             data: json!("hello"),
         }));
     }
 
     #[test]
     fn it_can_convert_handle_send_result() {
-        test_convert!(ProtocolWrapper::HandleSendResult(SendResultData {
+        test_convert!(ProtocolWrapper::HandleSendResult(MessageData {
+            dna_hash: "test_dna".to_string(),
+            to_agent_id: "test_to".to_string(),
+            from_agent_id: "test_from".to_string(),
             msg_id: "test_id".to_string(),
             data: json!("hello"),
         }));
     }
 
+    #[test]
+    fn it_can_convert_track_app() {
+        test_convert!(ProtocolWrapper::TrackApp(TrackAppData {
+            dna_hash: "test_dna".to_string(),
+            agent_id: "test_to".to_string(),
+        }));
+    }
 }

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -21,3 +21,7 @@ path = "src/main.rs"
 [[bin]]
 name = "test_bin_ipc"
 path = "src/test_bin_ipc.rs"
+
+[[bin]]
+name = "test_bin_mock_net"
+path = "src/test_bin_mock_net.rs"

--- a/test_bin/src/test_bin_mock_net.rs
+++ b/test_bin/src/test_bin_mock_net.rs
@@ -1,0 +1,125 @@
+#![feature(try_from)]
+
+extern crate holochain_net;
+extern crate holochain_net_connection;
+#[macro_use]
+extern crate serde_json;
+
+use holochain_net_connection::{
+    net_connection::NetConnection,
+    protocol::Protocol,
+    protocol_wrapper::{MessageData, ProtocolWrapper, TrackAppData},
+    NetResult,
+};
+
+use holochain_net::p2p_network::P2pNetwork;
+
+use std::{convert::TryFrom, sync::mpsc};
+
+// this is all debug code, no need to track code test coverage
+#[cfg_attr(tarpaulin, skip)]
+fn usage() {
+    println!("Usage: test_bin_mock_net");
+    std::process::exit(1);
+}
+
+// this is all debug code, no need to track code test coverage
+#[cfg_attr(tarpaulin, skip)]
+fn exec() -> NetResult<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 1 {
+        usage();
+    }
+
+    // use a mpsc channel for messaging
+    let (sender1, receiver1) = mpsc::channel::<Protocol>();
+
+    // create a new ipc P2pNetwork instance
+    let mut con1 = P2pNetwork::new(
+        Box::new(move |r| {
+            sender1.send(r?)?;
+            Ok(())
+        }),
+        &json!({
+            "backend": "mock"
+        }).into(),
+    )?;
+
+    let (sender2, receiver2) = mpsc::channel::<Protocol>();
+
+    let mut con2 = P2pNetwork::new(
+        Box::new(move |r| {
+            sender2.send(r?)?;
+            Ok(())
+        }),
+        &json!({
+            "backend": "mock"
+        }).into(),
+    )?;
+
+    con1.send(
+        ProtocolWrapper::TrackApp(TrackAppData {
+            dna_hash: "sandwich".to_string(),
+            agent_id: "node-1".to_string(),
+        }).into(),
+    )?;
+
+    con2.send(
+        ProtocolWrapper::TrackApp(TrackAppData {
+            dna_hash: "sandwich".to_string(),
+            agent_id: "node-2".to_string(),
+        }).into(),
+    )?;
+
+    con1.send(
+        ProtocolWrapper::SendMessage(MessageData {
+            dna_hash: "sandwich".to_string(),
+            to_agent_id: "node-2".to_string(),
+            from_agent_id: "node-1".to_string(),
+            msg_id: "yada".to_string(),
+            data: json!("hello"),
+        }).into(),
+    )?;
+
+    let res = ProtocolWrapper::try_from(receiver2.recv()?)?;
+    println!("got: {:?}", res);
+
+    if let ProtocolWrapper::HandleSend(msg) = res {
+        con2.send(
+            ProtocolWrapper::HandleSendResult(MessageData {
+                dna_hash: "sandwich".to_string(),
+                to_agent_id: "node-1".to_string(),
+                from_agent_id: "node-2".to_string(),
+                msg_id: "yada".to_string(),
+                data: json!(format!("echo: {}", msg.data.to_string())),
+            }).into(),
+        )?;
+    } else {
+        panic!("bad msg");
+    }
+
+    let res = ProtocolWrapper::try_from(receiver1.recv()?)?;
+    println!("got: {:?}", res);
+
+    if let ProtocolWrapper::SendResult(msg) = res {
+        assert_eq!("\"echo: \\\"hello\\\"\"".to_string(), msg.data.to_string());
+    } else {
+        panic!("bad msg");
+    }
+
+    // yay, everything worked
+    println!("test complete");
+
+    // shut down the P2pNetwork instance
+    con1.stop()?;
+    con2.stop()?;
+
+    Ok(())
+}
+
+// this is all debug code, no need to track code test coverage
+#[cfg_attr(tarpaulin, skip)]
+fn main() {
+    exec().unwrap();
+}


### PR DESCRIPTION
Creates a Mock networking / p2p module. Instances communicate through a shared `lazy_static!` singleton which routes messages back to the proper destination.

Note, this breaks the current integration with `n3h`, but I think that's appropriate at the moment.