### PR TITLE
Detereministic DNA hashes -> unflake flaky tests

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -105,38 +105,38 @@ test('get_post with non-existant hash returns null', (t) => {
 
 // this test is flaky!
 // even when we loop and wait sometimes app2 never sees the published entry
-// test('scenario test create & publish post -> get from other instance', (t) => {
-//     t.plan(3)
-//
-//     const content = "Holo world"
-//     const in_reply_to = ""
-//     const params = {content, in_reply_to}
-//     const create_result = app.call("blog", "main", "create_post", params)
-//
-//     t.equal(create_result.address.length, 46)
-//     t.equal(create_result.address, "QmNndXfXcxqwsnAXdvbnzdZUS7bm4WqimY7w873C3Uttx1")
-//
-//     const post_address = create_result.address
-//     const params_get = {post_address}
-//
-//     const check_get_result = function check_get_result (i = 0, get_result) {
-//       t.comment('checking get result for the ' + i + 'th time')
-//       t.comment(get_result + "")
-//
-//       if (get_result) {
-//         t.equal(get_result.content, content)
-//       }
-//       else if (i < 50) {
-//         setTimeout(function() {
-//           check_get_result(
-//             ++i,
-//             app2.call("blog", "main", "get_post", params_get)
-//           )
-//         }, 100)
-//       }
-//       else {
-//         t.end()
-//       }
-//
-//     }()
-// })
+test('scenario test create & publish post -> get from other instance', (t) => {
+    t.plan(3)
+
+    const content = "Holo world"
+    const in_reply_to = ""
+    const params = {content, in_reply_to}
+    const create_result = app.call("blog", "main", "create_post", params)
+
+    t.equal(create_result.address.length, 46)
+    t.equal(create_result.address, "QmNndXfXcxqwsnAXdvbnzdZUS7bm4WqimY7w873C3Uttx1")
+
+    const post_address = create_result.address
+    const params_get = {post_address}
+
+    const check_get_result = function check_get_result (i = 0, get_result) {
+      t.comment('checking get result for the ' + i + 'th time')
+      t.comment(get_result + "")
+
+      if (get_result) {
+        t.equal(get_result.content, content)
+      }
+      else if (i < 50) {
+        setTimeout(function() {
+          check_get_result(
+            ++i,
+            app2.call("blog", "main", "get_post", params_get)
+          )
+        }, 100)
+      }
+      else {
+        t.end()
+      }
+
+    }()
+})

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -37,40 +37,40 @@ pub async fn author_entry<'a>(
     await!(publish_entry(entry.address(), &context))
 }
 
- #[cfg(test)]
- pub mod tests {
-     use super::author_entry;
-     use crate::nucleus::actions::tests::*;
-     use futures::executor::block_on;
-     use holochain_core_types::entry::test_entry;
-     use std::{thread, time};
+#[cfg(test)]
+pub mod tests {
+    use super::author_entry;
+    use crate::nucleus::actions::tests::*;
+    use futures::executor::block_on;
+    use holochain_core_types::entry::test_entry;
+    use std::{thread, time};
 
-     #[test]
-     /// test that a commit will publish and entry to the dht of a connected instance via the mock network
-     fn test_commit_with_dht_publish() {
-         let dna = test_dna();
-         let (_instance1, context1) = instance_by_name("jill", dna.clone());
-         let (_instance2, context2) = instance_by_name("jack", dna);
+    #[test]
+    /// test that a commit will publish and entry to the dht of a connected instance via the mock network
+    fn test_commit_with_dht_publish() {
+        let dna = test_dna();
+        let (_instance1, context1) = instance_by_name("jill", dna.clone());
+        let (_instance2, context2) = instance_by_name("jack", dna);
 
-         let entry_address = block_on(author_entry(&test_entry(), &context1));
+        let entry_address = block_on(author_entry(&test_entry(), &context1));
 
-         println!("AUTHOR ENTRY ADDRESS: {:?}", entry_address);
-         let entry_address = entry_address.unwrap();
-         thread::sleep(time::Duration::from_millis(1000));
+        println!("AUTHOR ENTRY ADDRESS: {:?}", entry_address);
+        let entry_address = entry_address.unwrap();
+        thread::sleep(time::Duration::from_millis(1000));
 
-         let state = &context2.state().unwrap();
-         let json = state
-             .dht()
-             .content_storage()
-             .read()
-             .unwrap()
-             .fetch(&entry_address)
-             .expect("could not fetch from CAS");
+        let state = &context2.state().unwrap();
+        let json = state
+            .dht()
+            .content_storage()
+            .read()
+            .unwrap()
+            .fetch(&entry_address)
+            .expect("could not fetch from CAS");
 
-         let x: String = json.unwrap().to_string();
-         assert_eq!(
-             x,
-             "{\"value\":\"\\\"test entry value\\\"\",\"entry_type\":\"testEntryType\"}".to_string()
-         );
-     }
- }
+        let x: String = json.unwrap().to_string();
+        assert_eq!(
+            x,
+            "{\"value\":\"\\\"test entry value\\\"\",\"entry_type\":\"testEntryType\"}".to_string()
+        );
+    }
+}

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -37,40 +37,40 @@ pub async fn author_entry<'a>(
     await!(publish_entry(entry.address(), &context))
 }
 
