### PR TITLE
Actors are discussed in two contexts:

### DIFF
--- a/doc/holochain_101/src/state/actors.md
+++ b/doc/holochain_101/src/state/actors.md
@@ -1,6 +1,6 @@
 # Internal actors
 
-Actors are discussed in two context:
+Actors are discussed in two contexts:
 
 - Each Holochain agent as an actor in a networking context
 - Riker actors as an implemenation detail in the Holochain core lib


### PR DESCRIPTION
'context' should be plural