### PR TITLE
improve readability and completeness of hc run docs

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -188,8 +188,32 @@ where `test/test.js` is the path of the file.
 You have the flexibility to write tests in quite a variety of ways, open to you to explore.
 
 ## Running your application
-For the purpose of *testing* APIs or prototyping user interfaces, you can run your DNA using `hc run`.
-This will start the application and open a WebSocket on port `8888` or any other port specified by the `-p`/`--port` option. The `-b`/`--package` flag will build your DNA before running it. By default, none of the data your application is putting on the source chain gets persisted. To persist data onto the file system, use the `--persist` flag.
+For the purpose of *testing* APIs or prototyping user interfaces, you can run the DNA of a hApp, from the directory it's contained. The most basic way to do this is to run:
+```shell
+hc run
+```
+This will start the application and open a WebSocket on port `8888`.
+
+There are three option flags for `hc run`.
+
+If you wish to customize the port number that the WebSocket runs over, then run it with a `-p`/`--port` option, like:
+```shell
+hc run --port 3400
+```
+
+If you wish to "package" your DNA before running it, which is to build the `bundle.json` file from the source files, then use the `-b`/`--package` option, like:
+```shell
+hc run --package
+```
+Note that `hc run` always looks for a `bundle.json` file in the root of your app folder, so make sure that one exists there when trying to use it. `hc run --package` will do this, or run `hc package` and then move `dist/bundle.json` into the root.
+
+By default, none of the data your application is writing to the source chain gets persisted. If you wish to persist data onto the file system, use the `--persist` flag, like:
+```shell
+hc run --persist
+```
+This will store data in the same directory as your app, in a hidden folder called `.hc`.
+
+Of course these options can be used in combination with one another.
 
 ## Contribute
 Holochain is an open source project.  We welcome all sorts of participation and are actively working on increasing surface area to accept it.  Please see our [contributing guidelines](https://github.com/holochain/org/blob/master/CONTRIBUTING.md) for our general practices and protocols on participating in the community.

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -188,7 +188,7 @@ where `test/test.js` is the path of the file.
 You have the flexibility to write tests in quite a variety of ways, open to you to explore.
 
 ## Running your application
-For the purpose of *testing* APIs or prototyping user interfaces, you can run the DNA of a hApp, from the directory it's contained. The most basic way to do this is to run:
+For the purpose of *testing* APIs or prototyping user interfaces, you can run a DNA from the directory it's contained. The most basic way to do this is to run:
 ```shell
 hc run
 ```


### PR DESCRIPTION
Note that `hc run` relies on there being a `bundle.json` file in the app root, but that's different than where `hc package` puts it by default, which is in `dist/bundle.json`. This kinda sucks because its muddy, so it'd be better if `hc run` put (and looked for) `bundle.json` in the same place as `hc package`

if that gets changed, then this should also get re-updated.