-// #[cfg(test)]
-// pub mod tests {
-//     use super::author_entry;
-//     use crate::nucleus::actions::tests::*;
-//     use futures::executor::block_on;
-//     use holochain_core_types::entry::test_entry;
-//     use std::{thread, time};
-//
-//     #[test]
-//     /// test that a commit will publish and entry to the dht of a connected instance via the mock network
-//     fn test_commit_with_dht_publish() {
-//         let dna = test_dna();
-//         let (_instance1, context1) = instance_by_name("jill", dna.clone());
-//         let (_instance2, context2) = instance_by_name("jack", dna);
-//
-//         let entry_address = block_on(author_entry(&test_entry(), &context1));
-//
-//         println!("AUTHOR ENTRY ADDRESS: {:?}", entry_address);
-//         let entry_address = entry_address.unwrap();
-//         thread::sleep(time::Duration::from_millis(1000));
-//
-//         let state = &context2.state().unwrap();
-//         let json = state
-//             .dht()
-//             .content_storage()
-//             .read()
-//             .unwrap()
-//             .fetch(&entry_address)
-//             .expect("could not fetch from CAS");
-//
-//         let x: String = json.unwrap().to_string();
-//         assert_eq!(
-//             x,
-//             "{\"value\":\"\\\"test entry value\\\"\",\"entry_type\":\"testEntryType\"}".to_string()
-//         );
-//     }
-// }
+ #[cfg(test)]
+ pub mod tests {
+     use super::author_entry;
+     use crate::nucleus::actions::tests::*;
+     use futures::executor::block_on;
+     use holochain_core_types::entry::test_entry;
+     use std::{thread, time};
+
+     #[test]
+     /// test that a commit will publish and entry to the dht of a connected instance via the mock network
+     fn test_commit_with_dht_publish() {
+         let dna = test_dna();
+         let (_instance1, context1) = instance_by_name("jill", dna.clone());
+         let (_instance2, context2) = instance_by_name("jack", dna);
+
+         let entry_address = block_on(author_entry(&test_entry(), &context1));
+
+         println!("AUTHOR ENTRY ADDRESS: {:?}", entry_address);
+         let entry_address = entry_address.unwrap();
+         thread::sleep(time::Duration::from_millis(1000));
+
+         let state = &context2.state().unwrap();
+         let json = state
+             .dht()
+             .content_storage()
+             .read()
+             .unwrap()
+             .fetch(&entry_address)
+             .expect("could not fetch from CAS");
+
+         let x: String = json.unwrap().to_string();
+         assert_eq!(
+             x,
+             "{\"value\":\"\\\"test entry value\\\"\",\"entry_type\":\"testEntryType\"}".to_string()
+         );
+     }
+ }

--- a/core_types/src/dna/mod.rs
+++ b/core_types/src/dna/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 use multihash;
 use serde_json::{self, Value};
 use std::{
-    collections::{BTreeMap},
+    collections::BTreeMap,
     convert::TryInto,
     hash::{Hash, Hasher},
 };

--- a/core_types/src/dna/mod.rs
+++ b/core_types/src/dna/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 use multihash;
 use serde_json::{self, Value};
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap},
     convert::TryInto,
     hash::{Hash, Hasher},
 };
