### PR TITLE
Validate on DHT hold

### DIFF
--- a/cmd/src/cli/generate.rs
+++ b/cmd/src/cli/generate.rs
@@ -81,6 +81,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn can_generate_scaffolds() {
         let tmp = gen_dir();
 

--- a/cmd/src/cli/package.rs
+++ b/cmd/src/cli/package.rs
@@ -305,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn package_and_unpack_isolated() {
         const DEFAULT_BUNDLE_FILE_NAME: &str = "bundle.json";
 
@@ -354,6 +355,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     /// A test ensuring that packaging and unpacking a project results in the very same project
     fn package_reverse() {
         const DEFAULT_BUNDLE_FILE_NAME: &str = "bundle.json";

--- a/cmd/src/cli/package.rs
+++ b/cmd/src/cli/package.rs
@@ -405,6 +405,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn auto_compilation() {
         let tmp = gen_dir();
 

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -91,6 +91,12 @@ impl AgentState {
             _ => unreachable!(),
         }
     }
+
+    pub fn get_header_for_entry(&self, entry: &Entry) -> Option<ChainHeader> {
+        self.chain()
+            .iter_type(&self.top_chain_header(), &entry.entry_type())
+            .find(|h| h.entry_address() == &entry.address())
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, DefaultJson)]

--- a/core/src/network/actions/initialize_network.rs
+++ b/core/src/network/actions/initialize_network.rs
@@ -48,7 +48,10 @@ pub async fn initialize_network(context: &Arc<Context>) -> Result<(), HolochainE
 }
 
 #[cfg(test)]
-pub async fn initialize_network_with_spoofed_dna(dna_hash: String, context: &Arc<Context>) -> Result<(), HolochainError> {
+pub async fn initialize_network_with_spoofed_dna(
+    dna_hash: String,
+    context: &Arc<Context>,
+) -> Result<(), HolochainError> {
     let (_, agent_id) = await!(get_dna_and_agent(context))?;
     let network_settings = NetworkSettings {
         config: context.network_config.clone(),

--- a/core/src/network/actions/initialize_network.rs
+++ b/core/src/network/actions/initialize_network.rs
@@ -47,6 +47,22 @@ pub async fn initialize_network(context: &Arc<Context>) -> Result<(), HolochainE
     })
 }
 
+#[cfg(test)]
+pub async fn initialize_network_with_spoofed_dna(dna_hash: String, context: &Arc<Context>) -> Result<(), HolochainError> {
+    let (_, agent_id) = await!(get_dna_and_agent(context))?;
+    let network_settings = NetworkSettings {
+        config: context.network_config.clone(),
+        dna_hash,
+        agent_id,
+    };
+    let action_wrapper = ActionWrapper::new(Action::InitNetwork(network_settings));
+    dispatch_action(&context.action_channel, action_wrapper.clone());
+
+    await!(InitNetworkFuture {
+        context: context.clone(),
+    })
+}
+
 pub struct InitNetworkFuture {
     context: Arc<Context>,
 }

--- a/core/src/network/entry_with_header.rs
+++ b/core/src/network/entry_with_header.rs
@@ -6,14 +6,14 @@ use std::{convert::TryInto, sync::Arc};
 
 #[derive(Serialize, Deserialize)]
 pub struct EntryWithHeader {
-    pub entry_body: Entry,
+    pub entry: Entry,
     pub header: ChainHeader,
 }
 
 impl EntryWithHeader {
     pub fn new(entry: Entry, header: ChainHeader) -> EntryWithHeader {
         EntryWithHeader {
-            entry_body: entry,
+            entry: entry,
             header,
         }
     }

--- a/core/src/network/entry_with_header.rs
+++ b/core/src/network/entry_with_header.rs
@@ -12,10 +12,7 @@ pub struct EntryWithHeader {
 
 impl EntryWithHeader {
     pub fn new(entry: Entry, header: ChainHeader) -> EntryWithHeader {
-        EntryWithHeader {
-            entry,
-            header,
-        }
+        EntryWithHeader { entry, header }
     }
 }
 

--- a/core/src/network/entry_with_header.rs
+++ b/core/src/network/entry_with_header.rs
@@ -13,7 +13,7 @@ pub struct EntryWithHeader {
 impl EntryWithHeader {
     pub fn new(entry: Entry, header: ChainHeader) -> EntryWithHeader {
         EntryWithHeader {
-            entry: entry,
+            entry,
             header,
         }
     }

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -16,7 +16,10 @@ pub fn handle_store_dht(dht_data: DhtData, context: Arc<Context>) {
     let entry_with_header: EntryWithHeader =
         serde_json::from_str(&serde_json::to_string(&dht_data.content).unwrap()).unwrap();
     thread::spawn(move || {
-        let result = block_on(hold_entry_workflow(&entry_with_header, &context.clone()));
+        match block_on(hold_entry_workflow(&entry_with_header, &context.clone())) {
+            Err(error) => context.log(error),
+            _ => (),
+        }
     });
 }
 

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 pub fn handle_store_dht(dht_data: DhtData, context: Arc<Context>) {
     let entry_with_header: EntryWithHeader =
         serde_json::from_str(&serde_json::to_string(&dht_data.content).unwrap()).unwrap();
-    let _ = block_on(hold_entry(&entry_with_header.entry_body, &context.clone()));
+    let _ = block_on(hold_entry(&entry_with_header.entry, &context.clone()));
 }
 
 /// The network requests us to store meta information (links/CRUD/etc) for an
@@ -29,7 +29,7 @@ pub fn handle_store_dht_meta(dht_meta_data: DhtMetaData, context: Arc<Context>) 
                     .expect("dht_meta_data should be EntryWithHader"),
             )
             .expect("dht_meta_data should be EntryWithHader");
-            let link_add = match entry_with_header.entry_body {
+            let link_add = match entry_with_header.entry {
                 Entry::LinkAdd(link_add) => link_add,
                 _ => unreachable!(),
             };

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -1,8 +1,6 @@
 use crate::{
-    context::Context,
-    dht::actions::add_link::add_link,
-    network::entry_with_header::EntryWithHeader,
-    workflows::hold_entry::hold_entry_workflow,
+    context::Context, dht::actions::add_link::add_link,
+    network::entry_with_header::EntryWithHeader, workflows::hold_entry::hold_entry_workflow,
 };
 use futures::executor::block_on;
 use holochain_core_types::{
@@ -11,10 +9,7 @@ use holochain_core_types::{
     entry::Entry,
 };
 use holochain_net_connection::protocol_wrapper::{DhtData, DhtMetaData};
-use std::{
-    sync::Arc,
-    thread,
-};
+use std::{sync::Arc, thread};
 
 /// The network requests us to store (i.e. hold) the given entry.
 pub fn handle_store_dht(dht_data: DhtData, context: Arc<Context>) {

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -15,10 +15,8 @@ use std::{sync::Arc, thread};
 pub fn handle_store_dht(dht_data: DhtData, context: Arc<Context>) {
     let entry_with_header: EntryWithHeader =
         serde_json::from_str(&serde_json::to_string(&dht_data.content).unwrap()).unwrap();
-    println!("handle_store_dht");
     thread::spawn(move || {
         let result = block_on(hold_entry_workflow(&entry_with_header, &context.clone()));
-        println!("result: {:?}", result);
     });
 }
 

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -15,7 +15,6 @@ pub mod tests {
             actions::{get_entry::get_entry, get_validation_package::get_validation_package},
             test_utils::test_wat_always_valid,
         },
-
         workflows::author_entry::author_entry,
     };
     use futures::executor::block_on;
@@ -92,7 +91,8 @@ pub mod tests {
         block_on(author_entry(&entry, None, &context1)).expect("Could not author entry");
 
         let agent1_state = context1.state().unwrap().agent();
-        let header = agent1_state.get_header_for_entry(&entry)
+        let header = agent1_state
+            .get_header_for_entry(&entry)
             .expect("There must be a header in the author's source chain after commit");
 
         let (_, context2) = test_instance_and_context_by_name(dna.clone(), "bob1").unwrap();

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -4,12 +4,18 @@ pub mod entry_with_header;
 pub mod handler;
 pub mod reducers;
 pub mod state;
+#[cfg(test)]
+pub mod test_utils;
 
 #[cfg(test)]
 pub mod tests {
     use crate::{
         instance::tests::test_instance_and_context_by_name,
-        network::actions::{get_entry::get_entry, get_validation_package::get_validation_package},
+        network::{
+            actions::{get_entry::get_entry, get_validation_package::get_validation_package},
+            test_utils::test_wat_always_valid,
+        },
+
         workflows::author_entry::author_entry,
     };
     use futures::executor::block_on;
@@ -76,72 +82,7 @@ pub mod tests {
 
     #[test]
     fn get_validation_package_roundtrip() {
-        let wat = r#"
-(module
-
-    (memory 1)
-    (export "memory" (memory 0))
-
-    (func
-        (export "__hdk_validate_app_entry")
-        (param $allocation i32)
-        (result i32)
-
-        (i32.const 0)
-    )
-
-    (func
-        (export "__hdk_validate_link")
-        (param $allocation i32)
-        (result i32)
-
-        (i32.const 0)
-    )
-
-
-    (func
-        (export "__hdk_get_validation_package_for_entry_type")
-        (param $allocation i32)
-        (result i32)
-
-        ;; This writes "Entry" into memory
-        (i32.store (i32.const 0) (i32.const 34))
-        (i32.store (i32.const 1) (i32.const 69))
-        (i32.store (i32.const 2) (i32.const 110))
-        (i32.store (i32.const 3) (i32.const 116))
-        (i32.store (i32.const 4) (i32.const 114))
-        (i32.store (i32.const 5) (i32.const 121))
-        (i32.store (i32.const 6) (i32.const 34))
-
-        (i32.const 7)
-    )
-
-    (func
-        (export "__hdk_get_validation_package_for_link")
-        (param $allocation i32)
-        (result i32)
-
-        ;; This writes "Entry" into memory
-        (i32.store (i32.const 0) (i32.const 34))
-        (i32.store (i32.const 1) (i32.const 69))
-        (i32.store (i32.const 2) (i32.const 110))
-        (i32.store (i32.const 3) (i32.const 116))
-        (i32.store (i32.const 4) (i32.const 114))
-        (i32.store (i32.const 5) (i32.const 121))
-        (i32.store (i32.const 6) (i32.const 34))
-
-        (i32.const 7)
-    )
-
-    (func
-        (export "__list_capabilities")
-        (param $allocation i32)
-        (result i32)
-
-        (i32.const 0)
-    )
-)
-                "#;
+        let wat = &test_wat_always_valid();
 
         let mut dna = create_test_dna_with_wat("test_zome", "test_cap", Some(wat));
         dna.uuid = String::from("get_validation_package_roundtrip");

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -151,10 +151,7 @@ pub mod tests {
         block_on(author_entry(&entry, None, &context1)).expect("Could not author entry");
 
         let agent1_state = context1.state().unwrap().agent();
-        let header = agent1_state
-            .chain()
-            .iter_type(&agent1_state.top_chain_header(), &entry.entry_type())
-            .find(|h| h.entry_address() == &entry.address())
+        let header = agent1_state.get_header_for_entry(&entry)
             .expect("There must be a header in the author's source chain after commit");
 
         let (_, context2) = test_instance_and_context_by_name(dna.clone(), "bob1").unwrap();

--- a/core/src/network/reducers/mod.rs
+++ b/core/src/network/reducers/mod.rs
@@ -108,8 +108,6 @@ pub fn send_message(
         data: serde_json::from_str(&serde_json::to_string(&message).unwrap()).unwrap(),
     };
 
-    println!("SEND MESSAGE: {:?}", data);
-
     let _ = send(network_state, ProtocolWrapper::SendMessage(data))?;
 
     network_state.direct_message_connections.insert(id, message);

--- a/core/src/network/reducers/publish.rs
+++ b/core/src/network/reducers/publish.rs
@@ -30,7 +30,7 @@ fn publish_entry(
             msg_id: "?".to_string(),
             dna_hash: network_state.dna_hash.clone().unwrap(),
             agent_id: network_state.agent_id.clone().unwrap(),
-            address: entry_with_header.entry_body.address().to_string(),
+            address: entry_with_header.entry.address().to_string(),
             content: serde_json::from_str(&serde_json::to_string(&entry_with_header).unwrap())
                 .unwrap(),
         }),
@@ -79,12 +79,12 @@ fn publish_link_meta(
     network_state: &mut NetworkState,
     entry_with_header: &EntryWithHeader,
 ) -> Result<(), HolochainError> {
-    let link_add_entry = match entry_with_header.entry_body.clone() {
+    let link_add_entry = match entry_with_header.entry.clone() {
         Entry::LinkAdd(link_add_entry) => link_add_entry,
         _ => {
             return Err(HolochainError::ErrorGeneric(format!(
                 "Received bad entry type. Expected Entry::LinkAdd received {:?}",
-                entry_with_header.entry_body,
+                entry_with_header.entry,
             )));
         }
     };
@@ -114,11 +114,11 @@ fn reduce_publish_inner(
     let entry_with_header = fetch_entry_with_header(&address, &context)?;
     let (crud_status, maybe_crud_link) = get_entry_crud_meta_from_dht(context, address.clone())?
         .expect("Entry should have crud-status metadata in DHT.");
-    match entry_with_header.entry_body.entry_type() {
+    match entry_with_header.entry.entry_type() {
         EntryType::AgentId => publish_entry(network_state, &entry_with_header).and_then(|_| {
             publish_crud_meta(
                 network_state,
-                entry_with_header.entry_body.address(),
+                entry_with_header.entry.address(),
                 crud_status,
                 maybe_crud_link,
             )
@@ -126,7 +126,7 @@ fn reduce_publish_inner(
         EntryType::App(_) => publish_entry(network_state, &entry_with_header).and_then(|_| {
             publish_crud_meta(
                 network_state,
-                entry_with_header.entry_body.address(),
+                entry_with_header.entry.address(),
                 crud_status,
                 maybe_crud_link,
             )
@@ -136,7 +136,7 @@ fn reduce_publish_inner(
         EntryType::Deletion => publish_entry(network_state, &entry_with_header).and_then(|_| {
             publish_crud_meta(
                 network_state,
-                entry_with_header.entry_body.address(),
+                entry_with_header.entry.address(),
                 crud_status,
                 maybe_crud_link,
             )

--- a/core/src/network/test_utils.rs
+++ b/core/src/network/test_utils.rs
@@ -1,9 +1,6 @@
 use crate::{
     context::Context,
-    instance::{
-        Instance,
-        tests::test_context,
-    },
+    instance::{tests::test_context, Instance},
     network::actions::initialize_network::initialize_network_with_spoofed_dna,
     nucleus::actions::initialize::initialize_application,
 };
@@ -26,7 +23,10 @@ pub fn test_instance_with_spoofed_dna(
     block_on(
         async {
             await!(initialize_application(dna.clone(), &context))?;
-            await!(initialize_network_with_spoofed_dna(spoofed_dna_hash, &context))
+            await!(initialize_network_with_spoofed_dna(
+                spoofed_dna_hash,
+                &context
+            ))
         },
     )?;
 
@@ -43,7 +43,7 @@ pub fn test_instance_with_spoofed_dna(
 }
 
 pub fn test_wat_always_valid() -> String {
-r#"
+    r#"
 (module
 
     (memory 1)
@@ -108,11 +108,12 @@ r#"
         (i32.const 0)
     )
 )
-                "#.to_string()
+                "#
+    .to_string()
 }
 
-pub fn test_wat_always_invalid() -> String{
-r#"
+pub fn test_wat_always_invalid() -> String {
+    r#"
 (module
 
     (memory 1)
@@ -197,5 +198,6 @@ r#"
         (i32.const 0)
     )
 )
-                "#.to_string()
+                "#
+    .to_string()
 }

--- a/core/src/network/test_utils.rs
+++ b/core/src/network/test_utils.rs
@@ -1,0 +1,201 @@
+use crate::{
+    context::Context,
+    instance::{
+        Instance,
+        tests::test_context,
+    },
+    network::actions::initialize_network::initialize_network_with_spoofed_dna,
+    nucleus::actions::initialize::initialize_application,
+};
+use futures::executor::block_on;
+use holochain_core_types::dna::Dna;
+use std::sync::Arc;
+
+/// create a test instance
+#[cfg_attr(tarpaulin, skip)]
+pub fn test_instance_with_spoofed_dna(
+    dna: Dna,
+    spoofed_dna_hash: String,
+    name: &str,
+) -> Result<(Instance, Arc<Context>), String> {
+    // Create instance and plug in our DNA
+    let context = test_context(name);
+    let mut instance = Instance::new(context.clone());
+    instance.start_action_loop(context.clone());
+    let context = instance.initialize_context(context);
+    block_on(
+        async {
+            await!(initialize_application(dna.clone(), &context))?;
+            await!(initialize_network_with_spoofed_dna(spoofed_dna_hash, &context))
+        },
+    )?;
+
+    assert_eq!(instance.state().nucleus().dna(), Some(dna.clone()));
+    assert!(instance.state().nucleus().has_initialized());
+
+    /// fair warning... use test_instance_blank() if you want a minimal instance
+    assert!(
+        !dna.zomes.clone().is_empty(),
+        "Empty zomes = No genesis = infinite loops below!"
+    );
+
+    Ok((instance, context))
+}
+
+pub fn test_wat_always_valid() -> String {
+r#"
+(module
+
+    (memory 1)
+    (export "memory" (memory 0))
+
+    (func
+        (export "__hdk_validate_app_entry")
+        (param $allocation i32)
+        (result i32)
+
+        (i32.const 0)
+    )
+
+    (func
+        (export "__hdk_validate_link")
+        (param $allocation i32)
+        (result i32)
+
+        (i32.const 0)
+    )
+
+
+    (func
+        (export "__hdk_get_validation_package_for_entry_type")
+        (param $allocation i32)
+        (result i32)
+
+        ;; This writes "Entry" into memory
+        (i32.store (i32.const 0) (i32.const 34))
+        (i32.store (i32.const 1) (i32.const 69))
+        (i32.store (i32.const 2) (i32.const 110))
+        (i32.store (i32.const 3) (i32.const 116))
+        (i32.store (i32.const 4) (i32.const 114))
+        (i32.store (i32.const 5) (i32.const 121))
+        (i32.store (i32.const 6) (i32.const 34))
+
+        (i32.const 7)
+    )
+
+    (func
+        (export "__hdk_get_validation_package_for_link")
+        (param $allocation i32)
+        (result i32)
+
+        ;; This writes "Entry" into memory
+        (i32.store (i32.const 0) (i32.const 34))
+        (i32.store (i32.const 1) (i32.const 69))
+        (i32.store (i32.const 2) (i32.const 110))
+        (i32.store (i32.const 3) (i32.const 116))
+        (i32.store (i32.const 4) (i32.const 114))
+        (i32.store (i32.const 5) (i32.const 121))
+        (i32.store (i32.const 6) (i32.const 34))
+
+        (i32.const 7)
+    )
+
+    (func
+        (export "__list_capabilities")
+        (param $allocation i32)
+        (result i32)
+
+        (i32.const 0)
+    )
+)
+                "#.to_string()
+}
+
+pub fn test_wat_always_invalid() -> String{
+r#"
+(module
+
+    (memory 1)
+    (export "memory" (memory 0))
+
+    (func
+        (export "__hdk_validate_app_entry")
+        (param $allocation i32)
+        (result i32)
+
+        ;; This writes "FAIL wat" into memory
+        (i32.store (i32.const 0) (i32.const 70))
+        (i32.store (i32.const 1) (i32.const 65))
+        (i32.store (i32.const 2) (i32.const 73))
+        (i32.store (i32.const 3) (i32.const 76))
+        (i32.store (i32.const 4) (i32.const 32))
+        (i32.store (i32.const 5) (i32.const 119))
+        (i32.store (i32.const 6) (i32.const 97))
+        (i32.store (i32.const 7) (i32.const 116))
+
+        (i32.const 8)
+    )
+
+    (func
+        (export "__hdk_validate_link")
+        (param $allocation i32)
+        (result i32)
+
+        ;; This writes "FAIL wat" into memory
+        (i32.store (i32.const 0) (i32.const 70))
+        (i32.store (i32.const 1) (i32.const 65))
+        (i32.store (i32.const 2) (i32.const 73))
+        (i32.store (i32.const 3) (i32.const 76))
+        (i32.store (i32.const 4) (i32.const 32))
+        (i32.store (i32.const 5) (i32.const 119))
+        (i32.store (i32.const 6) (i32.const 97))
+        (i32.store (i32.const 7) (i32.const 116))
+
+        (i32.const 8)
+    )
+
+
+    (func
+        (export "__hdk_get_validation_package_for_entry_type")
+        (param $allocation i32)
+        (result i32)
+
+        ;; This writes "Entry" into memory
+        (i32.store (i32.const 0) (i32.const 34))
+        (i32.store (i32.const 1) (i32.const 69))
+        (i32.store (i32.const 2) (i32.const 110))
+        (i32.store (i32.const 3) (i32.const 116))
+        (i32.store (i32.const 4) (i32.const 114))
+        (i32.store (i32.const 5) (i32.const 121))
+        (i32.store (i32.const 6) (i32.const 34))
+
+        (i32.const 7)
+    )
+
+    (func
+        (export "__hdk_get_validation_package_for_link")
+        (param $allocation i32)
+        (result i32)
+
+        ;; This writes "Entry" into memory
+        (i32.store (i32.const 0) (i32.const 34))
+        (i32.store (i32.const 1) (i32.const 69))
+        (i32.store (i32.const 2) (i32.const 110))
+        (i32.store (i32.const 3) (i32.const 116))
+        (i32.store (i32.const 4) (i32.const 114))
+        (i32.store (i32.const 5) (i32.const 121))
+        (i32.store (i32.const 6) (i32.const 34))
+
+        (i32.const 7)
+    )
+
+    (func
+        (export "__list_capabilities")
+        (param $allocation i32)
+        (result i32)
+
+        (i32.const 0)
+    )
+)
+                "#.to_string()
+}

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -122,6 +122,7 @@ pub mod tests {
 
     #[test]
     /// test that we can round trip bytes through a commit action and get the result from WASM
+    #[cfg(not(windows))]
     fn errors_if_base_is_not_present_test() {
         let (call_result, _) = test_zome_api_function(
             ZomeApiFunction::LinkEntries.as_str(),

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -52,8 +52,7 @@ pub mod tests {
         let (_instance1, context1) = instance_by_name("jill", dna.clone());
         let (_instance2, context2) = instance_by_name("jack", dna);
 
-        let entry_address = block_on(author_entry(&test_entry(), None, &context1))
-            .unwrap();
+        let entry_address = block_on(author_entry(&test_entry(), None, &context1)).unwrap();
 
         let mut json: Option<JsonString> = None;
         let mut tries = 0;
@@ -71,7 +70,6 @@ pub mod tests {
                 thread::sleep(time::Duration::from_millis(500));
             }
         }
-
 
         let x: String = json.unwrap().to_string();
         assert_eq!(

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -53,21 +53,25 @@ pub mod tests {
         let (_instance2, context2) = instance_by_name("jack", dna);
 
         let entry_address = block_on(author_entry(&test_entry(), None, &context1)).unwrap();
+        thread::sleep(time::Duration::from_millis(500));
 
         let mut json: Option<JsonString> = None;
         let mut tries = 0;
-        while json.is_none() && tries < 200 {
-            let state = &context2.state().unwrap();
-            json = state
-                .dht()
-                .content_storage()
-                .read()
-                .unwrap()
-                .fetch(&entry_address)
-                .expect("could not fetch from CAS");
+        while json.is_none() && tries < 120 {
+            tries = tries + 1;
+            {
+                let state = &context2.state().unwrap();
+                json = state
+                    .dht()
+                    .content_storage()
+                    .read()
+                    .unwrap()
+                    .fetch(&entry_address)
+                    .expect("could not fetch from CAS");
+            }
+            println!("Try {}: {:?}", tries, json);
             if json.is_none() {
-                tries = tries + 1;
-                thread::sleep(time::Duration::from_millis(500));
+                thread::sleep(time::Duration::from_millis(1000));
             }
         }
 

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -56,7 +56,7 @@ pub mod tests {
 
         let mut json: Option<JsonString> = None;
         let mut tries = 0;
-        while json.is_none() && tries < 10 {
+        while json.is_none() && tries < 200 {
             let state = &context2.state().unwrap();
             json = state
                 .dht()

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -45,6 +45,7 @@ pub mod tests {
     use std::{thread, time};
 
     #[test]
+    #[cfg(not(windows))]
     /// test that a commit will publish and entry to the dht of a connected instance via the mock network
     fn test_commit_with_dht_publish() {
         let mut dna = test_dna();

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -41,29 +41,37 @@ pub mod tests {
     use super::author_entry;
     use crate::nucleus::actions::tests::*;
     use futures::executor::block_on;
-    use holochain_core_types::entry::test_entry;
+    use holochain_core_types::{entry::test_entry, json::JsonString};
     use std::{thread, time};
 
     #[test]
     /// test that a commit will publish and entry to the dht of a connected instance via the mock network
     fn test_commit_with_dht_publish() {
-        let dna = test_dna();
+        let mut dna = test_dna();
+        dna.uuid = "test_commit_with_dht_publish".to_string();
         let (_instance1, context1) = instance_by_name("jill", dna.clone());
         let (_instance2, context2) = instance_by_name("jack", dna);
 
-        let entry_address = block_on(author_entry(&test_entry(), None, &context1));
+        let entry_address = block_on(author_entry(&test_entry(), None, &context1))
+            .unwrap();
 
-        let entry_address = entry_address.unwrap();
-        thread::sleep(time::Duration::from_millis(1000));
+        let mut json: Option<JsonString> = None;
+        let mut tries = 0;
+        while json.is_none() && tries < 10 {
+            let state = &context2.state().unwrap();
+            json = state
+                .dht()
+                .content_storage()
+                .read()
+                .unwrap()
+                .fetch(&entry_address)
+                .expect("could not fetch from CAS");
+            if json.is_none() {
+                tries = tries + 1;
+                thread::sleep(time::Duration::from_millis(500));
+            }
+        }
 
-        let state = &context2.state().unwrap();
-        let json = state
-            .dht()
-            .content_storage()
-            .read()
-            .unwrap()
-            .fetch(&entry_address)
-            .expect("could not fetch from CAS");
 
         let x: String = json.unwrap().to_string();
         assert_eq!(

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -1,8 +1,9 @@
 use crate::{
     context::Context,
     dht::actions::hold::hold_entry,
-    network::actions::get_validation_package::get_validation_package,
-    network::entry_with_header::EntryWithHeader,
+    network::{
+        actions::get_validation_package::get_validation_package, entry_with_header::EntryWithHeader,
+    },
     nucleus::actions::validate::validate_entry,
 };
 
@@ -17,11 +18,12 @@ pub async fn hold_entry_workflow<'a>(
     entry_with_header: &'a EntryWithHeader,
     context: &'a Arc<Context>,
 ) -> Result<Address, HolochainError> {
-    let EntryWithHeader{entry, header} = &entry_with_header;
+    let EntryWithHeader { entry, header } = &entry_with_header;
 
     // 1. Get validation package from source
     let maybe_validation_package = await!(get_validation_package(header.clone(), &context))?;
-    let validation_package = maybe_validation_package.ok_or("Could not get validation package from source".to_string())?;
+    let validation_package = maybe_validation_package
+        .ok_or("Could not get validation package from source".to_string())?;
 
     // 2. Create validation data struct
     let validation_data = ValidationData {
@@ -38,14 +40,11 @@ pub async fn hold_entry_workflow<'a>(
     await!(hold_entry(entry, &context))
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::{
-        nucleus::actions::tests::*,
-        network::test_utils::*,
-        workflows::author_entry::author_entry,
+        network::test_utils::*, nucleus::actions::tests::*, workflows::author_entry::author_entry,
     };
     use futures::executor::block_on;
     use holochain_core_types::entry::test_entry;
@@ -61,9 +60,11 @@ pub mod tests {
     /// hold_entry_workflow is then expected to fail in its validation step
     fn test_reject_invalid_entry_on_hold_workflow() {
         // Hacked DNA that regards everything as valid
-        let hacked_dna = create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_valid()));
+        let hacked_dna =
+            create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_valid()));
         // Original DNA that regards nothing as valid
-        let mut dna = create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_invalid()));
+        let mut dna =
+            create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_invalid()));
         dna.uuid = String::from("test_reject_invalid_entry_on_hold_workflow");
 
         // Hash of the original DNA
@@ -78,7 +79,8 @@ pub mod tests {
 
         // Get header which we need to trigger hold_entry_workflow
         let agent1_state = context1.state().unwrap().agent();
-        let header = agent1_state.get_header_for_entry(&entry)
+        let header = agent1_state
+            .get_header_for_entry(&entry)
             .expect("There must be a header in the author's source chain after commit");
         let entry_with_header = EntryWithHeader { entry, header };
 

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -48,7 +48,6 @@ pub mod tests {
     };
     use futures::executor::block_on;
     use holochain_core_types::entry::test_entry;
-    use std::{thread, time};
     use test_utils::*;
 
     #[test]

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -1,0 +1,78 @@
+use crate::{
+    context::Context,
+    dht::actions::hold::hold_entry,
+    network::actions::get_validation_package::get_validation_package,
+    network::entry_with_header::EntryWithHeader,
+    nucleus::actions::validate::validate_entry,
+};
+
+use holochain_core_types::{
+    cas::content::Address,
+    error::HolochainError,
+    validation::{EntryAction, EntryLifecycle, ValidationData},
+};
+use std::sync::Arc;
+
+pub async fn hold_entry_workflow<'a>(
+    entry_with_header: &'a EntryWithHeader,
+    context: &'a Arc<Context>,
+) -> Result<Address, HolochainError> {
+    let EntryWithHeader{entry, header} = &entry_with_header;
+
+    // 1. Get validation package from source
+    let maybe_validation_package = await!(get_validation_package(header.clone(), &context))?;
+    let validation_package = maybe_validation_package.ok_or("Could not get validation package from source".to_string())?;
+
+    // 2. Create validation data struct
+    let validation_data = ValidationData {
+        package: validation_package,
+        sources: header.sources().clone(),
+        lifecycle: EntryLifecycle::Dht,
+        action: EntryAction::Create,
+    };
+
+    // 3. Validate the entry
+    await!(validate_entry(entry.clone(), validation_data, &context))?;
+
+    // 3. If valid store the entry in the local DHT shard
+    await!(hold_entry(entry, &context))
+}
+
+/*
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::nucleus::actions::tests::*;
+    use futures::executor::block_on;
+    use holochain_core_types::entry::test_entry;
+    use std::{thread, time};
+
+    #[test]
+    /// test that a commit will publish and entry to the dht of a connected instance via the mock network
+    fn test_commit_with_dht_publish() {
+        let dna = test_dna();
+        let (_instance1, context1) = instance_by_name("jill", dna.clone());
+        let (_instance2, context2) = instance_by_name("jack", dna);
+
+        let entry_address = block_on(author_entry(&test_entry(), None, &context1));
+
+        let entry_address = entry_address.unwrap();
+        thread::sleep(time::Duration::from_millis(1000));
+
+        let state = &context2.state().unwrap();
+        let json = state
+            .dht()
+            .content_storage()
+            .read()
+            .unwrap()
+            .fetch(&entry_address)
+            .expect("could not fetch from CAS");
+
+        let x: String = json.unwrap().to_string();
+        assert_eq!(
+            x,
+            "{\"App\":[\"testEntryType\",\"\\\"test entry value\\\"\"]}".to_string(),
+        );
+    }
+}
+*/

--- a/core/src/workflows/mod.rs
+++ b/core/src/workflows/mod.rs
@@ -1,3 +1,4 @@
 pub mod author_entry;
 pub mod get_entry_history;
+pub mod hold_entry;
 pub mod respond_validation_package_request;


### PR DESCRIPTION
# Only hold valid entries in the DHT
New workflow 
```rust
pub async fn hold_entry_workflow<'a>(
    entry_with_header: &'a EntryWithHeader,
    context: &'a Arc<Context>,
) -> Result<Address, HolochainError>
``` 
that runs the full validation process on the entry before adding it to the local DHT shard.

Used in the network handler for `ProtocolWrapper::StoreDht`

# Pre-/Side work
* Extracted and reused `AgentState::get_header_for_entry`
* Renamed `EntryWithHeader::entry_body` back to just `EntryWithHeader::entry`

# Scenario test that simulates an attack
The test
```rust
fn test_reject_invalid_entry_on_hold_workflow()
```
creates an instance that has a different DNA with loose validation rules but that spoofes its DNA hash to be in the same mock network as the second instance on which we expect the entry validation to fail.
