### PR TITLE
Check currently installed version of Rust, offer to un/re-install (OLD: See #782)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ lint: fmt_check clippy
 # Check if Rust version is correct, and offer to uninstall mismatching version.  Requires
 # RUST_VERSION to be set (defaults to CORE_RUST_VERSION; see install_rustup..., below).  We'll
 # export PATH to default Rust installation here in the Makefile, in case this is the first time
-# rustup has been run, and we don't have a rustup-modified .profile loaded yet.
+# rustup has been run, and we don't have a rustup-modified .profile loaded yet.  If not a terminal
+# (stin is not a tty), defaults to not replace.
 export PATH := $(HOME)/.cargo/bin:$(PATH)
 RUST_VERSION = $(CORE_RUST_VERSION)
 .PHONY: version_rustup
@@ -47,8 +48,8 @@ version_rustup:
 	    echo "\033[0;93m## Current Rust version installed: ##\033[0m"; \
 	    if ! rustup show | grep "$(RUST_VERSION)"; then \
 	        rustup show; \
-		echo "\033[0;93m## Replace current Rust version (using rustup uninstall) with '$(RUST_VERSION)' ##\033[0m"; \
-	        read -p "Continue? (y/N) " yes; \
+		echo "\033[0;93m## Replace current Rust version (after rustup self uninstall) with '$(RUST_VERSION)' ##\033[0m"; \
+	        [ -t 0 ] && read -p "Continue? (y/N) " yes; \
 	        if [[ "$${yes:0:1}" == "y" ]] || [[ "$${yes:0:1}" == "Y" ]]; then \
 	            echo "\033[0;93m## Uninstalling Rust... ##\033[0m"; \
 	            rustup self uninstall || true; \

--- a/Makefile
+++ b/Makefile
@@ -36,24 +36,25 @@ C_BINDING_CLEAN = $(foreach dir,$(C_BINDING_DIRS),$(dir)Makefile $(dir).qmake.st
 # apply formatting / style guidelines
 lint: fmt_check clippy
 
-# Check if Rust version is correct, and offer to uninstall mismatching version.  Requires
-# RUST_VERSION to be set (defaults to CORE_RUST_VERSION; see install_rustup..., below).  We'll
+# Check if Rust version is correct, and offer to change to the correct version.  Requires
+# RUST_VERSION to be set (defaults to CORE_RUST_VERSION; see install_rustup..., below).  We'll also
 # export PATH to default Rust installation here in the Makefile, in case this is the first time
-# rustup has been run, and we don't have a rustup-modified .profile loaded yet.  If connected to a terminal
-# (stdin is a tty) and not running under a Continuous Integration test (CI), defaults to not replace.
+# rustup has been installed/run, and we don't have a rustup-modified .profile loaded yet.  If
+# connected to a terminal (stdin is a tty) and not running under a Continuous Integration test (CI),
+# defaults to not replace.
 export PATH := $(HOME)/.cargo/bin:$(PATH)
 RUST_VERSION = $(CORE_RUST_VERSION)
 .PHONY: version_rustup
 version_rustup:
 	@if which rustup; then \
 	    echo "\033[0;93m## Current Rust version installed (need: '$(RUST_VERSION)'): ##\033[0m"; \
-	    if ! rustup show | grep "$(RUST_VERSION)"; then \
+	    if ! rustup show 2>/dev/null | grep -qe "$(RUST_VERSION).*(default)"; then \
 	        rustup show; \
-		echo "\033[0;93m## Replace current Rust version (after rustup self uninstall) with '$(RUST_VERSION)' ##\033[0m"; \
+		echo "\033[0;93m## Change current Rust version to '$(RUST_VERSION)' ##\033[0m"; \
 	        [ -t 1 ] && [[ "$(CI)" == "" ]] && read -p "Continue? (y/N) " yes; \
 	        if [[ "$${yes:0:1}" == "y" ]] || [[ "$${yes:0:1}" == "Y" ]]; then \
-	            echo "\033[0;93m## Uninstalling Rust... ##\033[0m"; \
-	            rustup self uninstall || true; \
+	            echo "\033[0;93m## Selecting Rust version '$(RUST_VERSION)'... ##\033[0m"; \
+	            rustup default $(RUST-VERSION); \
 	        fi; \
 	    fi; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -131,15 +131,17 @@ ensure_wasm_target: core_toolchain
 	rustup target add wasm32-unknown-unknown
 
 # idempotent installation of development tooling; RUST_VERSION defaults to TOOLS_RUST_VERSION
+# Since the default toolchain has been changed (see: tools_toolchain, version_rustup), we can
+# install the component without specifying which toolchain version to use)
 .PHONY: install_rust_tools
 install_rust_tools: tools_toolchain
 	# rust format
-	if ! rustup component list --toolchain $(RUST_VERSION) | grep 'rustfmt-preview.*(installed)'; then \
-		rustup component add --toolchain $(RUST_VERSION) rustfmt-preview; \
+	if ! rustup component list | grep 'rustfmt-preview.*(installed)'; then \
+		rustup component add rustfmt-preview; \
 	fi
 	# clippy
-	if ! rustup component list --toolchain $(RUST_VERSION) | grep 'clippy-preview.*(installed)'; then \
-		rustup component add --toolchain $(RUST_VERSION) clippy-preview; \
+	if ! rustup component list | grep 'clippy-preview.*(installed)'; then \
+		rustup component add clippy-preview; \
 	fi
 
 # idempotent installation of code coverage CI/testing tools
@@ -217,7 +219,7 @@ fmt_check: install_rust_tools
 	$(CARGO_TOOLS) fmt -- --check
 
 clippy: install_rust_tools
-	$(CARGO_TOOLS) clippy -- -A needless_return --A useless_attribute
+	$(CARGO_TOOLS) clippy -- -A clippy::needless_return --A clippy::useless_attribute
 
 fmt: install_rust_tools
 	$(CARGO_TOOLS) fmt

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ core_toolchain: version_rustup install_rustup install_system_libs
 
 # idempotent installation of tools toolchain.  Changes default toolchain to TOOLS_RUST_VERSION.
 .PHONY: tools_toolchain
-core_toolchain: RUST_VERSION=$(TOOLS_RUST_VERSION)
+tools_toolchain: RUST_VERSION=$(TOOLS_RUST_VERSION)
 tools_toolchain: version_rustup install_rustup_tools install_system_libs
 
 # idempotent addition of wasm target in current (default: CORE_RUST_VERSION) toolchain

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ version_rustup:
 	        [ -t 1 ] && [[ "$(CI)" == "" ]] && read -p "Continue? (y/N) " yes; \
 	        if [[ "$${yes:0:1}" == "y" ]] || [[ "$${yes:0:1}" == "Y" ]]; then \
 	            echo "\033[0;93m## Selecting Rust version '$(RUST_VERSION)'... ##\033[0m"; \
-	            rustup default $(RUST-VERSION); \
+	            rustup default $(RUST_VERSION); \
 	        fi; \
 	    fi; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 
 all: lint build_holochain build_cmd
 
+SHELL = /bin/bash
 CORE_RUST_VERSION ?= nightly-2018-11-28
 TOOLS_RUST_VERSION ?= nightly-2018-11-28
 CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(CORE_RUST_VERSION) cargo $(CARGO_ARGS)
@@ -38,18 +39,18 @@ lint: fmt_check clippy
 # Check if Rust version is correct, and offer to uninstall mismatching version.  Requires
 # RUST_VERSION to be set (defaults to CORE_RUST_VERSION; see install_rustup..., below).  We'll
 # export PATH to default Rust installation here in the Makefile, in case this is the first time
-# rustup has been run, and we don't have a rustup-modified .profile loaded yet.  If not a terminal
-# (stin is not a tty), defaults to not replace.
+# rustup has been run, and we don't have a rustup-modified .profile loaded yet.  If connected to a terminal
+# (stdin is a tty) and not running under a Continuous Integration test (CI), defaults to not replace.
 export PATH := $(HOME)/.cargo/bin:$(PATH)
 RUST_VERSION = $(CORE_RUST_VERSION)
 .PHONY: version_rustup
 version_rustup:
 	@if which rustup; then \
-	    echo "\033[0;93m## Current Rust version installed: ##\033[0m"; \
+	    echo "\033[0;93m## Current Rust version installed (need: '$(RUST_VERSION)'): ##\033[0m"; \
 	    if ! rustup show | grep "$(RUST_VERSION)"; then \
 	        rustup show; \
 		echo "\033[0;93m## Replace current Rust version (after rustup self uninstall) with '$(RUST_VERSION)' ##\033[0m"; \
-	        [ -t 0 ] && read -p "Continue? (y/N) " yes; \
+	        [ -t 1 ] && [[ "$(CI)" == "" ]] && read -p "Continue? (y/N) " yes; \
 	        if [[ "$${yes:0:1}" == "y" ]] || [[ "$${yes:0:1}" == "Y" ]]; then \
 	            echo "\033[0;93m## Uninstalling Rust... ##\033[0m"; \
 	            rustup self uninstall || true; \

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -41,7 +41,8 @@ use wabt::Wat2Wasm;
 
 /// Load WASM from filesystem
 pub fn create_wasm_from_file(fname: &str) -> Vec<u8> {
-    let mut file = File::open(fname).unwrap();
+    let mut file = File::open(fname).unwrap_or_else(
+        |err| panic!( "Couldn't create WASM from file: {}; {}", fname, err ));
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).unwrap();
     buf


### PR DESCRIPTION
o Properly export PATH (in case this is the first installation of Rust)
o Use target-specific variables to select TOOLS/CORE_RUST_VERSION

If the wrong version of Rust is installed, we can check and offer to replace it with
one compatible with holochain-rust.