@@ -80,7 +80,7 @@ pub struct Dna {
 
     /// An array of zomes associated with your holochain application.
     #[serde(default)]
-    pub zomes: HashMap<String, zome::Zome>,
+    pub zomes: BTreeMap<String, zome::Zome>,
 }
 
 impl Default for Dna {
@@ -93,7 +93,7 @@ impl Default for Dna {
             uuid: new_uuid(),
             dna_spec_version: String::from("2.0"),
             properties: empty_object(),
-            zomes: HashMap::new(),
+            zomes: BTreeMap::new(),
         }
     }
 }

--- a/core_types/src/dna/zome/mod.rs
+++ b/core_types/src/dna/zome/mod.rs
@@ -4,7 +4,7 @@ pub mod capabilities;
 pub mod entry_types;
 
 use crate::dna::wasm::DnaWasm;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Enum for "zome" "config" "error_handling" property.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Hash)]
@@ -59,11 +59,11 @@ pub struct Zome {
 
     /// An array of entry_types associated with this zome.
     #[serde(default)]
-    pub entry_types: HashMap<String, entry_types::EntryTypeDef>,
+    pub entry_types: BTreeMap<String, entry_types::EntryTypeDef>,
 
     /// An array of capabilities associated with this zome.
     #[serde(default)]
-    pub capabilities: HashMap<String, capabilities::Capability>,
+    pub capabilities: BTreeMap<String, capabilities::Capability>,
 
     /// Validation code for this entry_type.
     #[serde(default)]
@@ -78,8 +78,8 @@ impl Default for Zome {
         Zome {
             description: String::new(),
             config: Config::new(),
-            entry_types: HashMap::new(),
-            capabilities: HashMap::new(),
+            entry_types: BTreeMap::new(),
+            capabilities: BTreeMap::new(),
             code: DnaWasm::new(),
         }
     }
@@ -90,8 +90,8 @@ impl Zome {
     pub fn new(
         description: &str,
         config: &Config,
-        entry_types: &HashMap<String, entry_types::EntryTypeDef>,
-        capabilities: &HashMap<String, capabilities::Capability>,
+        entry_types: &BTreeMap<String, entry_types::EntryTypeDef>,
+        capabilities: &BTreeMap<String, capabilities::Capability>,
         code: &DnaWasm,
     ) -> Zome {
         Zome {

--- a/net/src/mock_worker.rs
+++ b/net/src/mock_worker.rs
@@ -24,17 +24,17 @@ fn cat_dna_agent(dna_hash: &str, agent_id: &str) -> String {
 /// a lazy_static! singleton for routing messages in-memory
 struct MockSingleton {
     // keep track of senders by `dna_hash::agent_id`
-    senders: Mutex<HashMap<String, mpsc::Sender<Protocol>>>,
+    senders: HashMap<String, mpsc::Sender<Protocol>>,
     // keep track of senders as arrays by dna_hash
-    senders_by_dna: Mutex<HashMap<String, Vec<mpsc::Sender<Protocol>>>>,
+    senders_by_dna: HashMap<String, Vec<mpsc::Sender<Protocol>>>,
 }
 
 impl MockSingleton {
     /// create a new mock singleton
     pub fn new() -> Self {
         Self {
-            senders: Mutex::new(HashMap::new()),
-            senders_by_dna: Mutex::new(HashMap::new()),
+            senders: HashMap::new(),
+            senders_by_dna: HashMap::new(),
         }
     }
 
@@ -45,9 +45,9 @@ impl MockSingleton {
         agent_id: &str,
         sender: mpsc::Sender<Protocol>,
     ) -> NetResult<()> {
-        self.senders.lock().unwrap()
+        self.senders
             .insert(cat_dna_agent(dna_hash, agent_id), sender.clone());
-        match self.senders_by_dna.lock().unwrap().entry(dna_hash.to_string()) {
+        match self.senders_by_dna.entry(dna_hash.to_string()) {
             Entry::Occupied(mut e) => {
                 e.get_mut().push(sender.clone());
             }
@@ -110,7 +110,7 @@ impl MockSingleton {
 
     /// send a message to the appropriate channel based on dna_hash::agent_id
     fn priv_send_one(&mut self, dna_hash: &str, agent_id: &str, data: Protocol) -> NetResult<()> {
-        if let Some(sender) = self.senders.lock().unwrap().get_mut(&cat_dna_agent(dna_hash, agent_id)) {
+        if let Some(sender) = self.senders.get_mut(&cat_dna_agent(dna_hash, agent_id)) {
             sender.send(data)?;
         }
         Ok(())
@@ -118,7 +118,7 @@ impl MockSingleton {
 
     /// send a message to all nodes connected with this dna hash
     fn priv_send_all(&mut self, dna_hash: &str, data: Protocol) -> NetResult<()> {
-        if let Some(arr) = self.senders_by_dna.lock().unwrap().get_mut(dna_hash) {
+        if let Some(arr) = self.senders_by_dna.get_mut(dna_hash) {
             for val in arr.iter_mut() {
                 (*val).send(data.clone())?;
             }
@@ -154,7 +154,7 @@ impl MockSingleton {
     /// this mock module routes it to the first node connected on that dna.
     /// this works because we also send store requests to all connected nodes.
     fn priv_handle_get_dht(&mut self, msg: &GetDhtData) -> NetResult<()> {
-        match self.senders_by_dna.lock().unwrap().entry(msg.dna_hash.to_string()) {
+        match self.senders_by_dna.entry(msg.dna_hash.to_string()) {
             Entry::Occupied(mut e) => {
                 if !e.get().is_empty() {
                     let r = &e.get_mut()[0];
@@ -200,7 +200,7 @@ impl MockSingleton {
     /// this mock module routes it to the first node connected on that dna.
     /// this works because we also send store requests to all connected nodes.
     fn priv_handle_get_dht_meta(&mut self, msg: &GetDhtMetaData) -> NetResult<()> {
-        match self.senders_by_dna.lock().unwrap().entry(msg.dna_hash.to_string()) {
+        match self.senders_by_dna.entry(msg.dna_hash.to_string()) {
             Entry::Occupied(mut e) => {
                 if !e.get().is_empty() {
                     let r = &e.get_mut()[0];

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -24,7 +24,7 @@ use holochain_core_types::dna::{
 };
 
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::{BTreeMap, hash_map::DefaultHasher},
     fmt,
     fs::File,
     hash::{Hash, Hasher},
@@ -74,7 +74,7 @@ pub fn create_test_dna_with_wasm(zome_name: &str, cap_name: &str, wasm: Vec<u8>)
     let mut dna = Dna::new();
     let capability = create_test_cap_with_fn_name("main");
 
-    let mut capabilities = HashMap::new();
+    let mut capabilities = BTreeMap::new();
     capabilities.insert(cap_name.to_string(), capability);
 
     let mut test_entry_def = EntryTypeDef::new();
@@ -89,7 +89,7 @@ pub fn create_test_dna_with_wasm(zome_name: &str, cap_name: &str, wasm: Vec<u8>)
         tag: String::from("test-tag"),
     });
 
-    let mut entry_types = HashMap::new();
+    let mut entry_types = BTreeMap::new();
     entry_types.insert(String::from("testEntryType"), test_entry_def);
     entry_types.insert(String::from("testEntryTypeB"), test_entry_b_def);
 
@@ -131,11 +131,11 @@ pub fn create_test_dna_with_cap(
 ) -> Dna {
     let mut dna = Dna::new();
 
-    let mut capabilities = HashMap::new();
+    let mut capabilities = BTreeMap::new();
     capabilities.insert(cap_name.to_string(), cap.clone());
 
     let etypedef = EntryTypeDef::new();
-    let mut entry_types = HashMap::new();
+    let mut entry_types = BTreeMap::new();
     entry_types.insert("testEntryType".to_string(), etypedef);
     let zome = Zome::new(
         "some zome description",


### PR DESCRIPTION
`HashMap`'s sorting is undefined. The DNA hash is calculated through the DNA content which we get through a serialization step. As a consequence we end up with different hashes non-deterministically. In the context of networking it means that instances in the test network are in the same network, or not, non-deterministically.

Changing `HashMap` to `BTreeMap` fixes that.