### PR TITLE
futures 0.2 -> 0.3

### DIFF
--- a/container_api/Cargo.toml
+++ b/container_api/Cargo.toml
@@ -8,7 +8,7 @@ holochain_cas_implementations = { path = "../cas_implementations" }
 holochain_core = { path = "../core" }
 holochain_core_types = { path = "../core_types" }
 holochain_net = { path = "../net" }
-futures-preview = "0.2.2"
+futures-preview = "0.3.0-alpha.9"
 tempfile = "3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/container_api/src/holochain.rs
+++ b/container_api/src/holochain.rs
@@ -87,7 +87,7 @@ impl Holochain {
         let name = dna.name.clone();
         instance.start_action_loop(context.clone());
         let context = instance.initialize_context(context);
-        match block_on(initialize_application(dna, context.clone())) {
+        match block_on(initialize_application(dna, &context.clone())) {
             Ok(_) => {
                 context.log(&format!("{} instantiated", name))?;
                 let hc = Holochain {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 multihash = "0.8.0"
 bitflags = "1.0"
 holochain_wasm_utils = { path = "../wasm_utils"}
-futures-preview = "0.2.2"
+futures-preview = "0.3.0-alpha.9"
 lazy_static = "1.1.0"
 unwrap_to = "0.1.0"
 num-traits = "0.2"

--- a/core/src/agent/actions/commit.rs
+++ b/core/src/agent/actions/commit.rs
@@ -5,7 +5,10 @@ use crate::{
     context::Context,
     instance::dispatch_action,
 };
-use futures::{task::{Poll, LocalWaker}, future::Future};
+use futures::{
+    future::Future,
+    task::{LocalWaker, Poll},
+};
 use holochain_core_types::{cas::content::Address, entry::Entry, error::HolochainError};
 use std::{
     pin::{Pin, Unpin},
@@ -43,10 +46,7 @@ impl Unpin for CommitFuture {}
 impl Future for CommitFuture {
     type Output = Result<Address, HolochainError>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        lw: &LocalWaker,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/agent/actions/commit.rs
+++ b/core/src/agent/actions/commit.rs
@@ -5,9 +5,13 @@ use crate::{
     context::Context,
     instance::dispatch_action,
 };
-use futures::Future;
+use futures::{task::{Poll, LocalWaker}, future::Future};
 use holochain_core_types::{cas::content::Address, entry::Entry, error::HolochainError};
-use std::sync::{mpsc::SyncSender, Arc};
+use std::{
+    pin::{Pin, Unpin},
+    sync::{mpsc::SyncSender, Arc},
+};
+//use core::mem::PinMut;
 
 /// Commit Action Creator
 /// This is the high-level commit function that wraps the whole commit process and is what should
@@ -34,19 +38,20 @@ pub struct CommitFuture {
     action: ActionWrapper,
 }
 
+impl Unpin for CommitFuture {}
+
 impl Future for CommitFuture {
-    type Item = Address;
-    type Error = HolochainError;
+    type Output = Result<Address, HolochainError>;
 
     fn poll(
-        &mut self,
-        cx: &mut futures::task::Context<'_>,
-    ) -> Result<futures::Async<Address>, Self::Error> {
+        self: Pin<&mut Self>,
+        lw: &LocalWaker,
+    ) -> Poll<Self::Output> {
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314
         //
-        cx.waker().wake();
+        lw.wake();
         match self
             .context
             .state()
@@ -56,11 +61,11 @@ impl Future for CommitFuture {
             .get(&self.action)
         {
             Some(ActionResponse::Commit(result)) => match result {
-                Ok(address) => Ok(futures::Async::Ready(address.clone())),
-                Err(error) => Err(error.clone()),
+                Ok(address) => Poll::Ready(Ok(address.clone())),
+                Err(error) => Poll::Ready(Err(error.clone())),
             },
             Some(_) => unreachable!(),
-            None => Ok(futures::Async::Pending),
+            None => Poll::Pending,
         }
     }
 }

--- a/core/src/dht/actions/add_link.rs
+++ b/core/src/dht/actions/add_link.rs
@@ -5,7 +5,10 @@ use crate::{
     context::Context,
     instance::dispatch_action,
 };
-use futures::{task::{Poll, LocalWaker}, future::Future};
+use futures::{
+    future::Future,
+    task::{LocalWaker, Poll},
+};
 use holochain_core_types::{error::HolochainError, link::Link};
 use std::{
     pin::{Pin, Unpin},
@@ -40,10 +43,7 @@ impl Unpin for AddLinkFuture {}
 impl Future for AddLinkFuture {
     type Output = Result<(), HolochainError>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        lw: &LocalWaker,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -488,7 +488,7 @@ pub mod tests {
         instance.start_action_loop(context.clone());
         let context = instance.initialize_context(context);
 
-        block_on(initialize_application(dna.clone(), context.clone()))?;
+        block_on(initialize_application(dna.clone(), &context.clone()))?;
 
         assert_eq!(instance.state().nucleus().dna(), Some(dna.clone()));
         assert!(instance.state().nucleus().has_initialized());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,5 @@
 //! The library implementing the holochain pattern of validation rules + local source chain + DHT
-#![feature(try_from)]
-
+#![feature(try_from, pin, arbitrary_self_types, futures_api)]
 #[macro_use]
 extern crate serde_derive;
 extern crate chrono;

--- a/core/src/nucleus/actions/get_entry.rs
+++ b/core/src/nucleus/actions/get_entry.rs
@@ -1,6 +1,6 @@
 extern crate serde_json;
 use crate::context::Context;
-use futures::{future, Future};
+use futures::future::{self, FutureObj};
 use holochain_core_types::{
     cas::content::Address,
     entry::{Entry, SerializedEntry},
@@ -24,13 +24,13 @@ fn get_entry_from_dht_cas(
 /// GetEntry Action Creator
 ///
 /// Returns a future that resolves to an Ok(ActionWrapper) or an Err(error_message:String).
-pub fn get_entry(
-    context: &Arc<Context>,
+pub fn get_entry<'a>(
+    context: &'a Arc<Context>,
     address: Address,
-) -> Box<dyn Future<Item = Option<Entry>, Error = HolochainError>> {
+) -> FutureObj<'a, Result<Option<Entry>, HolochainError>> {
     match get_entry_from_dht_cas(context, address) {
-        Err(err) => Box::new(future::err(err)),
-        Ok(result) => Box::new(future::ok(result)),
+        Err(err) => FutureObj::new(Box::new(future::err(err))),
+        Ok(result) => FutureObj::new(Box::new(future::ok(result))),
     }
 }
 

--- a/core/src/nucleus/actions/initialize.rs
+++ b/core/src/nucleus/actions/initialize.rs
@@ -9,11 +9,17 @@ use crate::{
         state::NucleusStatus,
     },
 };
-use futures::{executor::block_on, future::Future, task::{Poll, LocalWaker}};
+use futures::{
+    executor::block_on,
+    future::Future,
+    task::{LocalWaker, Poll},
+};
 use holochain_core_types::{dna::Dna, entry::ToEntry};
 use std::{
     pin::{Pin, Unpin},
-    sync::Arc, thread, time::*
+    sync::Arc,
+    thread,
+    time::*,
 };
 
 /// Timeout in seconds for initialization process.
@@ -28,10 +34,7 @@ const INITIALIZATION_TIMEOUT: u64 = 30;
 /// the Dna error or errors from the genesis callback.
 ///
 /// Use futures::executor::block_on to wait for an initialized instance.
-pub fn initialize_application<'a>(
-    dna: Dna,
-    context: &'a Arc<Context>,
-) -> InitializationFuture {
+pub fn initialize_application<'a>(dna: Dna, context: &'a Arc<Context>) -> InitializationFuture {
     if context.state().unwrap().nucleus().status != NucleusStatus::New {
         return InitializationFuture {
             context: context.clone(),
@@ -137,7 +140,7 @@ pub fn initialize_application<'a>(
 pub struct InitializationFuture {
     context: Arc<Context>,
     created_at: Instant,
-    error: Option<String>
+    error: Option<String>,
 }
 
 impl Unpin for InitializationFuture {}
@@ -145,10 +148,7 @@ impl Unpin for InitializationFuture {}
 impl Future for InitializationFuture {
     type Output = Result<NucleusStatus, String>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        lw: &LocalWaker,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
         if let Some(ref error) = self.error {
             return Poll::Ready(Err(error.clone()));
         }

--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -5,7 +5,10 @@ use crate::{
     context::Context,
     nucleus::ribosome::callback::{self, CallbackResult},
 };
-use futures::{task::{Poll, LocalWaker}, future::{self, FutureObj, Future}};
+use futures::{
+    future::{self, Future, FutureObj},
+    task::{LocalWaker, Poll},
+};
 use holochain_core_types::{
     cas::content::AddressableContent,
     entry::{entry_type::EntryType, Entry},
@@ -16,7 +19,8 @@ use holochain_core_types::{
 use snowflake;
 use std::{
     pin::{Pin, Unpin},
-    sync::Arc, thread,
+    sync::Arc,
+    thread,
 };
 
 /// ValidateEntry Action Creator
@@ -42,10 +46,9 @@ pub fn validate_entry<'a>(
             .get_zome_name_for_entry_type(&entry.entry_type().to_string())
             .is_none()
         {
-            return FutureObj::new(Box::new(future::err(HolochainError::ValidationFailed(format!(
-                "Unknown entry type: '{}'",
-                entry.entry_type().to_string(),
-            )))));
+            return FutureObj::new(Box::new(future::err(HolochainError::ValidationFailed(
+                format!("Unknown entry type: '{}'", entry.entry_type().to_string(),),
+            ))));
         }
     }
 
@@ -100,12 +103,9 @@ pub struct ValidationFuture {
 impl Unpin for ValidationFuture {}
 
 impl Future for ValidationFuture {
-    type Output = Result<HashString,HolochainError>;
+    type Output = Result<HashString, HolochainError>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        lw: &LocalWaker,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -5,7 +5,7 @@ use crate::{
         ribosome::{api::ZomeApiResult, Runtime},
     },
 };
-use futures::{executor::block_on, future::TryFutureExt};
+use futures::{executor::block_on, future::{self, TryFutureExt}};
 use holochain_core_types::{
     cas::content::Address,
     entry::{Entry, SerializedEntry},
@@ -43,12 +43,12 @@ pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> Zom
         // 1. Build the context needed for validation of the entry
         build_validation_package(&entry, &runtime.context)
             .and_then(|validation_package| {
-                Ok(ValidationData {
+                future::ready(Ok(ValidationData {
                     package: validation_package,
                     sources: vec![HashString::from("<insert your agent key here>")],
                     lifecycle: EntryLifecycle::Chain,
                     action: EntryAction::Commit,
-                })
+                }))
             })
             // 2. Validate the entry
             .and_then(|validation_data| {
@@ -66,7 +66,7 @@ pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> Zom
                     &runtime.context.action_channel,
                     &runtime.context,
                 )
-            }),
+            })
     );
 
     runtime.store_result(task_result)

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -5,7 +5,10 @@ use crate::{
         ribosome::{api::ZomeApiResult, Runtime},
     },
 };
-use futures::{executor::block_on, future::{self, TryFutureExt}};
+use futures::{
+    executor::block_on,
+    future::{self, TryFutureExt},
+};
 use holochain_core_types::{
     cas::content::Address,
     entry::{Entry, SerializedEntry},
@@ -61,7 +64,7 @@ pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> Zom
                     &runtime.context.action_channel,
                     &runtime.context,
                 )
-            })
+            }),
     );
 
     runtime.store_result(task_result)

--- a/core/src/nucleus/ribosome/api/commit.rs
+++ b/core/src/nucleus/ribosome/api/commit.rs
@@ -5,7 +5,7 @@ use crate::{
         ribosome::{api::ZomeApiResult, Runtime},
     },
 };
-use futures::{executor::block_on, FutureExt};
+use futures::{executor::block_on, future::TryFutureExt};
 use holochain_core_types::{
     cas::content::Address,
     entry::{Entry, SerializedEntry},

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -4,10 +4,12 @@ use crate::{
     nucleus::{
         actions::{build_validation_package::*, validate::*},
         ribosome::{api::ZomeApiResult, Runtime},
-    }
+    },
 };
-use futures::{executor::block_on, future::{self, TryFutureExt}};
-use holochain_wasm_utils::api_serialization::link_entries::LinkEntriesArgs;
+use futures::{
+    executor::block_on,
+    future::{self, TryFutureExt},
+};
 use holochain_core_types::{
     cas::content::Address,
     entry::ToEntry,
@@ -15,6 +17,7 @@ use holochain_core_types::{
     link::link_add::LinkAddEntry,
     validation::{EntryAction, EntryLifecycle, ValidationData},
 };
+use holochain_wasm_utils::api_serialization::link_entries::LinkEntriesArgs;
 use std::convert::TryFrom;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
@@ -175,7 +178,8 @@ pub mod tests {
             test_entry(),
             &context.action_channel.clone(),
             &context,
-        )).expect("Could not commit entry for testing");
+        ))
+        .expect("Could not commit entry for testing");
 
         let call_result = test_zome_api_function_call(
             &context.get_dna().unwrap().name.to_string(),
@@ -201,7 +205,8 @@ pub mod tests {
             test_entry(),
             &context.action_channel.clone(),
             &context,
-        )).expect("Could not commit entry for testing");
+        ))
+        .expect("Could not commit entry for testing");
 
         let call_result = test_zome_api_function_call(
             &context.get_dna().unwrap().name.to_string(),

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -1,7 +1,4 @@
-use crate::{
-    context::Context,
-    nucleus::actions::get_entry::get_entry,
-};
+use crate::{context::Context, nucleus::actions::get_entry::get_entry};
 use futures::executor::block_on;
 use holochain_core_types::{
     entry::{entry_type::EntryType, Entry},
@@ -80,7 +77,8 @@ pub fn find_link_definition_in_dna(
                 })
             }),
         _ => None,
-    }.or(match target_type {
+    }
+    .or(match target_type {
         EntryType::App(app_entry_type) => dna
             .get_entry_type_def(&app_entry_type)
             .ok_or(HolochainError::ErrorGeneric(String::from(
@@ -101,7 +99,7 @@ pub fn find_link_definition_in_dna(
             }),
         _ => None,
     })
-        .ok_or(HolochainError::ErrorGeneric(String::from(
-            "Unknown entry type",
-        )))
+    .ok_or(HolochainError::ErrorGeneric(String::from(
+        "Unknown entry type",
+    )))
 }

--- a/core/src/nucleus/ribosome/callback/validate_entry.rs
+++ b/core/src/nucleus/ribosome/callback/validate_entry.rs
@@ -69,7 +69,8 @@ fn validate_link_entry(
         link.tag(),
         &target.entry_type(),
         &context,
-    ).map_err(|_| HolochainError::NotImplemented)?;
+    )
+    .map_err(|_| HolochainError::NotImplemented)?;
 
     let wasm = context
         .get_wasm(&link_definition_path.zome_name)

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -57,7 +57,8 @@ pub fn get_validation_package_definition(
                 link_add_entry.link().tag(),
                 &target.entry_type(),
                 &context,
-            ).map_err(|_| HolochainError::NotImplemented)?;
+            )
+            .map_err(|_| HolochainError::NotImplemented)?;
 
             let wasm = context
                 .get_wasm(&link_definition_path.zome_name)


### PR DESCRIPTION
Futures 0.3.0-alpha can work with async/await.
Switching to async/await syntax in another PR.

Changes accroding to:
* Futures blog post: https://rust-lang-nursery.github.io/futures-rs/blog/2018/07/19/futures-0.3.0-alpha.1.html
* Futures companion RFC: https://github.com/aturon/rfcs/blob/async-trait/text/0000-async.md
* Summarizing post about changes: https://boats.gitlab.io/blog/post/2018-04-06-async-await-final/

I recommend reading all of withoutboats' post about this: https://boats.gitlab.io/blog/post/2018-01-25-async-i-self-referential-structs/ (especially to understand why using `Pin` and `Unpin`)