### PR TITLE
tarpaulin install fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CORE_RUST_VERSION ?= nightly-2018-11-28
 TOOLS_RUST_VERSION ?= nightly-2018-10-12
 CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(CORE_RUST_VERSION) cargo $(CARGO_ARGS)
 CARGO_TOOLS = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(TOOLS_RUST_VERSION) cargo $(CARGO_ARGS)
-CARGO_TARPULIN = RUSTFLAGS="--cfg procmacro2_semver_exempt -Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 cargo $(CARGO_ARGS) +$(CORE_RUST_VERSION)
+CARGO_TARPULIN_INSTALL = RUSTFLAGS="--cfg procmacro2_semver_exempt -D warnings" RUST_BACKTRACE=1 cargo $(CARGO_ARGS) +$(CORE_RUST_VERSION)
 
 # list all the "C" binding tests that have been written
 C_BINDING_DIRS = $(sort $(dir $(wildcard c_binding_tests/*/)))
@@ -116,7 +116,7 @@ install_rust_tools: tools_toolchain
 install_ci: core_toolchain
 	# tarpaulin (code coverage)
 	if ! $(CARGO) install --list | grep 'cargo-tarpaulin'; then \
-		 $(CARGO_TARPULIN) install cargo-tarpaulin --force; \
+		 $(CARGO_TARPULIN_INSTALL) install cargo-tarpaulin --force; \
 	fi
 
 .PHONY: install_mdbook


### PR DESCRIPTION
on my ubuntu box I would get this error when the makefile tried to run the installed Tarpaulin:

```
# tarpaulin (code coverage)
if ! RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run nightly-2018-11-28 cargo  install --list | grep 'cargo-tarpaulin'; then \
     RUSTFLAGS="--cfg procmacro2_semver_exempt -Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 cargo  +nightly-2018-11-28 install cargo-tarpaulin --force; \
fi
cargo-tarpaulin v0.6.9:
    cargo-tarpaulin
RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run nightly-2018-11-28 cargo  tarpaulin --timeout 600 --all --out Xml --skip-clean -v -e holochain_core_api_c_binding -e hdk -e hc
/home/eric/.cargo/bin/cargo-tarpaulin: error while loading shared libraries: libproc_macro-f453da4e87c5fc8a.so: cannot open shared object file: No such file or directory
Makefile:179: recipe for target 'code_coverage' failed
```
then I noticed that the flags set on install were not the same as recommended by the [tarpaulin install instructions](https://crates.io/crates/cargo-tarpaulin)

So I updated the makefile and forced an install, and it now works on my local machine.  @lucksus I need help though clearing the right part of the travis cache to make sure this also works in CI.