### PR TITLE
[WIP] Add API function get_links_and_load

### DIFF
--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -13,7 +13,7 @@ pub use holochain_wasm_utils::api_serialization::validation::*;
 use holochain_wasm_utils::{
     api_serialization::{
         get_entry::{EntryHistory, GetEntryArgs, GetEntryOptions, StatusRequestKind},
-        get_links::{GetLinksArgs, GetLinksResult},
+        get_links::{GetLinksArgs, GetLinksResult, GetLinksLoadElement, GetLinksLoadResult},
         link_entries::LinkEntriesArgs,
         QueryArgs, QueryResult, UpdateEntryArgs, ZomeFnCallArgs,
     },
@@ -171,15 +171,6 @@ pub enum BundleOnClose {
     Commit,
     Discard,
 }
-
-// Response for calls to get_links_and_load
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct GetLinksLoadElement<T> {
-    pub address: HashString,
-    pub entry: T
-}
-
-pub type GetLinksLoadResult<T> = Vec<GetLinksLoadElement<T>>;
 
 //--------------------------------------------------------------------------------------------------
 // API FUNCTIONS

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -925,8 +925,8 @@ pub fn get_links_and_load<S: Into<String>>(
 
 /// Similar to get_links_and_load but also handles converting the response to a given native type.
 /// Only linked entries that can be successfully converted are returned. This means if a link contains a variety of entry
-/// types `get_links_and_load_type` will filter out only the entries that can be converted successfully.
-pub fn get_links_and_load_type<
+/// types `get_links_and_load_as` will filter out only the entries that can be converted successfully.
+pub fn get_links_and_load_as<
     S: Into<String>,
     R: TryFrom<AppEntryValue>
 >(

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -143,6 +143,7 @@ fn start_holochain_instance<T: Into<String>>(uuid: T) -> (Holochain, Arc<Mutex<T
         "update_entry_ok",
         "remove_entry_ok",
         "remove_modified_entry_ok",
+        "check_get_links_and_load"
     ]);
     let mut dna = create_test_dna_with_cap("test_zome", "test_cap", &capabability, &wasm);
     dna.uuid = uuid.into();
@@ -583,5 +584,12 @@ fn can_update_entry() {
 fn can_remove_modified_entry() {
     let (mut hc, _) = start_holochain_instance("can_remove_modified_entry");
     let result = hc.call("test_zome", "test_cap", "remove_modified_entry_ok", r#"{}"#);
+    assert!(result.is_ok(), "result = {:?}", result);
+}
+
+#[test]
+fn can_call_get_links_load() {
+    let (mut hc, _) = start_holochain_instance("can_call_get_links_load");
+    let result = hc.call("test_zome", "test_cap", "check_get_links_and_load", r#"{}"#);
     assert!(result.is_ok(), "result = {:?}", result);
 }

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -531,6 +531,11 @@ define_zome! {
                 outputs: |response: TweetResponse|,
                 handler: handle_send_tweet
             }
+
+            check_get_links_and_load: {
+                inputs: ||,
+                outputs: |result: ZomeApiResult<GetLinksLoadResult>|
+            }
         }
     }
 }

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -21,7 +21,7 @@ use hdk::{
 use holochain_wasm_utils::{
     api_serialization::{
         get_entry::{GetEntryOptions, EntryHistory},
-        get_links::GetLinksResult,
+        get_links::{GetLinksResult, GetLinksLoadResult},
     },
     holochain_core_types::dna::zome::entry_types::Sharing,
     holochain_core_types::{
@@ -289,6 +289,18 @@ fn handle_check_call_with_args() -> ZomeApiResult<JsonString> {
     )
 }
 
+fn handle_check_get_links_and_load() -> ZomeApiResult<GetLinksLoadResult<Entry>> {
+    handle_link_two_entries()?;
+    let entry_1 = Entry::App(
+        "testEntryType".into(),
+        EntryStruct {
+            stuff: "entry1".into(),
+        }.into(),
+    );
+    let entry_1_address = hdk::entry_address(&entry_1)?; 
+    hdk::get_links_and_load(&entry_1_address, "test-tag")
+}
+
 #[derive(Serialize, Deserialize, Debug, DefaultJson)]
 struct TweetResponse {
     first: String,
@@ -533,8 +545,9 @@ define_zome! {
             }
 
             check_get_links_and_load: {
-                inputs: ||,
-                outputs: |result: ZomeApiResult<GetLinksLoadResult>|
+                inputs: | |,
+                outputs: |result: ZomeApiResult<GetLinksLoadResult<Entry>>|,
+                handler: handle_check_get_links_and_load
             }
         }
     }

--- a/wasm_utils/src/api_serialization/get_links.rs
+++ b/wasm_utils/src/api_serialization/get_links.rs
@@ -20,3 +20,11 @@ impl GetLinksResult {
         &self.addresses
     }
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetLinksLoadElement<T> {
+    pub address: Address,
+    pub entry: T
+}
+
+pub type GetLinksLoadResult<T> = Vec<GetLinksLoadElement<T>>;


### PR DESCRIPTION
This aims to restore some of the functionality that was in holochain-proto for loading all the entries linked to a given address.

It also adds a function `get_links_and_load_as` which is identical but will also attempt to convert the loaded entries to a given native type. Any entries that cannot be successfully converted are dropped so this function can still be called on a link base that has different entry types linked to it.

While this does not enable any new functionality it does significant reduce the boilerplate code required to write zomes. Combined with the ability to return `ZomeApiResult<>` means many zome functions can be written in one line.

example from holo-chat:
```
pub fn handle_get_my_channels() -> ZomeApiResult<utils::GetLinksLoadResult<Channel>> {
    utils::get_links_and_load_as(&get_my_member_id().hash(), "member_of")
}

pub fn handle_get_members(address: HashString) -> ZomeApiResult<utils::GetLinksLoadResult<member::Member>> {
    utils::get_links_and_load_as(&address, "has_member")
}

pub fn handle_get_messages(address: HashString) -> ZomeApiResult<utils::GetLinksLoadResult<message::Message>> {
    utils::get_links_and_load_as(&address, "message_in")
}

pub fn handle_get_subjects(address: HashString) -> ZomeApiResult<utils::GetLinksLoadResult<Subject>> {
    utils::get_links_and_load_as(&address, "channel_subject")
}
```

We have been including this helper function in our zomes up to this point but to encourage good practices for other developers it makes sense to include this as part of the core api