### PR TITLE
use .into() more consistently for Entry::App

### DIFF
--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -30,15 +30,15 @@ pub fn handle_check_sum(num1: u32, num2: u32) -> ZomeApiResult<JsonString> {
 
 pub fn handle_post_address(content: String) -> ZomeApiResult<Address> {
     let post_entry = Entry::App(
-        AppEntryType::from("post"),
-        AppEntryValue::from(Post::new(&content, "now")),
+        "post".into(),
+        Post::new(&content, "now").into(),
     );
     hdk::entry_address(&post_entry)
 }
 
 pub fn handle_create_post(content: String, in_reply_to: Option<Address>) -> ZomeApiResult<Address> {
     let post_entry = Entry::App(
-        AppEntryType::from("post"),
+        "post".into(),
         Post::new(&content, "now").into(),
     );
 

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -3,7 +3,7 @@ use hdk::{
     error::ZomeApiResult,
     holochain_core_types::{
         cas::content::Address,
-        entry::{entry_type::AppEntryType, AppEntryValue, Entry},
+        entry::Entry,
         error::HolochainError,
         json::JsonString,
     },

--- a/container_api/wasm-test/src/lib.rs
+++ b/container_api/wasm-test/src/lib.rs
@@ -14,8 +14,6 @@ use holochain_core_types::{
 use holochain_wasm_utils::{memory_allocation::*, memory_serialization::*};
 use std::convert::TryInto;
 use holochain_core_types::entry::Entry;
-use holochain_core_types::entry::entry_type::AppEntryType;
-use holochain_core_types::entry::AppEntryValue;
 
 //-------------------------------------------------------------------------------------------------
 // HC DEBUG Function Call
@@ -114,7 +112,10 @@ fn hdk_commit(
     entry_value: &str,
 ) -> Result<Address, String> {
     // Put args in struct and serialize into memory
-    let entry = Entry::App(AppEntryType::from(entry_type_name.to_string()), AppEntryValue::from(entry_value.to_string()));
+    let entry = Entry::App(
+        entry_type_name.to_owned().into(),
+        entry_value.to_owned().into(),
+    );
     let allocation_of_input = store_as_json(mem_stack, JsonString::from(entry))?;
 
     // Call WASMI-able commit

--- a/core/src/nucleus/actions/mod.rs
+++ b/core/src/nucleus/actions/mod.rs
@@ -18,8 +18,8 @@ pub mod tests {
             zome::{capabilities::Capability, entry_types::EntryTypeDef},
             Dna,
         },
-        json::RawString,
         entry::Entry,
+        json::RawString,
     };
     use std::sync::Arc;
     use test_utils::*;
@@ -76,26 +76,17 @@ pub mod tests {
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_chain_entries() -> Entry {
-        Entry::App(
-            "package_chain_entries".into(),
-            "test value".into(),
-        )
+        Entry::App("package_chain_entries".into(), "test value".into())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_chain_headers() -> Entry {
-        Entry::App(
-            "package_chain_headers".into(),
-            "test value".into(),
-        )
+        Entry::App("package_chain_headers".into(), "test value".into())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_chain_full() -> Entry {
-        Entry::App(
-            "package_chain_full".into(),
-            "test value".into(),
-        )
+        Entry::App("package_chain_full".into(), "test value".into())
     }
 
     #[cfg_attr(tarpaulin, skip)]

--- a/core/src/nucleus/actions/mod.rs
+++ b/core/src/nucleus/actions/mod.rs
@@ -18,7 +18,8 @@ pub mod tests {
             zome::{capabilities::Capability, entry_types::EntryTypeDef},
             Dna,
         },
-        entry::{entry_type::AppEntryType, Entry},
+        json::RawString,
+        entry::Entry,
     };
     use std::sync::Arc;
     use test_utils::*;
@@ -70,13 +71,13 @@ pub mod tests {
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_entry() -> Entry {
-        Entry::App(AppEntryType::from("package_entry"), "test value".into())
+        Entry::App("package_entry".into(), RawString::from("test value").into())
     }
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_chain_entries() -> Entry {
         Entry::App(
-            AppEntryType::from("package_chain_entries"),
+            "package_chain_entries".into(),
             "test value".into(),
         )
     }
@@ -84,7 +85,7 @@ pub mod tests {
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_chain_headers() -> Entry {
         Entry::App(
-            AppEntryType::from("package_chain_headers"),
+            "package_chain_headers".into(),
             "test value".into(),
         )
     }
@@ -92,7 +93,7 @@ pub mod tests {
     #[cfg_attr(tarpaulin, skip)]
     pub fn test_entry_package_chain_full() -> Entry {
         Entry::App(
-            AppEntryType::from("package_chain_full"),
+            "package_chain_full".into(),
             "test value".into(),
         )
     }

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -92,10 +92,7 @@ pub mod tests {
 
         let mut entry_addresses: Vec<Address> = Vec::new();
         for i in 0..3 {
-            let entry = Entry::App(
-                test_app_entry_type(),
-                format!("entry{} value", i).into(),
-            );
+            let entry = Entry::App(test_app_entry_type(), format!("entry{} value", i).into());
             let address = block_on(commit_entry(entry, None, &initialized_context))
                 .expect("Could not commit entry for testing");
             entry_addresses.push(address);

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -94,7 +94,7 @@ pub mod tests {
         for i in 0..3 {
             let entry = Entry::App(
                 test_app_entry_type(),
-                JsonString::from(format!("entry{} value", i)),
+                format!("entry{} value", i).into(),
             );
             let address = block_on(commit_entry(entry, None, &initialized_context))
                 .expect("Could not commit entry for testing");

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -66,10 +66,7 @@ pub mod tests {
     use std::{convert::TryFrom, sync::Arc};
 
     pub fn test_entry_b() -> Entry {
-        Entry::App(
-            "testEntryTypeB".into(),
-            "test".into(),
-        )
+        Entry::App("testEntryTypeB".into(), "test".into())
     }
 
     /// dummy link_entries args from standard test entry

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -57,7 +57,7 @@ pub mod tests {
     use futures::executor::block_on;
     use holochain_core_types::{
         cas::content::AddressableContent,
-        entry::{entry_type::AppEntryType, test_entry, AppEntryValue, Entry},
+        entry::{test_entry, Entry},
         error::{CoreError, ZomeApiInternalResult},
         json::JsonString,
     };
@@ -67,8 +67,8 @@ pub mod tests {
 
     pub fn test_entry_b() -> Entry {
         Entry::App(
-            AppEntryType::from("testEntryTypeB"),
-            AppEntryValue::from("test"),
+            "testEntryTypeB".into(),
+            "test".into(),
         )
     }
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -423,7 +423,7 @@ pub fn call<S: Into<String>>(
 ///
 /// pub fn handle_create_post(content: String) -> JsonString {
 ///
-///     let post_entry = Entry::App(AppEntryType::from("post"), Post{
+///     let post_entry = Entry::App("post".into(), Post{
 ///         content,
 ///         date_created: "now".into(),
 ///     }.into());
@@ -585,7 +585,7 @@ pub fn get_entry_result(address: Address, options: GetEntryOptions) -> ZomeApiRe
 /// }
 ///
 /// pub fn handle_link_entries(content: String) -> JsonString {
-///     let post_entry = Entry::App(AppEntryType::from("post"), Post{
+///     let post_entry = Entry::App("post".into(), Post{
 ///         content,
 ///         date_created: "now".into(),
 ///     }.into());
@@ -677,7 +677,7 @@ pub fn property<S: Into<String>>(_name: S) -> ZomeApiResult<String> {
 ///
 /// fn handle_post_address(content: String) -> JsonString {
 ///
-///     let post_entry = Entry::App(AppEntryType::from("post"), Post {
+///     let post_entry = Entry::App("post".into(), Post {
 ///         content,
 ///         date_created: "now".into(),
 ///     }.into());

--- a/hdk-rust/src/macros.rs
+++ b/hdk-rust/src/macros.rs
@@ -71,7 +71,7 @@ macro_rules! load_json {
 /// }
 ///
 /// fn handle_post_address(content: String) -> ZomeApiResult<Address> {
-///     let post_entry = Entry::App(AppEntryType::from("post"), Post {
+///     let post_entry = Entry::App("post".into(), Post {
 ///         content,
 ///         date_created: "now".into(),
 ///     }.into());

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -96,7 +96,8 @@ fn example_valid_entry() -> Entry {
         test_app_entry_type().into(),
         EntryStruct {
             stuff: "non fail".into(),
-        }.into(),
+        }
+        .into(),
     )
 }
 

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -23,8 +23,8 @@ use holochain_core_types::{
         entry_types::{EntryTypeDef, LinksTo},
     },
     entry::{
-        entry_type::{test_app_entry_type, AppEntryType, EntryType},
-        AppEntryValue, Entry,
+        entry_type::{test_app_entry_type, EntryType},
+        Entry,
     },
     error::{CoreError, HolochainError, ZomeApiInternalResult},
     hash::HashString,
@@ -93,10 +93,10 @@ struct EntryStruct {
 
 fn example_valid_entry() -> Entry {
     Entry::App(
-        AppEntryType::from(test_app_entry_type()),
-        AppEntryValue::from(EntryStruct {
+        test_app_entry_type().into(),
+        EntryStruct {
             stuff: "non fail".into(),
-        }),
+        }.into(),
     )
 }
 
@@ -340,10 +340,10 @@ fn can_invalidate_invalid_commit() {
         "check_commit_entry_macro",
         &json!({"entry":
             Entry::App(
-                AppEntryType::from(test_app_entry_type()),
-                AppEntryValue::from(EntryStruct {
+                test_app_entry_type().into(),
+                EntryStruct {
                     stuff: "FAIL".into(),
-                }),
+                }.into(),
             )
         })
         .to_string(),

--- a/hdk-rust/wasm-test/src/handle_crud.rs
+++ b/hdk-rust/wasm-test/src/handle_crud.rs
@@ -26,7 +26,7 @@ pub(crate) fn handle_update_entry_ok() -> JsonString {
     // update it to v2
     hdk::debug("**** update it to v2").ok();
     let entry_v2 =
-        Entry::App(hdk_test_app_entry_type(), JsonString::from(TestEntryType { stuff: "v2".into() }));
+        Entry::App(hdk_test_app_entry_type(), TestEntryType { stuff: "v2".into() }.into());
     let res = hdk::update_entry(entry_v2.clone(), addr_v1.clone());
     let addr_v2 = res.unwrap();
     // get latest from latest
@@ -54,7 +54,7 @@ pub(crate) fn handle_update_entry_ok() -> JsonString {
     hdk::debug("**** update it again from v1").ok();
     let entry_v3 = Entry::App(
         hdk_test_app_entry_type(),
-        JsonString::from(TestEntryType { stuff: "v3".into() }));
+        TestEntryType { stuff: "v3".into() }.into());
     let res = hdk::update_entry(entry_v3.clone(), addr_v1.clone());
     let addr_v3 = res.unwrap();
     // get latest from v1
@@ -71,7 +71,7 @@ pub(crate) fn handle_update_entry_ok() -> JsonString {
     // update it again from v3
     let entry_v4 = Entry::App(
         hdk_test_app_entry_type(),
-        JsonString::from(TestEntryType { stuff: "v4".into() }),
+        TestEntryType { stuff: "v4".into() }.into(),
     );
     let res = hdk::update_entry(entry_v4.clone(), addr_v3.clone());
     let addr_v4 = res.unwrap();
@@ -199,7 +199,7 @@ pub fn handle_remove_modified_entry_ok() -> JsonString {
     hdk::debug("**** update it to v2").ok();
     let entry_v2 = Entry::App(
         hdk_test_app_entry_type(),
-        JsonString::from(TestEntryType { stuff: "v2".into() }),
+        TestEntryType { stuff: "v2".into() }.into(),
     );
     let res = hdk::update_entry(entry_v2.clone(), addr_v1.clone());
     let addr_v2 = res.unwrap();

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -103,7 +103,7 @@ fn handle_check_get_entry(entry_address: Address) -> ZomeApiResult<Option<Entry>
 fn handle_commit_validation_package_tester() -> ZomeApiResult<Address> {
     hdk::commit_entry(&Entry::App(
         "validation_package_tester".into(),
-        JsonString::from(RawString::from("test")),
+        RawString::from("test").into(),
     ))
 }
 
@@ -235,7 +235,7 @@ fn handle_check_app_entry_address() -> ZomeApiResult<Address> {
     }
 
     // Check bad entry type name
-    let bad_result = hdk::entry_address(&Entry::App(AppEntryType::from("bad"), entry_value.clone()));
+    let bad_result = hdk::entry_address(&Entry::App("bad".into(), entry_value.clone()));
     if !bad_result.is_err() {
         return bad_result.into();
     }


### PR DESCRIPTION
## background

where we started...

"ugh, this is gross!":

```rust
let entry = Entry::App(
    AppEntryType::from("foo"),
    AppEntryValue::from(RawString::from("bar")),
);
```

what we tried:

```rust
impl Entry {
  fn app_from<T: Into<AppEntryType>, V: Into<AppEntryValue>>(t: T, v: V) -> Entry {
    Entry::App(t.into(), v.into())
  }
}
```

but really, is that helping much?

compare the use of `into` rather than `From` for the same thing:

```rust
let entry = Entry::App(t.into(), v.into()); // <-- alternative syntax to the X::from() verbosity above
let entry = Entry::app_from(t.clone(), v.clone()); // <-- can sometimes drop the t.clone() if t is &str
```

doesn't look like a huge win, actually, usage of `.into()` almost completely cleans up things here

what we're left with:

why do we need to write `Entry::App(..)` at all inside zomes? aren't *all* entries supposed to be app entries in a zome?

- sort of?
  - in one sense, it forces us to be aware of the enum variant, e.g. that `Entry::App` is distinct from `Entry::Dna`, etc. which is **bad** because we will never use anything else in that context (zome) it is redundant info
  - in another sense, it's just a glorified tuple `(AppEntryType, AppEntryValue)` from the zome's perspective so isn't causing much harm
  - i don't know how you could _prevent_ a zome developer from creating an `Entry::Dna` enum in the zome, it just doesn't seem useful
    - we can stop them _committing_ that entry by failing validation, but they can always build one in memory if they really want (calculate an expected address?)
    - we could do magic with actual tuples that we then convert into an `Entry` enum, but why? seems like magic for the sake of it, or just to remove a little bit of typing... potential loss of compiler help/debugability?
- trying to remove/hide the `AppEntryType`, e.g. using a macro or similar so we can do `Post { .. }.into()` directly to get an `Entry` locks us into a 1:1 relationship between structs used as entry values and entry types
  - e.g. we cannot use `Post` as the content for more than one entry as the macro would _always_ inject some `AppEntryType` (which one?) for us
  - only the zome knows when a type/value combo makes sense for a given `Entry` so it is the zome's responsibility to provide both
  - nothing stopping zomes from creating their own `PostEntry::from_post(post)` methods or similar
```rust
type PostEntry = Entry;
impl PostEntry {
  fn from_post(post: Post) -> Entry {
    Entry::App("post".into(), post.into())
  }
}
```
- we looked at something like `v.as_app_entry(t)`
  - benefits vs. `Entry::App(t.into(), v.into())` are dubious
    - doesn't abstract anything away, developer still needs to juggle all the same types mentally, just saves a small amount of typing (~10 keystrokes)
    - achieving this elegantly isn't immediately obvious... custom derive somewhere? some other macro? additional zome boilerplate? a new method on `JsonString`?

## changes

sweeps usage of `Entry::App( .. )` to prefer `Entry::App(t.into(), v.into())` over `Entry::App(AppEntryType::from(t), AppEntryValue::from(v))`