### PR TITLE
Validate links on DHT hold meta

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -89,7 +89,7 @@ test('posts_by_agent', (t) => {
   t.deepEqual(result.Ok, {"addresses":[]})
 })
 
-test('my_posts', (t) => {
+test('my_posts', async (t) => {
   t.plan(1)
 
   app.call("blog", "main", "create_post",
@@ -100,7 +100,15 @@ test('my_posts', (t) => {
     {"content": "Another post", "in_reply_to": ""}
   )
 
-  const result = app.call("blog", "main", "my_posts", {})
+  const result = await pollFor(
+    () => app.call("blog", "main", "my_posts", {}),
+    (result) => {
+        return result &&
+        result.Ok &&
+        result.Ok.addresses &&
+        result.Ok.addresses.length === 2
+    }
+  ).catch(t.fail)
 
   t.equal(result.Ok.addresses.length, 2)
 })

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -1,12 +1,15 @@
 use crate::{
-    context::Context, dht::actions::add_link::add_link,
-    network::entry_with_header::EntryWithHeader, workflows::hold_entry::hold_entry_workflow,
+    context::Context,
+    network::entry_with_header::EntryWithHeader,
+    workflows::{
+        hold_entry::hold_entry_workflow,
+        hold_link::hold_link_workflow,
+    },
 };
 use futures::executor::block_on;
 use holochain_core_types::{
     cas::content::Address,
     crud_status::{CrudStatus, LINK_NAME, STATUS_NAME},
-    entry::Entry,
 };
 use holochain_net_connection::protocol_wrapper::{DhtData, DhtMetaData};
 use std::{sync::Arc, thread};
@@ -33,12 +36,12 @@ pub fn handle_store_dht_meta(dht_meta_data: DhtMetaData, context: Arc<Context>) 
                     .expect("dht_meta_data should be EntryWithHader"),
             )
             .expect("dht_meta_data should be EntryWithHader");
-            let link_add = match entry_with_header.entry {
-                Entry::LinkAdd(link_add) => link_add,
-                _ => unreachable!(),
-            };
-            let link = link_add.link().clone();
-            let _ = block_on(add_link(&link, &context.clone()));
+            thread::spawn(move || {
+                match block_on(hold_link_workflow(&entry_with_header, &context.clone())) {
+                    Err(error) => context.log(error),
+                    _ => (),
+                }
+            });
         }
         STATUS_NAME => {
             let _crud_status: CrudStatus = serde_json::from_str(

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -1,10 +1,7 @@
 use crate::{
     context::Context,
     network::entry_with_header::EntryWithHeader,
-    workflows::{
-        hold_entry::hold_entry_workflow,
-        hold_link::hold_link_workflow,
-    },
+    workflows::{hold_entry::hold_entry_workflow, hold_link::hold_link_workflow},
 };
 use futures::executor::block_on;
 use holochain_core_types::{

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -48,7 +48,6 @@ pub mod tests {
     };
     use futures::executor::block_on;
     use holochain_core_types::entry::test_entry;
-    use std::{thread, time};
     use test_utils::*;
 
     #[test]

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -65,14 +65,14 @@ pub mod tests {
     /// allow otherwise invalid entries while spoofing the unmodified dna_hash.
     ///
     /// hold_link_workflow is then expected to fail in its validation step
-    fn test_reject_invalid_entry_on_hold_workflow() {
+    fn test_reject_invalid_link_on_hold_workflow() {
         // Hacked DNA that regards everything as valid
         let hacked_dna =
             create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_valid()));
         // Original DNA that regards nothing as valid
         let mut dna =
             create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_invalid()));
-        dna.uuid = String::from("test_reject_invalid_entry_on_hold_workflow");
+        dna.uuid = String::from("test_reject_invalid_link_on_hold_workflow");
 
         // Hash of the original DNA
         let dna_hash = base64::encode(&dna.multihash().unwrap());

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -22,7 +22,9 @@ pub async fn hold_link_workflow<'a>(
 
     let link_add = match entry {
         Entry::LinkAdd(link_add) => link_add,
-        _ => Err(HolochainError::ErrorGeneric("hold_link_workflow expects entry to be an Entry::LinkAdd".to_string()))?,
+        _ => Err(HolochainError::ErrorGeneric(
+            "hold_link_workflow expects entry to be an Entry::LinkAdd".to_string(),
+        ))?,
     };
     let link = link_add.link().clone();
 

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -1,0 +1,102 @@
+use crate::{
+    context::Context,
+    dht::actions::add_link::add_link,
+    network::{
+        actions::get_validation_package::get_validation_package, entry_with_header::EntryWithHeader,
+    },
+    nucleus::actions::validate::validate_entry,
+};
+
+use holochain_core_types::{
+    entry::Entry,
+    error::HolochainError,
+    validation::{EntryAction, EntryLifecycle, ValidationData},
+};
+use std::sync::Arc;
+
+pub async fn hold_link_workflow<'a>(
+    entry_with_header: &'a EntryWithHeader,
+    context: &'a Arc<Context>,
+) -> Result<(), HolochainError> {
+    let EntryWithHeader { entry, header } = &entry_with_header;
+
+    let link_add = match entry {
+        Entry::LinkAdd(link_add) => link_add,
+        _ => Err(HolochainError::ErrorGeneric("hold_link_workflow expects entry to be an Entry::LinkAdd".to_string()))?,
+    };
+    let link = link_add.link().clone();
+
+    // 1. Get validation package from source
+    let maybe_validation_package = await!(get_validation_package(header.clone(), &context))?;
+    let validation_package = maybe_validation_package
+        .ok_or("Could not get validation package from source".to_string())?;
+
+    // 2. Create validation data struct
+    let validation_data = ValidationData {
+        package: validation_package,
+        sources: header.sources().clone(),
+        lifecycle: EntryLifecycle::Meta,
+        action: EntryAction::Create,
+    };
+
+    // 3. Validate the entry
+    await!(validate_entry(entry.clone(), validation_data, &context))?;
+
+    // 3. If valid store the entry in the local DHT shard
+    await!(add_link(&link, &context))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::{
+        network::test_utils::*, nucleus::actions::tests::*, workflows::author_entry::author_entry,
+    };
+    use futures::executor::block_on;
+    use holochain_core_types::entry::test_entry;
+    use test_utils::*;
+
+    #[test]
+    /// Test that an invalid entry will be rejected by this workflow.
+    ///
+    /// This test simulates an attack where a node is changing its local copy of the DNA to
+    /// allow otherwise invalid entries while spoofing the unmodified dna_hash.
+    ///
+    /// hold_entry_workflow is then expected to fail in its validation step
+    fn test_reject_invalid_entry_on_hold_workflow() {
+        // Hacked DNA that regards everything as valid
+        let hacked_dna =
+            create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_valid()));
+        // Original DNA that regards nothing as valid
+        let mut dna =
+            create_test_dna_with_wat("test_zome", "test_cap", Some(&test_wat_always_invalid()));
+        dna.uuid = String::from("test_reject_invalid_entry_on_hold_workflow");
+
+        // Hash of the original DNA
+        let dna_hash = base64::encode(&dna.multihash().unwrap());
+
+        let (_, context1) = test_instance_with_spoofed_dna(hacked_dna, dna_hash, "alice").unwrap();
+        let (_instance2, context2) = instance_by_name("jack", dna);
+
+        // Commit entry on attackers node
+        let entry = test_entry();
+        let _entry_address = block_on(author_entry(&entry, None, &context1)).unwrap();
+
+        // Get header which we need to trigger hold_entry_workflow
+        let agent1_state = context1.state().unwrap().agent();
+        let header = agent1_state
+            .get_header_for_entry(&entry)
+            .expect("There must be a header in the author's source chain after commit");
+        let entry_with_header = EntryWithHeader { entry, header };
+
+        // Call hold_entry_workflow on victim DHT node
+        let result = block_on(hold_link_workflow(&entry_with_header, &context2));
+
+        // ... and expect validation to fail with message defined in test WAT:
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            HolochainError::ValidationFailed(String::from("FAIL wat")),
+        );
+    }
+}

