### PR TITLE
moved network config to InstanceConfiguration

### DIFF
--- a/cmd/src/cli/run.rs
+++ b/cmd/src/cli/run.rs
@@ -25,7 +25,7 @@ pub fn run(package: bool, port: u16) -> DefaultResult<()> {
         agent: "hc-run-agent".into(),
         logger: Default::default(),
         storage: StorageConfiguration::Memory,
-        network: "{\"backend\": \"mock\"}".to_string(),
+        network: Some("{\"backend\": \"mock\"}".to_string()),
     };
 
     let interface_config = InterfaceConfiguration {

--- a/cmd/src/cli/run.rs
+++ b/cmd/src/cli/run.rs
@@ -25,6 +25,7 @@ pub fn run(package: bool, port: u16) -> DefaultResult<()> {
         agent: "hc-run-agent".into(),
         logger: Default::default(),
         storage: StorageConfiguration::Memory,
+        network: "{\"backend\": \"mock\"}".to_string(),
     };
 
     let interface_config = InterfaceConfiguration {

--- a/container/example-config/basic.toml
+++ b/container/example-config/basic.toml
@@ -12,7 +12,7 @@ hash = "Qm328wyq38924y"
 id = "app spec instance"
 dna = "app spec rust"
 agent = "test agent"
-network = "{\"backend\": \"mock\"}"
+network = ""
 [instances.logger]
 type = "simple"
 file = "app_spec.log"

--- a/container/example-config/basic.toml
+++ b/container/example-config/basic.toml
@@ -12,7 +12,6 @@ hash = "Qm328wyq38924y"
 id = "app spec instance"
 dna = "app spec rust"
 agent = "test agent"
-network = ""
 [instances.logger]
 type = "simple"
 file = "app_spec.log"

--- a/container/example-config/basic.toml
+++ b/container/example-config/basic.toml
@@ -12,6 +12,7 @@ hash = "Qm328wyq38924y"
 id = "app spec instance"
 dna = "app spec rust"
 agent = "test agent"
+network = "{\"backend\": \"mock\"}"
 [instances.logger]
 type = "simple"
 file = "app_spec.log"

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -147,7 +147,7 @@ pub struct InstanceConfiguration {
     pub agent: String,
     pub logger: LoggerConfiguration,
     pub storage: StorageConfiguration,
-    pub network: String,
+    pub network: Option<String>,
 }
 
 /// There might be different kinds of loggers in the future.
@@ -343,7 +343,10 @@ pub mod tests {
 
         let instances = config.instances;
         let instance_config = instances.get(0).unwrap();
-        assert_eq!(instance_config.network, "{\"backend\":\"special\"}");
+        assert_eq!(
+            instance_config.network,
+            Some("{\"backend\":\"special\"}".to_string())
+        );
     }
 
     #[test]
@@ -363,7 +366,6 @@ pub mod tests {
     id = "app spec instance"
     dna = "app spec rust"
     agent = "test agent"
-    network = ""
     [instances.logger]
     type = "simple"
     file = "app_spec.log"
@@ -402,7 +404,7 @@ pub mod tests {
         assert_eq!(instance_config.id, "app spec instance");
         assert_eq!(instance_config.dna, "app spec rust");
         assert_eq!(instance_config.agent, "test agent");
-        assert_eq!(instance_config.network, "");
+        assert_eq!(instance_config.network, None);
     }
 
     #[test]

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -230,7 +230,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use crate::config::{load_configuration, Configuration,};
+    use crate::config::{load_configuration, Configuration};
 
     pub fn example_serialized_network_config() -> String {
         String::from("{\\\"backend\\\":\\\"mock\\\"}")
@@ -289,7 +289,8 @@ pub mod tests {
 
     #[test]
     fn test_load_complete_config() {
-        let toml = &format!(r#"
+        let toml = &format!(
+            r#"
     [[agents]]
     id = "test agent"
     name = "Holo Tester"
@@ -327,7 +328,9 @@ pub mod tests {
     file = "/tmp/holochain.sock"
     [[interfaces.instances]]
     id = "app spec instance"
-    "#,"{\\\"backend\\\":\\\"special\\\"}");
+    "#,
+            "{\\\"backend\\\":\\\"special\\\"}"
+        );
 
         let config = load_configuration::<Configuration>(toml).unwrap();
 
@@ -342,7 +345,6 @@ pub mod tests {
         let instance_config = instances.get(0).unwrap();
         assert_eq!(instance_config.network, "{\"backend\":\"special\"}");
     }
-
 
     #[test]
     fn test_load_complete_config_default_network() {
@@ -403,10 +405,10 @@ pub mod tests {
         assert_eq!(instance_config.network, "");
     }
 
-
     #[test]
     fn test_inconsistent_config() {
-        let toml = &format!(r#"
+        let toml = &format!(
+            r#"
     [[agents]]
     id = "test agent"
     name = "Holo Tester"
@@ -428,7 +430,9 @@ pub mod tests {
     [instances.storage]
     type = "file"
     path = "app_spec_storage"
-    "#,example_serialized_network_config());
+    "#,
+            example_serialized_network_config()
+        );
         let config: Configuration = load_configuration(toml).unwrap();
 
         assert_eq!(config.check_consistency(), Err("DNA configuration \"WRONG DNA ID\" not found, mentioned in instance \"app spec instance\"".to_string()));
@@ -436,7 +440,8 @@ pub mod tests {
 
     #[test]
     fn test_inconsistent_config_interface_1() {
-        let toml = &format!(r#"
+        let toml = &format!(
+            r#"
     [[agents]]
     id = "test agent"
     name = "Holo Tester"
@@ -466,7 +471,9 @@ pub mod tests {
     port = 8888
     [[interfaces.instances]]
     id = "WRONG INSTANCE ID"
-    "#,example_serialized_network_config());
+    "#,
+            example_serialized_network_config()
+        );
         let config = load_configuration::<Configuration>(toml).unwrap();
 
         assert_eq!(
@@ -480,7 +487,8 @@ pub mod tests {
 
     #[test]
     fn test_invalid_toml_1() {
-        let toml = &format!(r#"
+        let toml = &format!(
+            r#"
     [[agents]]
     id = "test agent"
     name = "Holo Tester"
@@ -510,7 +518,9 @@ pub mod tests {
     port = 8888
     [[interfaces.instances]]
     id = "app spec instance"
-    "#,example_serialized_network_config());
+    "#,
+            example_serialized_network_config()
+        );
         if let Err(e) = load_configuration::<Configuration>(toml) {
             assert!(
                 true,

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -237,7 +237,10 @@ fn instantiate_from_config(
                 ))
             })?;
 
-            let network_config = instance_config.network.unwrap_or(default_network_config.to_owned()).into();
+            let network_config = instance_config
+                .network
+                .unwrap_or(default_network_config.to_owned())
+                .into();
 
             let context: Context = match instance_config.storage {
                 StorageConfiguration::File { path } => {

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -237,10 +237,9 @@ fn instantiate_from_config(
                 ))
             })?;
 
-            let network_config = if instance_config.network == "" {
-                instance_config.network
-            } else {
-                default_network_config.to_owned()
+            let network_config = match instance_config.network {
+                None => default_network_config.to_owned(),
+                Some(config) => config,
             }
             .into();
 
@@ -338,7 +337,6 @@ pub mod tests {
     id = "app spec instance"
     dna = "app spec rust"
     agent = "test agent"
-    network = ""
     [instances.logger]
     type = "simple"
     file = "app_spec.log"
@@ -452,7 +450,7 @@ pub mod tests {
         let io = dispatcher.io;
 
         let request = r#"{"jsonrpc": "2.0", "method": "info/instances", "params": null, "id": 1}"#;
-        let response = r#"{"jsonrpc":"2.0","result":"{\"app spec instance\":{\"id\":\"app spec instance\",\"dna\":\"app spec rust\",\"agent\":\"test agent\",\"logger\":{\"type\":\"simple\",\"file\":\"app_spec.log\"},\"storage\":{\"type\":\"memory\"},\"network\":\"{\\\"backend\\\":\\\"mock\\\"}\"}}","id":1}"#;
+        let response = r#"{"jsonrpc":"2.0","result":"{\"app spec instance\":{\"id\":\"app spec instance\",\"dna\":\"app spec rust\",\"agent\":\"test agent\",\"logger\":{\"type\":\"simple\",\"file\":\"app_spec.log\"},\"storage\":{\"type\":\"memory\"},\"network\":null}}","id":1}"#;
 
         assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
     }

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -237,11 +237,7 @@ fn instantiate_from_config(
                 ))
             })?;
 
-            let network_config = match instance_config.network {
-                None => default_network_config.to_owned(),
-                Some(config) => config,
-            }
-            .into();
+            let network_config = instance_config.network.unwrap_or(default_network_config.to_owned()).into();
 
             let context: Context = match instance_config.storage {
                 StorageConfiguration::File { path } => {

--- a/container_api/src/lib.rs
+++ b/container_api/src/lib.rs
@@ -99,9 +99,9 @@ extern crate serde;
 extern crate tempfile;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 extern crate boolinator;
 extern crate jsonrpc_ws_server;
+extern crate serde_json;
 #[cfg(test)]
 extern crate test_utils;
 extern crate tiny_http;

--- a/container_api/src/lib.rs
+++ b/container_api/src/lib.rs
@@ -99,7 +99,6 @@ extern crate serde;
 extern crate tempfile;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
 extern crate serde_json;
 extern crate boolinator;
 extern crate jsonrpc_ws_server;


### PR DESCRIPTION
currently `container_api::instantiate_from_config()` hard codes the network configuration.  This PR moves the config into InstanceConfiguration.  This is necessary to connect a real network to instances, and also looks forward to containers that could connect different DNA to different networks.
