### PR TITLE
Add regex-based "glob" pattern matching to hdk::query (OLD: See #781)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ cobertura.xml
 
 .idea
 .DS_Store
+*~
 /**/Makefile
 !/Makefile
 .vs

--- a/.gitignore
+++ b/.gitignore
@@ -18,13 +18,17 @@ cobertura.xml
 
 .idea
 .DS_Store
-*~
 /**/Makefile
 !/Makefile
 .vs
 *.hcpkg
 # symlinked Makefile for docker hub
 !/docker/Makefile
+
+# Editor temporary files
+*~
+.\#*
+\#*\#
 
 # Things being generated on the FS that should not be
 container/example-config/tmp-storage/*

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -70,7 +70,7 @@ pub fn handle_my_posts_as_commited() -> ZomeApiResult<Vec<Address>> {
     // This allows for pagination.
     // Future versions will also include more parameters for more complex
     // queries.
-    hdk::query( vec!["post".to_string()], 0, 0)
+    hdk::query( "post".into(), 0, 0)
 }
 
 pub fn handle_get_post(post_address: Address) -> ZomeApiResult<Option<Entry>> {

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -70,7 +70,7 @@ pub fn handle_my_posts_as_commited() -> ZomeApiResult<Vec<Address>> {
     // This allows for pagination.
     // Future versions will also include more parameters for more complex
     // queries.
-    hdk::query("post", 0, 0)
+    hdk::query( vec!["post".to_string()], 0, 0)
 }
 
 pub fn handle_get_post(post_address: Address) -> ZomeApiResult<Option<Entry>> {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,7 @@ holochain_net_connection = { path = "../net_connection" }
 base64 = "*"
 boolinator = "2.4.0"
 jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc" }
+globset = "0.4.2"
 
 [dev-dependencies]
 wabt = "0.7.2"

--- a/core/src/agent/chain_store.rs
+++ b/core/src/agent/chain_store.rs
@@ -5,8 +5,12 @@ use holochain_core_types::{
     },
     chain_header::ChainHeader,
     entry::entry_type::EntryType,
+    error::RibosomeErrorCode,
+    error::RibosomeErrorCode::*,
 };
 use std::sync::{Arc, RwLock};
+use globset::{ GlobBuilder, GlobSetBuilder };
+use std::str::FromStr;
 
 #[derive(Debug, Clone)]
 pub struct ChainStore {
@@ -37,6 +41,9 @@ impl ChainStore {
         ChainStoreIterator::new(self.content_storage.clone(), start_chain_header.clone())
     }
 
+    /// Scans the local chain for the first Entry of EntryType, and then creates a
+    /// ChainStoreTypeIter to return the sequence of all Entrys with the same EntryType. Requires a
+    /// single EntryType.
     pub fn iter_type(
         &self,
         start_chain_header: &Option<ChainHeader>,
@@ -52,23 +59,83 @@ impl ChainStore {
     pub fn query(
         &self,
         start_chain_header: &Option<ChainHeader>,
-        entry_type: &EntryType,
+        entry_type_names: &[&str],
         start: u32,
         limit: u32,
-    ) -> Vec<Address> {
-        let base_iter = self
-            .iter_type(start_chain_header, entry_type)
-            .map(|header| header.entry_address().clone())
-            .skip(start as usize);
+    ) -> Result<Vec<Address>,RibosomeErrorCode> {
+        // Get entry_type name(s), if any.  If empty/blank, returns the complete source chain.  A
+        // single matching entry type name with no glob pattern matching will use the single
+        // entry_type optimization.  Otherwise, we'll construct a GlobSet match and scan the list to
+        // create a pattern-match engine to select the EntryTypes we want.
+        fn is_glob( c: &char ) -> bool { "./*[]{}".chars().any( |y| y == *c ) }
+        fn is_glob_str( s: &str ) -> bool { s.chars().any( |c| is_glob( &c )) }
 
-        if limit > 0 {
-            base_iter.take(limit as usize).collect()
-        } else {
-            base_iter.collect()
-        }
+        Ok( match entry_type_names {
+            [] | [""] => {
+                // No filtering desired; uses bare .iter()
+                let base_iter = self.iter(start_chain_header)
+                    .skip(start as usize)
+                    .map(|header| header.entry_address().clone());
+                if limit > 0 {
+                    base_iter.take(limit as usize).collect()
+                } else {
+                    base_iter.collect()
+                }
+            }
+            [one] if ! is_glob_str( one ) => {
+                // Single EntryType without "glob" pattern; uses .iter_type()
+                let entry_type = match EntryType::from_str(&one) {
+                    Ok(inner) => inner,
+                    Err(..) => return Err(UnknownEntryType),
+                };
+                let base_iter = self.iter_type(start_chain_header, &entry_type)
+                    .skip(start as usize)
+                    .map(|header| header.entry_address().clone());
+                if limit > 0 {
+                    base_iter.take(limit as usize).collect()
+                } else {
+                    base_iter.collect()
+                }
+            }
+            rest => {
+                // 1 or more EntryTypes, may or may not include glob wildcards.  Create a
+                // GlobSetBuilder and add all the EntryType name patterns to it; this will recognize
+                // all matching EntryTypes using a single regex machine invocation.  In order to
+                // support .../... EntryType namespaces, force the '/' path separator to match
+                // literally.
+                let mut builder = GlobSetBuilder::new();
+                for name in rest {
+                    builder.add( match GlobBuilder::new( name )
+                                 .literal_separator( true )
+                                 .build() {
+                                     Ok(pat) => pat,
+                                     Err(_) => return Err( UnknownEntryType ),
+                                 } );
+                };
+                let globset = match builder.build() {
+                    Ok(set) => set,
+                    Err(_) => return Err( UnknownEntryType ),
+                };
+                let base_iter = self.iter(start_chain_header)
+                    .filter( |header| globset.matches( String::from( (*header.entry_type()).clone() )).len() > 0 )
+                    .skip( start as usize )
+                    .map( |header| header.entry_address().clone() );
+                if limit > 0 {
+                    base_iter.take(limit as usize).collect()
+                } else {
+                    base_iter.collect()
+                }
+            }
+        })
     }
 }
 
+/// Access each Entry
+/// 
+/// # Remarks
+///
+/// Locates the next Entry by following ChainHeader's .link
+/// 
 pub struct ChainStoreIterator {
     content_storage: Arc<RwLock<dyn ContentAddressableStorage>>,
     current: Option<ChainHeader>,
@@ -86,6 +153,7 @@ impl ChainStoreIterator {
     }
 }
 
+/// Follows ChainHeader.link through every previous Entry (of any EntryType) in the chain 
 impl Iterator for ChainStoreIterator {
     type Item = ChainHeader;
 
@@ -114,6 +182,15 @@ impl Iterator for ChainStoreIterator {
     }
 }
 
+/// Quickly access each Entry of a single known EntryType
+/// 
+/// # Remarks
+///
+/// Iterates over subsequent instances of the same EntryType using .link_same_type.
+/// 
+/// This Iterator will only work with a single EntryType; it cannot handle None (wildcard) or
+/// multiple EntryType queries.
+/// 
 pub struct ChainStoreTypeIterator {
     content_storage: Arc<RwLock<dyn ContentAddressableStorage>>,
     current: Option<ChainHeader>,
@@ -131,6 +208,7 @@ impl ChainStoreTypeIterator {
     }
 }
 
+/// Follows ChainHeader.link_same_type through every previous Entry of the same EntryType in the chain 
 impl Iterator for ChainStoreTypeIterator {
     type Item = ChainHeader;
 
@@ -145,7 +223,9 @@ impl Iterator for ChainStoreTypeIterator {
             // @TODO should this panic?
             // @see https://github.com/holochain/holochain-rust/issues/146
             .and_then(|linked_chain_header_address| {
-                (*storage.read().unwrap())
+                storage
+                    .read()
+                    .unwrap()
                     .fetch(linked_chain_header_address)
                     .expect("failed to fetch from CAS")
                     .map(|content| {
@@ -166,14 +246,15 @@ pub mod tests {
     use holochain_core_types::{
         cas::content::AddressableContent,
         chain_header::{test_chain_header, test_sources, ChainHeader},
-        entry::{test_entry, test_entry_b, test_entry_c},
-        signature::{test_signature_b, test_signature_c, test_signatures},
+        entry::{Entry, test_entry, test_entry_b, test_entry_c,
+                entry_type::{ AppEntryType, test_entry_type_b }},
+        signature::{Signature, test_signature_b, test_signature_c, test_signatures},
         time::test_iso_8601,
+        json::JsonString,
     };
-    use std::sync::{Arc, RwLock};
 
     pub fn test_chain_store() -> ChainStore {
-        ChainStore::new(Arc::new(RwLock::new(
+        ChainStore::new(std::sync::Arc::new(std::sync::RwLock::new(
             FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap())
                 .expect("could not create chain store"),
         )))
@@ -300,6 +381,7 @@ pub mod tests {
     fn query_test() {
         let chain_store = test_chain_store();
 
+        // Two entries w/ the same EntryType "testEntryTypeB".  
         let chain_header_a = test_chain_header();
         let entry = test_entry_b();
         let chain_header_b = ChainHeader::new(
@@ -307,8 +389,8 @@ pub mod tests {
             &entry.address(),
             &test_sources(),
             &vec![test_signature_b()],
-            &Some(chain_header_a.address()),
-            &None,
+            &Some(chain_header_a.address()),    // .link                (to previous entry)
+            &None,                              // .link_same_type      (to previous entry of same type)
             &None,
             &test_iso_8601(),
         );
@@ -323,6 +405,28 @@ pub mod tests {
             &None,
             &test_iso_8601(),
         );
+        let entry = Entry::App(AppEntryType::from("another/something"), JsonString::from("Hello, World!"));
+        let chain_header_d = ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &test_sources(),
+            &vec![Signature::from("sig-d")],
+            &Some(chain_header_c.address()),
+            &None,
+            &None,
+            &test_iso_8601(),
+        );
+        let entry = Entry::App(AppEntryType::from("another/different"), JsonString::from("Kthxbye"));
+        let chain_header_e = ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &test_sources(),
+            &vec![Signature::from("sig-e")],
+            &Some(chain_header_d.address()),
+            &None,
+            &None,
+            &test_iso_8601(),
+        );
 
         let storage = chain_store.content_storage.clone();
         (*storage.write().unwrap())
@@ -334,17 +438,223 @@ pub mod tests {
         (*storage.write().unwrap())
             .add(&chain_header_c)
             .expect("could not add header to cas");
+        (*storage.write().unwrap())
+            .add(&chain_header_d)
+            .expect("could not add header to cas");
+        (*storage.write().unwrap())
+            .add(&chain_header_e)
+            .expect("could not add header to cas");
 
-        let found = chain_store.query(&Some(chain_header_c.clone()), &entry.entry_type(), 0, 0);
+        // First, lets see if we can find the EntryType "testEntryTypeB" Entries
+        let found = chain_store.query(&Some(chain_header_e.clone()), &vec![test_entry_type_b().to_string().as_ref()], 0, 0).unwrap();
         let expected = vec![
             chain_header_c.entry_address().clone(),
             chain_header_b.entry_address().clone(),
         ];
         assert_eq!(expected, found);
 
-        let found = chain_store.query(&Some(chain_header_c.clone()), &entry.entry_type(), 0, 1);
+        // Then, limit to 1 at a time, starting from the 0'th match
+        let found = chain_store.query(&Some(chain_header_e.clone()), &vec![test_entry_type_b().to_string().as_ref()], 0, 1).unwrap();
         let expected = vec![chain_header_c.entry_address().clone()];
         assert_eq!(expected, found);
+
+        // Now query for all EntryTypes via entry_type == None
+        let found = chain_store.query(&Some(chain_header_e.clone()), &[], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_e.entry_address().clone(),
+            chain_header_d.entry_address().clone(),
+            chain_header_c.entry_address().clone(),
+            chain_header_b.entry_address().clone(),
+            chain_header_a.entry_address().clone()];
+        assert_eq!(expected, found);
+
+        // Test Glob matching, namespacing.
+
+        // Wildcard glob, all paths
+        let found = chain_store.query(&Some(chain_header_e.clone()), &vec!["**".to_string().as_ref()], 0, 0).unwrap();
+        assert_eq!(expected, found);
+
+        // Globbing plus some arbitrary EntryType names, thus matches everything again
+        let found = chain_store.query(&Some(chain_header_e.clone()), &vec!["another/*".to_string().as_ref(), "testEntryType*"], 0, 0).unwrap();
+        assert_eq!(expected, found);
+
+        // Just globbing
+        let found = chain_store.query(&Some(chain_header_e.clone()), &vec!["another/*".to_string().as_ref()], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_e.entry_address().clone(),
+            chain_header_d.entry_address().clone(),
+        ];
+        assert_eq!(expected, found);
+
+        let entry = Entry::App(AppEntryType::from("ns/one"), JsonString::from("1"));
+        let chain_header_f = ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &test_sources(),
+            &vec![Signature::from("sig-f")],
+            &Some(chain_header_e.address()),
+            &None,
+            &None,
+            &test_iso_8601(),
+        );
+        let entry = Entry::App(AppEntryType::from("ns/sub/two"), JsonString::from("2"));
+        let chain_header_g = ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &test_sources(),
+            &vec![Signature::from("sig-g")],
+            &Some(chain_header_f.address()),
+            &None,
+            &None,
+            &test_iso_8601(),
+        );
+        let entry = Entry::App(AppEntryType::from("ns/sub/three"), JsonString::from("3"));
+        let chain_header_h = ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &test_sources(),
+            &vec![Signature::from("sig-g")],
+            &Some(chain_header_g.address()),
+            &None,
+            &None,
+            &test_iso_8601(),
+        );
+        (*storage.write().unwrap())
+            .add(&chain_header_f)
+            .expect("could not add header to cas");
+        (*storage.write().unwrap())
+            .add(&chain_header_g)
+            .expect("could not add header to cas");
+        (*storage.write().unwrap())
+            .add(&chain_header_h)
+            .expect("could not add header to cas");
+        
+        // Multiple complex globs.  The leading '**/' matches 0 or more leading .../ segments, so returns
+        let found = chain_store.query(&Some(chain_header_h.clone()), &vec!["another/*", "ns/**/t*"], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_h.entry_address().clone(),
+            chain_header_g.entry_address().clone(),
+            chain_header_e.entry_address().clone(),
+            chain_header_d.entry_address().clone(),
+        ];
+        assert_eq!(expected, found);
+
+        // So, we should be able to find EntryType names by suffix at any depth
+        let found = chain_store.query(&Some(chain_header_h.clone()), &vec!["**/*{e,B}"], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_h.entry_address().clone(), // .../three
+            chain_header_f.entry_address().clone(), // .../one
+            chain_header_c.entry_address().clone(), // testEntryTypeB
+            chain_header_b.entry_address().clone(), // testEntryTypeB
+            chain_header_a.entry_address().clone(), // testEntryType
+        ];
+        assert_eq!(expected, found);
+        
+        let entry = Entry::App(AppEntryType::from("%system_entry_type"), JsonString::from("System Entry"));
+        let chain_header_i = ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &test_sources(),
+            &vec![Signature::from("sig-i")],
+            &Some(chain_header_h.address()),
+            &None,
+            &None,
+            &test_iso_8601(),
+        );
+        (*storage.write().unwrap())
+            .add(&chain_header_i)
+            .expect("could not add header to cas");
+
+        // Find EntryTypes which are/not System (start with '%'), and end in 'e'
+        let found = chain_store.query(&Some(chain_header_i.clone()), &vec!["[!%]*e"], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_a.entry_address().clone(), // testEntryType
+        ];
+        assert_eq!(expected, found);
+        // Including all namespaced EntryTypes
+        let found = chain_store.query(&Some(chain_header_i.clone()), &vec!["**/[!%]*e"], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_h.entry_address().clone(), // .../three
+            chain_header_f.entry_address().clone(), // .../one
+            chain_header_a.entry_address().clone(), // testEntryType
+        ];
+        assert_eq!(expected, found);
+        let found = chain_store.query(&Some(chain_header_i.clone()), &vec!["%*e"], 0, 0).unwrap();
+        let expected = vec![
+            chain_header_i.entry_address().clone(), // %system_entry_type
+        ];
+        assert_eq!(expected, found);
+        
+    }
+
+    use globset::{ Glob, GlobBuilder, GlobSetBuilder };
+
+    #[test]
+    /// show query() globbing implementation
+    fn glob_query_test() {
+
+        let glob = match Glob::new( "*.rs" ) {
+            Ok(pat) => pat.compile_matcher(),
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        };
+        assert!(glob.is_match( "foo.rs" ));
+        assert!(glob.is_match( "foo/bar.rs" )); // separators not specially handled
+        assert!(!glob.is_match( "Cargo.toml" ));
+
+        let glob = match GlobBuilder::new( "*.rs" ).literal_separator(true).build() {
+            Ok(pat) => pat.compile_matcher(),
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        };
+        assert!(glob.is_match( "foo.rs" ));
+        assert!(!glob.is_match( "foo/bar.rs" )); // separators now are special
+        assert!(!glob.is_match( "Cargo.toml" ));
+        
+        let mut builder = GlobSetBuilder::new();
+        // A GlobBuilder can be used to configure each glob's match semantics
+        // independently.  Either using simple Glob::new (default semantics):
+        builder.add( match Glob::new( "*.rs" ) {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        builder.add( match Glob::new( "src/lib.rs" ) {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        builder.add(match Glob::new( "src/**/foo.rs" ) {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        let set = match builder.build() {
+            Ok(globset) => globset,
+            Err(_) => { panic!( "Couldn't build GlobSetBuilder" ) }
+        };
+        assert_eq!( set.matches( "src/bar/baz/foo.rs" ), vec![0, 2] ); // separators are not treated specially; '*' matches them
+
+        // Or using GlobBuilder::new for specific modifiers on each pattern's behaviour
+        let mut builder = GlobSetBuilder::new();
+        builder.add( match GlobBuilder::new( "*.rs" ).literal_separator(true).build() {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        builder.add( match GlobBuilder::new( "src/lib.rs" ).literal_separator(true).build() {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        builder.add( match GlobBuilder::new( "src/**/foo.rs" ).literal_separator(true).build() {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        builder.add( match GlobBuilder::new( "**/foo.rs" ).literal_separator(true).build() {
+            Ok(pat) => pat,
+            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+        });
+        let set = match builder.build() {
+            Ok(globset) => globset,
+            Err(_) => { panic!( "Couldn't build GlobSetBuilder" ) }
+        };
+        assert_eq!( set.matches( "src/bar/baz/foo.rs" ), vec![2,3] ); // *.rs no longer matches, due to '/' separators
+        assert_eq!( set.matches( "foo.rs" ), vec![0,3] ); // but, any number of leading '/' are matched by a '**/...'
+
     }
 
 }

--- a/core/src/agent/chain_store.rs
+++ b/core/src/agent/chain_store.rs
@@ -1,4 +1,4 @@
-use globset::{ GlobBuilder, GlobSetBuilder };
+use globset::{GlobBuilder, GlobSetBuilder};
 use holochain_core_types::{
     cas::{
         content::{Address, AddressableContent},
@@ -111,17 +111,16 @@ impl ChainStore {
                 // literally.
                 let mut builder = GlobSetBuilder::new();
                 for name in rest {
-                    builder.add( match GlobBuilder::new( name )
-                                 .literal_separator( true )
-                                 .build() {
-                                     Ok(pat) => pat,
-                                     Err(_) => return Err(UnknownEntryType),
-                                 } );
+                    builder.add(
+                        GlobBuilder::new( name )
+                            .literal_separator( true )
+                            .build()
+                            .map_err(|_| UnknownEntryType)?
+                    );
                 };
-                let globset = match builder.build() {
-                    Ok(set) => set,
-                    Err(_) => return Err(UnknownEntryType),
-                };
+                let globset = builder
+                    .build()
+                    .map_err(|_| UnknownEntryType)?;
                 let base_iter = self
                     .iter(start_chain_header)
                     .filter(|header|
@@ -676,7 +675,7 @@ pub mod tests {
 
         let glob = match Glob::new( "*.rs" ) {
             Ok(pat) => pat.compile_matcher(),
-            Err(_) => { panic!( "Couldn't craete new Glob" ) }
+            Err(_) => panic!( "Couldn't craete new Glob" ),
         };
         assert!(glob.is_match( "foo.rs" ));
         assert!(glob.is_match( "foo/bar.rs" )); // separators not specially handled

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,6 +39,7 @@ extern crate holochain_core_types;
 extern crate holochain_core_types_derive;
 extern crate base64;
 extern crate holochain_net_connection;
+extern crate globset;
 
 pub mod action;
 pub mod agent;

--- a/core/src/nucleus/ribosome/api/query.rs
+++ b/core/src/nucleus/ribosome/api/query.rs
@@ -1,5 +1,5 @@
 use crate::nucleus::ribosome::{api::ZomeApiResult, Runtime};
-use holochain_wasm_utils::api_serialization::QueryArgs;
+use holochain_wasm_utils::api_serialization::{QueryArgs, QueryArgsNames};
 use std::convert::TryFrom;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
@@ -59,15 +59,24 @@ pub fn invoke_query(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult 
     let top = agent
         .top_chain_header()
         .expect("Should have genesis entries.");
-    
-    let pats: Vec<&str> = query.entry_type_names
-                              .iter()
-                              .map(AsRef::as_ref)
-                              .collect(); // Vec<String> -> Vec[&str]
+
+    /*
+    // We can't do this because of lifespans...?
+    let pats:Vec<&str> = match query.entry_type_names {
+        QueryArgsNames::QueryList(list) => { // Vec<String> -> Vec[&str]
+            list.iter()
+                .map(AsRef::as_ref)
+                .collect()
+        }
+        QueryArgsNames::QueryName(name) => {
+            vec![&name] // String -> Vec<&str>
+        }
+     };
+
     runtime.store_result(
         match agent.chain().query(
             &Some(top),
-            pats.as_slice(), // Vec[&str] -> &[&str]
+            pats.as_slice(), // Vec<&str> -> &[&str]
             query.start,
             query.limit,
         ) {
@@ -76,6 +85,44 @@ pub fn invoke_query(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult 
             // UnknownEntryType code here, rather than trying to return a specific error code.
             Ok(result) => Ok(result),
             Err(_code) => return ribosome_error_code!(UnknownEntryType),
+        }
+    */
+
+    // TODO: Code duplication; handle the query enum for String/Vec<String> without copying code
+    runtime.store_result(
+        match query.entry_type_names {
+            QueryArgsNames::QueryList(pats) => { // Vec<String> -> Vec[&str]
+                let refs:Vec<&str> = pats.iter()
+                        .map(AsRef::as_ref)
+                        .collect();
+                match agent.chain().query(
+                    &Some(top),
+                    refs.as_slice(), // Vec<&str> -> Vec[&str]
+                    query.start,
+                    query.limit,
+                ) {
+                    // TODO: the Err(_code) is the RibosomeErrorCode, but we can't import that type here.
+                    // Perhaps return chain().query should return Some(result)/None instead, and the fixed
+                    // UnknownEntryType code here, rather than trying to return a specific error code.
+                    Ok(result) => Ok(result),
+                    Err(_code) => return ribosome_error_code!(UnknownEntryType),
+                }
+            },
+            QueryArgsNames::QueryName(name) => {
+                let refs:Vec<&str> = vec![&name]; // String -> Vec<&str>
+                match agent.chain().query(
+                    &Some(top),
+                    refs.as_slice(), // Vec[&str] -> &[&str]
+                    query.start,
+                    query.limit,
+                ) {
+                    // TODO: the Err(_code) is the RibosomeErrorCode, but we can't import that type here.
+                    // Perhaps return chain().query should return Some(result)/None instead, and the fixed
+                    // UnknownEntryType code here, rather than trying to return a specific error code.
+                    Ok(result) => Ok(result),
+                    Err(_code) => return ribosome_error_code!(UnknownEntryType),
+                }
+            }
         }
     )
 }

--- a/core/src/nucleus/ribosome/api/query.rs
+++ b/core/src/nucleus/ribosome/api/query.rs
@@ -49,7 +49,6 @@ use wasmi::{RuntimeArgs, RuntimeValue};
 pub fn invoke_query(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
     // deserialize args
     let args_str = runtime.load_json_string_from_args(&args);
-    println!("invoke_query: {}", args_str);
     let query = match QueryArgs::try_from(args_str) {
         Ok(input) => input,
         Err(..) => return ribosome_error_code!(ArgumentDeserializationFailed),

--- a/core/src/nucleus/ribosome/api/query.rs
+++ b/core/src/nucleus/ribosome/api/query.rs
@@ -1,25 +1,58 @@
 use crate::nucleus::ribosome::{api::ZomeApiResult, Runtime};
-use holochain_core_types::entry::entry_type::EntryType;
 use holochain_wasm_utils::api_serialization::QueryArgs;
-use std::{convert::TryFrom, str::FromStr};
+use std::convert::TryFrom;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
 /// ZomeApiFunction::query function code
 /// args: [0] encoded MemoryAllocation as u32
 /// Expected complex argument: ?
 /// Returns an HcApiReturnCode as I32
+/// 
+/// Specify 0 or more simple or "glob" patterns matching EntryType names.
+/// 
+/// The empty String or an empty Vec matches all.  The '*' glob pattern matches all simple EntryType
+/// names (with no '/'), while the ** pattern matches everything (use "" or [] for efficiency).
+///  
+/// // [ ]
+/// // [ "" ]
+/// // [ "**" ]
+/// 
+/// Namespaces (groups of related EntryType names) can be queried easily, eg:
+/// 
+/// // [ "name/*" ]
+/// 
+/// Several simple names and/or "glob" patterns can be supplied, and are efficiently
+/// searched for in a single pass using a single efficient Regular Expression engine:
+/// 
+/// // [ "name/*", "and_another", "SomethingElse" ]
+/// 
+/// EntryType names can be excluded, eg. to return every simple (non-namespaced) EntryType except System:
+/// 
+/// // [ "[!%]*" ]
+/// 
+/// To match a pattern, including all namespaced EntryType names, eg. every EntryType except System:
+/// 
+/// // [ "**/[!%]*" ]
+/// 
+/// The following standard "glob" patterns are supported:
+/// 
+/// // Pattern	Match
+/// // =======     =====
+/// // .           One character (other than a '/')
+/// // [abcd]      One of a set of characters
+/// // [a-d]	Once range of characters
+/// // [!a-d]	Once range of characters
+/// // {abc,123}   one of a number of sequences of characters
+/// // *           Zero or more of any character
+/// // **/         Zero or more namespace components
+/// 
 pub fn invoke_query(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
     // deserialize args
     let args_str = runtime.load_json_string_from_args(&args);
+    println!("invoke_query: {}", args_str);
     let query = match QueryArgs::try_from(args_str) {
         Ok(input) => input,
         Err(..) => return ribosome_error_code!(ArgumentDeserializationFailed),
-    };
-
-    // Get entry_type
-    let entry_type = match EntryType::from_str(&query.entry_type_name) {
-        Ok(inner) => inner,
-        Err(..) => return ribosome_error_code!(UnknownEntryType),
     };
 
     // Perform query
@@ -27,11 +60,23 @@ pub fn invoke_query(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult 
     let top = agent
         .top_chain_header()
         .expect("Should have genesis entries.");
-
-    runtime.store_result(Ok(agent.chain().query(
-        &Some(top),
-        &entry_type,
-        query.start,
-        query.limit,
-    )))
+    
+    let pats: Vec<&str> = query.entry_type_names
+                              .iter()
+                              .map(AsRef::as_ref)
+                              .collect(); // Vec<String> -> Vec[&str]
+    runtime.store_result(
+        match agent.chain().query(
+            &Some(top),
+            pats.as_slice(), // Vec[&str] -> &[&str]
+            query.start,
+            query.limit,
+        ) {
+            // TODO: the Err(_code) is the RibosomeErrorCode, but we can't import that type here.
+            // Perhaps return chain().query should return Some(result)/None instead, and the fixed
+            // UnknownEntryType code here, rather than trying to return a specific error code.
+            Ok(result) => Ok(result),
+            Err(_code) => return ribosome_error_code!(UnknownEntryType),
+        }
+    )
 }

--- a/core_types/src/entry/entry_type.rs
+++ b/core_types/src/entry/entry_type.rs
@@ -117,7 +117,8 @@ impl EntryType {
     /// Checks entry_type_name is valid
     pub fn has_valid_app_name(entry_type_name: &str) -> bool {
         // TODO #445 - do a real regex test instead
-        // must not be empty
+        // - must not be empty
+        // - must not contain any glob wildcards
         entry_type_name.len() > 0
         // Must not have sys_prefix
             && &entry_type_name[0..1] != "%"

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -855,7 +855,7 @@ pub fn get_links<S: Into<String>>(base: &Address, tag: S) -> ZomeApiResult<GetLi
 }
 
 /// Returns a list of entries from your local source chain, that match a given type.
-/// entry_type_name: Specify type of entry to retrieve
+/// entry_type_names: Specify type of entry(s) to retrieve, as a Vec<String> of 0 or more names.
 /// limit: Max number of entries to retrieve
 /// # Examples
 /// ```rust
@@ -867,18 +867,18 @@ pub fn get_links<S: Into<String>>(base: &Address, tag: S) -> ZomeApiResult<GetLi
 ///
 /// # fn main() {
 /// pub fn handle_my_posts_as_commited() -> ZomeApiResult<Vec<Address>> {
-///     hdk::query("post", 0, 0)
+///     hdk::query("post".into(), 0, 0)
 /// }
 /// # }
 /// ```
-pub fn query(entry_type_name: &str, start: u32, limit: u32) -> ZomeApiResult<QueryResult> {
+pub fn query(entry_type_names: Vec<String>, start: u32, limit: u32) -> ZomeApiResult<QueryResult> {
     let mut mem_stack: SinglePageStack = unsafe { G_MEM_STACK.unwrap() };
 
     // Put args in struct and serialize into memory
     let allocation_of_input = store_as_json(
         &mut mem_stack,
         QueryArgs {
-            entry_type_name: entry_type_name.to_string(),
+            entry_type_names,
             start,
             limit,
         },

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -17,7 +17,7 @@ use holochain_wasm_utils::{
         get_links::{GetLinksArgs, GetLinksResult},
         link_entries::LinkEntriesArgs,
         send::SendArgs,
-        QueryArgs, QueryResult, UpdateEntryArgs, ZomeFnCallArgs,
+        QueryArgs, QueryArgsNames, QueryResult, UpdateEntryArgs, ZomeFnCallArgs,
     },
     holochain_core_types::{
         hash::HashString,
@@ -871,7 +871,7 @@ pub fn get_links<S: Into<String>>(base: &Address, tag: S) -> ZomeApiResult<GetLi
 /// }
 /// # }
 /// ```
-pub fn query(entry_type_names: Vec<String>, start: u32, limit: u32) -> ZomeApiResult<QueryResult> {
+pub fn query(entry_type_names: QueryArgsNames, start: u32, limit: u32) -> ZomeApiResult<QueryResult> {
     let mut mem_stack: SinglePageStack = unsafe { G_MEM_STACK.unwrap() };
 
     // Put args in struct and serialize into memory

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -529,7 +529,7 @@ fn can_check_query() {
         "test_zome",
         "test_cap",
         "check_query",
-        r#"{ "entry_type_name": "testEntryType", "limit": "0" }"#,
+        r#"{ "entry_type_names": ["testEntryType"], "limit": "0" }"#,
     );
     assert!(result.is_ok(), "result = {:?}", result);
 

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -24,6 +24,7 @@ use holochain_wasm_utils::{
     api_serialization::{
         get_entry::{GetEntryOptions, GetEntryResult},
         get_links::GetLinksResult,
+        query::QueryArgsNames,
     },
     holochain_core_types::{
         cas::content::{Address, AddressableContent},
@@ -173,22 +174,22 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
         Err(ZomeApiError::Internal(s.to_owned()))
     }
 
-    // Query DNA entry
-    let addresses = hdk::query(vec![EntryType::Dna.to_string()], 0, 0).unwrap();
+    // Query DNA entry; EntryTypes will convert into the appropriate single-name enum type
+    let addresses = hdk::query(EntryType::Dna.into(), 0, 0).unwrap();
 
     if !addresses.len() == 1 {
         return err("Dna Addresses not length 1");
     }
 
     // Query AgentId entry
-    let addresses = hdk::query(vec![EntryType::AgentId.to_string()], 0, 0).unwrap();
+    let addresses = hdk::query(QueryArgsNames::QueryList(vec![EntryType::AgentId.to_string()]), 0, 0).unwrap();
 
     if !addresses.len() == 1 {
         return err("AgentId Addresses not length 1");
     }
 
-    // Query unknown entry
-    let addresses = hdk::query(vec!["bad_type".to_string()], 0, 0).unwrap();
+    // Query unknown entry; An &str will convert to a QueryArgsNames::QueryName
+    let addresses = hdk::query("bad_type".into(), 0, 0).unwrap();
 
     if !addresses.len() == 0 {
         return err("bad_type Addresses not length 1");
@@ -203,7 +204,7 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
         .into(),
     ))
     .unwrap();
-    let addresses = hdk::query(vec!["testEntryType".to_string()], 0, 1).unwrap();
+    let addresses = hdk::query(QueryArgsNames::QueryName("testEntryType".to_string()), 0, 1).unwrap();
 
     if !addresses.len() == 1 {
         return err("testEntryType Addresses not length 1");
@@ -227,13 +228,23 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     ))
     .unwrap();
 
-    let addresses = hdk::query(vec!["testEntryType".to_string()], 0, 0).unwrap();
+    let addresses = hdk::query("testEntryType".into(), 0, 0).unwrap();
 
     if !addresses.len() == 3 {
         return err("testEntryType Addresses not length 3");
     }
 
-    hdk::query(vec!["testEntryType".to_string()], 0, 1)
+    // See if we can get all System EntryTypes, and then System + testEntryType
+    let addresses = hdk::query("[%]*".into(), 0, 0).unwrap();
+    if !addresses.len() == 2 {
+        return err("System Addresses not length 3");
+    }
+    let addresses = hdk::query(vec!["[%]*","testEntryType"].into(), 0, 0).unwrap();
+    if !addresses.len() == 5 {
+        return err("System Addresses not length 3");
+    }
+
+    hdk::query(QueryArgsNames::QueryName("testEntryType".to_string()), 0, 1)
 }
 
 fn handle_check_app_entry_address() -> ZomeApiResult<Address> {

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -168,26 +168,27 @@ fn handle_links_roundtrip_get(address: Address) -> ZomeApiResult<GetLinksResult>
 }
 
 fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
+    println!("handle_check_query");
     fn err(s: &str) -> ZomeApiResult<Vec<Address>> {
         Err(ZomeApiError::Internal(s.to_owned()))
     }
 
     // Query DNA entry
-    let addresses = hdk::query(&EntryType::Dna.to_string(), 0, 0).unwrap();
+    let addresses = hdk::query(vec![EntryType::Dna.to_string()], 0, 0).unwrap();
 
     if !addresses.len() == 1 {
         return err("Dna Addresses not length 1");
     }
 
     // Query AgentId entry
-    let addresses = hdk::query(&EntryType::AgentId.to_string(), 0, 0).unwrap();
+    let addresses = hdk::query(vec![EntryType::AgentId.to_string()], 0, 0).unwrap();
 
     if !addresses.len() == 1 {
         return err("AgentId Addresses not length 1");
     }
 
     // Query unknown entry
-    let addresses = hdk::query("bad_type", 0, 0).unwrap();
+    let addresses = hdk::query(vec!["bad_type".to_string()], 0, 0).unwrap();
 
     if !addresses.len() == 0 {
         return err("bad_type Addresses not length 1");
@@ -202,7 +203,7 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
         .into(),
     ))
     .unwrap();
-    let addresses = hdk::query("testEntryType", 0, 1).unwrap();
+    let addresses = hdk::query(vec!["testEntryType".to_string()], 0, 1).unwrap();
 
     if !addresses.len() == 1 {
         return err("testEntryType Addresses not length 1");
@@ -226,13 +227,13 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     ))
     .unwrap();
 
-    let addresses = hdk::query("testEntryType", 0, 0).unwrap();
+    let addresses = hdk::query(vec!["testEntryType".to_string()], 0, 0).unwrap();
 
     if !addresses.len() == 3 {
         return err("testEntryType Addresses not length 3");
     }
 
-    hdk::query("testEntryType", 0, 1)
+    hdk::query(vec!["testEntryType".to_string()], 0, 1)
 }
 
 fn handle_check_app_entry_address() -> ZomeApiResult<Address> {

--- a/wasm_utils/src/api_serialization/query.rs
+++ b/wasm_utils/src/api_serialization/query.rs
@@ -1,8 +1,7 @@
 use holochain_core_types::{cas::content::Address, error::HolochainError, json::*};
-
 #[derive(Deserialize, Default, Debug, Serialize, DefaultJson)]
 pub struct QueryArgs {
-    pub entry_type_name: String,
+    pub entry_type_names: Vec<String>,
     pub start: u32,
     pub limit: u32,
 }

--- a/wasm_utils/src/api_serialization/query.rs
+++ b/wasm_utils/src/api_serialization/query.rs
@@ -1,8 +1,54 @@
-use holochain_core_types::{cas::content::Address, error::HolochainError, json::*};
+use holochain_core_types::{cas::content::Address, error::HolochainError, json::*, entry::entry_type::EntryType};
 
+// QueryArgsNames -- support querying single/multiple EntryType names
+#[derive(Deserialize, Debug, Serialize, DefaultJson, Clone, PartialEq)]
+#[serde(untagged)] // No type in serialized data; try deserializing as a String, then as a Vec<String>
+pub enum QueryArgsNames {
+    QueryName(String),
+    QueryList(Vec<String>),
+}
+
+impl Default for QueryArgsNames {
+    fn default() -> QueryArgsNames {
+        QueryArgsNames::QueryList( vec![] )
+    }
+}
+
+// Handle automatic convertions from various types into the appropriate QueryArgsNames enum type
+impl From<EntryType> for QueryArgsNames {
+    fn from( e: EntryType ) -> QueryArgsNames {
+        QueryArgsNames::QueryName( e.to_string() )
+    }
+}
+
+impl From<String> for QueryArgsNames {
+    fn from( s: String ) -> QueryArgsNames {
+        QueryArgsNames::QueryName( s )
+    }
+}
+
+impl From<&str> for QueryArgsNames {
+    fn from( s: &str ) -> QueryArgsNames {
+        QueryArgsNames::QueryName( s.to_string() )
+    }
+}
+
+impl From<Vec<String>> for QueryArgsNames {
+    fn from( v: Vec<String> ) -> QueryArgsNames {
+        QueryArgsNames::QueryList( v )
+    }
+}
+
+impl From<Vec<&str>> for QueryArgsNames {
+    fn from( v: Vec<&str> ) -> QueryArgsNames {
+        QueryArgsNames::QueryList( v.iter().map(|s| s.to_string()).collect() )
+    }
+}
+
+// Query{Args,Result} -- the query API parameters and return type
 #[derive(Deserialize, Default, Debug, Serialize, DefaultJson)]
 pub struct QueryArgs {
-    pub entry_type_names: Vec<String>,
+    pub entry_type_names: QueryArgsNames,
     pub start: u32,
     pub limit: u32,
 }

--- a/wasm_utils/src/api_serialization/query.rs
+++ b/wasm_utils/src/api_serialization/query.rs
@@ -1,4 +1,5 @@
 use holochain_core_types::{cas::content::Address, error::HolochainError, json::*};
+
 #[derive(Deserialize, Default, Debug, Serialize, DefaultJson)]
 pub struct QueryArgs {
     pub entry_type_names: Vec<String>,

--- a/wasm_utils/tests/integration-test.rs
+++ b/wasm_utils/tests/integration-test.rs
@@ -68,7 +68,7 @@ fn call_store_as_json_str_ok() {
 fn call_store_as_json_obj_ok() {
     let call_result = call_zome_function_with_hc("test_store_as_json_obj_ok");
     assert_eq!(
-        JsonString::from("{\"value\":\"fish\"}"),
+        JsonString::from("{\"value\":\"fish\",\"list\":[\"hello\",\"world!\"]}"),
         call_result.unwrap()
     );
 }
@@ -114,7 +114,7 @@ fn call_load_json_from_raw_err() {
 fn call_load_json_ok() {
     let call_result = call_zome_function_with_hc("test_load_json_ok");
     assert_eq!(
-        JsonString::from("{\"value\":\"fish\"}"),
+        JsonString::from("{\"value\":\"fish\",\"list\":[\"hello\",\"world!\"]}"),
         call_result.unwrap()
     );
 }
@@ -124,6 +124,7 @@ fn call_load_json_err_test() {
     #[derive(Serialize, Deserialize, Debug, DefaultJson)]
     struct TestStruct {
         value: String,
+        list: Vec<String>,
     }
     type TestResult = Result<TestStruct, HolochainError>;
 
@@ -169,7 +170,7 @@ fn call_stacked_json_str() {
 fn call_stacked_json_obj() {
     let call_result = call_zome_function_with_hc("test_stacked_json_obj");
     assert_eq!(
-        JsonString::from("{\"value\":\"first\"}"),
+        JsonString::from("{\"value\":\"first\",\"list\":[\"hello\",\"world!\"]}"),
         call_result.unwrap()
     );
 }

--- a/wasm_utils/wasm-test/integration-test/src/lib.rs
+++ b/wasm_utils/wasm-test/integration-test/src/lib.rs
@@ -19,11 +19,13 @@ use std::os::raw::c_char;
 #[derive(Serialize, Default, Clone, PartialEq, Deserialize, Debug, DefaultJson)]
 struct TestStruct {
     value: String,
+    list: Vec<String>,
 }
 
 #[derive(Serialize, Default, Clone, PartialEq, Deserialize, Debug, DefaultJson)]
 struct OtherTestStruct {
     other: String,
+    list: Vec<String>,
 }
 
 #[no_mangle]
@@ -74,6 +76,7 @@ pub extern "C" fn test_store_as_json_obj_ok(_: u32) -> u32 {
     let mut stack = SinglePageStack::default();
     let obj = TestStruct {
         value: "fish".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     };
     assert_eq!(0, stack.top());
     let res = store_as_json(&mut stack, obj.clone());
@@ -101,6 +104,7 @@ pub extern "C" fn test_store_as_json_err(_: u32) -> u32 {
     let mut stack = maybe_stack.unwrap();
     let obj = TestStruct {
         value: "fish".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     };
     let res = store_as_json(&mut stack, obj.clone());
     assert!(res.is_err());
@@ -112,6 +116,7 @@ pub extern "C" fn test_load_json_from_raw_ok(_: u32) -> u32 {
     let mut stack = SinglePageStack::default();
     let obj = TestStruct {
         value: "fish".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     };
     let res = store_as_json(&mut stack, obj.clone());
     let ptr = res.unwrap().offset() as *mut c_char;
@@ -125,6 +130,7 @@ pub extern "C" fn test_load_json_from_raw_err(_: u32) -> u32 {
     let mut stack = SinglePageStack::default();
     let obj = TestStruct {
         value: "fish".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     };
     assert_eq!(0, stack.top());
     let store_res = store_as_json(&mut stack, obj.clone());
@@ -192,9 +198,11 @@ pub extern "C" fn test_stacked_json_obj(_: u32) -> u32 {
     let mut stack = SinglePageStack::default();
     let first = store_as_json_into_encoded_allocation(&mut stack, TestStruct {
         value: "first".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     });
     let _second = store_as_json_into_encoded_allocation(&mut stack, TestStruct {
         value: "second".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     });
     first as u32
 }
@@ -204,12 +212,14 @@ pub extern "C" fn test_stacked_mix(_: u32) -> u32 {
     let mut stack = SinglePageStack::default();
     let _first = store_as_json_into_encoded_allocation(&mut stack, TestStruct {
         value: "first".to_string(),
+        list: vec!["hello".to_string(), "world!".to_string()],
     });
     let _second = store_as_json_into_encoded_allocation(&mut stack, "second");
     let third = store_string_into_encoded_allocation(&mut stack, "third");
     let _fourth = store_as_json_into_encoded_allocation(&mut stack, "fourth");
     let _fifth = store_as_json_into_encoded_allocation(&mut stack, TestStruct {
         value: "fifth".to_string(),
+        list: vec!["fifthlist".to_string()],
     });
     third as u32
 }


### PR DESCRIPTION
o Change the Holochain query API to accept a `Vec<String>` vs. `String`
o If multiple EntryType names (or one with "glob" wildcards) is used,
  then produce a GlobSetBuilder matcher to recognize the selected names.

There is no way to get more than a single EntryType via hdk::query.

The primary purpose of this change is to support querying multiple EntryType names in a single hdk::query request.  To do this efficiently, a single regex encompassing all of the desired EntryType names is produced.

The globset::GlobSetBuilder is used to do this, and also supports the full "glob" pattern matching on EntryType names.  This includes the concept of path-like namespaces for EntryType names.  For example, if you have 3 EntryTypes `"one"`, `"two"` and `"three"` related to the concept "tx" in your Holochain application, you can name them `"tx/one"`, `"tx/two"` and `"tx/three"`.  Then, when you want to query all of your tx-related entries from your local chain, you'd call

```
hdk::query( vec!("tx/*".to_string()))
```

Later, when you add a fourth "tx/four" EntryType, the above code would automatically get all the tx-related EntryTypes.

You can also do things like get all EntryTypes except the System EntryTypes: `"[!%]*"`.

NOTE: Changes the hdk::query API!