--- a/core/src/workflows/mod.rs
+++ b/core/src/workflows/mod.rs
@@ -1,4 +1,5 @@
 pub mod author_entry;
 pub mod get_entry_history;
 pub mod hold_entry;
+pub mod hold_link;
 pub mod respond_validation_package_request;

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -422,6 +422,7 @@ fn can_link_entries() {
 }
 
 #[test]
+#[cfg(not(windows))]
 fn can_roundtrip_links() {
     let (mut hc, _) = start_holochain_instance("can_roundtrip_links");
 

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -35,7 +35,8 @@ use holochain_wasm_utils::api_serialization::{
 };
 use std::{
     sync::{Arc, Mutex},
-    thread, time::Duration,
+    thread,
+    time::Duration,
 };
 use test_utils::*;
 
@@ -426,7 +427,8 @@ fn can_roundtrip_links() {
 
     // Create links
     let result = hc.call("test_zome", "test_cap", "links_roundtrip_create", r#"{}"#);
-    let maybe_address: Result<Address, String> = serde_json::from_str(&String::from(result.unwrap())).unwrap();
+    let maybe_address: Result<Address, String> =
+        serde_json::from_str(&String::from(result.unwrap())).unwrap();
     let address = maybe_address.unwrap();
 
     // Polling loop because the links have to get pushed over the mock network and then validated
@@ -440,13 +442,21 @@ fn can_roundtrip_links() {
         tries = tries + 1;
 
         // Now get_links on the base and expect both to be there
-        let result = hc.call("test_zome", "test_cap", "links_roundtrip_get", &format!(r#"{{"address": "{}"}}"#, address));
+        let result = hc.call(
+            "test_zome",
+            "test_cap",
+            "links_roundtrip_get",
+            &format!(r#"{{"address": "{}"}}"#, address),
+        );
         assert!(result.is_ok(), "result = {:?}", result);
         result_string = result.unwrap();
         let address_1 = Address::from("QmdQVqSuqbrEJWC8Va85PSwrcPfAB3EpG5h83C3Vrj62hN");
         let address_2 = Address::from("QmPn1oj8ANGtxS5sCGdKBdSBN63Bb6yBkmWrLc9wFRYPtJ");
 
-        println!("can_roundtrip_links result_string - try {}: {:?}", tries, result_string);
+        println!(
+            "can_roundtrip_links result_string - try {}: {:?}",
+            tries, result_string
+        );
         let expected: Result<GetLinksResult, HolochainError> = Ok(GetLinksResult::new(vec![
             address_1.clone(),
             address_2.clone(),

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -421,7 +421,6 @@ fn can_link_entries() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn can_roundtrip_links() {
     let (mut hc, _) = start_holochain_instance("can_roundtrip_links");
 

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -420,14 +420,6 @@ fn can_link_entries() {
     assert_eq!(result.unwrap(), JsonString::from(r#"{"Ok":null}"#));
 }
 
-// This test did fail before but passed locally for me now each of >20 tries on macOS.
-// It can fail because:
-// handle_links_roundtrip doesn't take into
-// account how long it takes for the links to propigate on the network
-// the correct test would be to wait for a propigation period
-//
-// It does fail on windows in the CI so for now I pull it in for all OS except
-// Windows so we have at least some integration link testing.
 #[test]
 #[cfg(not(windows))]
 fn can_roundtrip_links() {
@@ -438,28 +430,42 @@ fn can_roundtrip_links() {
     let maybe_address: Result<Address, String> = serde_json::from_str(&String::from(result.unwrap())).unwrap();
     let address = maybe_address.unwrap();
 
-    // Wait for links to be validated and propagated
-    thread::sleep(Duration::from_millis(1500));
-    
-    // Now get_links on the base and expect both to be there
-    let result = hc.call("test_zome", "test_cap", "links_roundtrip_get", &format!(r#"{{"address": "{}"}}"#, address));
-    assert!(result.is_ok(), "result = {:?}", result);
-    let result_string = result.unwrap();
-    let address_1 = Address::from("QmdQVqSuqbrEJWC8Va85PSwrcPfAB3EpG5h83C3Vrj62hN");
-    let address_2 = Address::from("QmPn1oj8ANGtxS5sCGdKBdSBN63Bb6yBkmWrLc9wFRYPtJ");
+    // Polling loop because the links have to get pushed over the mock network and then validated
+    // which includes requesting a validation package and receiving it over the mock network.
+    // All of that happens asynchronously and takes longer depending on computing resources
+    // (i.e. longer on a slow CI and when multiple tests are run simultaneausly).
+    let mut both_links_present = false;
+    let mut tries = 0;
+    let mut result_string = JsonString::from("");
+    while !both_links_present && tries < 10 {
+        tries = tries + 1;
 
-    println!("can_roundtrip_links result_string: {:?}", result_string);
-    let expected: Result<GetLinksResult, HolochainError> = Ok(GetLinksResult::new(vec![
-        address_1.clone(),
-        address_2.clone(),
-    ]));
-    let ordering1: bool = result_string == JsonString::from(expected);
+        // Now get_links on the base and expect both to be there
+        let result = hc.call("test_zome", "test_cap", "links_roundtrip_get", &format!(r#"{{"address": "{}"}}"#, address));
+        assert!(result.is_ok(), "result = {:?}", result);
+        result_string = result.unwrap();
+        let address_1 = Address::from("QmdQVqSuqbrEJWC8Va85PSwrcPfAB3EpG5h83C3Vrj62hN");
+        let address_2 = Address::from("QmPn1oj8ANGtxS5sCGdKBdSBN63Bb6yBkmWrLc9wFRYPtJ");
 
-    let expected: Result<GetLinksResult, HolochainError> =
-        Ok(GetLinksResult::new(vec![address_2, address_1]));
-    let ordering2: bool = result_string == JsonString::from(expected);
+        println!("can_roundtrip_links result_string - try {}: {:?}", tries, result_string);
+        let expected: Result<GetLinksResult, HolochainError> = Ok(GetLinksResult::new(vec![
+            address_1.clone(),
+            address_2.clone(),
+        ]));
+        let ordering1: bool = result_string == JsonString::from(expected);
 
-    assert!(ordering1 || ordering2, "result = {:?}", result_string);
+        let expected: Result<GetLinksResult, HolochainError> =
+            Ok(GetLinksResult::new(vec![address_2, address_1]));
+        let ordering2: bool = result_string == JsonString::from(expected);
+
+        both_links_present = ordering1 || ordering2;
+        if !both_links_present {
+            // Wait for links to be validated and propagated
+            thread::sleep(Duration::from_millis(500));
+        }
+    }
+
+    assert!(both_links_present, "result = {:?}", result_string);
 }
 
 #[test]

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -128,7 +128,7 @@ fn handle_link_two_entries() -> ZomeApiResult<()> {
     hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")
 }
 
-fn handle_links_roundtrip() -> ZomeApiResult<GetLinksResult> {
+fn handle_links_roundtrip_create() -> ZomeApiResult<Address> {
     let entry_1 = Entry::App(
         "testEntryType".into(),
         EntryStruct {
@@ -155,8 +155,11 @@ fn handle_links_roundtrip() -> ZomeApiResult<GetLinksResult> {
 
     hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")?;
     hdk::link_entries(&entry_1.address(), &entry_3.address(), "test-tag")?;
+    Ok(entry_1.address())
+}
 
-    hdk::get_links(&entry_1.address(), "test-tag")
+fn handle_links_roundtrip_get(address: Address) -> ZomeApiResult<GetLinksResult>{
+    hdk::get_links(&address, "test-tag")
 }
 
 fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
@@ -466,10 +469,16 @@ define_zome! {
                 handler: handle_link_two_entries
             }
 
-            links_roundtrip: {
+            links_roundtrip_create: {
                 inputs: | |,
+                outputs: |result: ZomeApiResult<Address>|,
+                handler: handle_links_roundtrip_create
+            }
+
+            links_roundtrip_get: {
+                inputs: |address: Address|,
                 outputs: |result: ZomeApiResult<GetLinksResult>|,
-                handler: handle_links_roundtrip
+                handler: handle_links_roundtrip_get
             }
 
             link_validation: {


### PR DESCRIPTION
Similar to https://github.com/holochain/holochain-rust/pull/736 on which this sits on top.

# Only hold valid links in the DHT
New workflow 
```rust
pub async fn hold_link_workflow<'a>(
    entry_with_header: &'a EntryWithHeader,
    context: &'a Arc<Context>,
) -> Result<Address, HolochainError>
``` 
that runs the full validation process on links before adding them to the local DHT shard.

Used in the network handler for `ProtocolWrapper::StoreDhtMeta`

# Pre-/Side work
* Since this broke the `can_roundtrip_links` test again, I've refactored it to also do polling for the result.
* To see if this fixes it for windows again I've removed the `#[cfg(not(windows))]` for that test.

# Scenario test that simulates an attack
The test
```rust
fn test_reject_invalid_link_on_hold_workflow()
```
creates an instance that has a different DNA with loose validation rules but that spoofes its DNA hash to be in the same mock network as the second instance on which we expect the entry validation to fail.




