### PR TITLE
Handle bridge dependencies with graph theory

### DIFF
--- a/container_api/Cargo.toml
+++ b/container_api/Cargo.toml
@@ -17,6 +17,7 @@ toml = "0.4.8"
 boolinator = "2.4"
 tiny_http = "0.6.0"
 jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc" }
+petgraph = "0.4.13"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils"}

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -179,7 +179,7 @@ impl Configuration {
             HolochainError::ConfigError("Cyclic dependency in bridge configuration".to_string())
         })?;
 
-        // REVERSE order because we want to the instance with NO dependencies first
+        // REVERSE order because we want to get the instance with NO dependencies first
         // since that is the instance we should spawn first.
         sorted_nodes.reverse();
 

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -697,9 +697,18 @@ pub mod tests {
         let config = load_configuration::<Configuration>(&toml).expect("Config should be syntactically correct");
         assert_eq!(config.check_consistency(), Ok(()));
 
+        // "->": calls
+        // app1 -> app2 -> app3
+        // app3 has no dependency so it can be instantiated first.
+        // app2 depends on (calls) only app3, so app2 is next.
+        // app1 should be last.
         assert_eq!(
             config.instance_ids_sorted_by_bridge_dependencies(),
-            Ok(vec![String::from("app3"), String::from("app2"), String::from("app1")])
+            Ok(vec![
+                String::from("app3"),
+                String::from("app2"),
+                String::from("app1")]
+            )
         );
     }
 

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -16,8 +16,12 @@ use holochain_core_types::{
     error::{HcResult, HolochainError},
     json::JsonString,
 };
+use petgraph::{
+    algo::toposort, graph::DiGraph,
+    prelude::NodeIndex,
+};
 use serde::Deserialize;
-use std::{convert::TryFrom, fs::File, io::prelude::*};
+use std::{collections::HashMap, convert::TryFrom, fs::File, io::prelude::*};
 use toml;
 
 /// Main container configuration struct
@@ -73,6 +77,23 @@ impl Configuration {
             }
         }
 
+        for ref bridge in self.bridges.iter() {
+            self.instance_by_id(&bridge.callee_id).is_some().ok_or_else(|| {
+                format!(
+                    "Instance configuration \"{}\" not found, mentioned in bridge",
+                    bridge.callee_id
+                )
+            })?;
+            self.instance_by_id(&bridge.caller_id).is_some().ok_or_else(|| {
+                format!(
+                    "Instance configuration \"{}\" not found, mentioned in bridge",
+                    bridge.caller_id
+                )
+            })?;
+        }
+
+        let _ = self.instance_ids_sorted_by_bridge_dependencies()?;
+
         Ok(())
     }
 
@@ -102,6 +123,73 @@ impl Configuration {
             .iter()
             .map(|instance| instance.id.clone())
             .collect()
+    }
+
+    /// This function uses the petgraph crate to model the bridge connections in this config
+    /// as a graph and then create a topological sorting of the nodes, which are instances.
+    /// The sorting gets reversed to get those instances first that do NOT depend on others
+    /// such that this ordering of instances can be used to spawn them and simultaneously create
+    /// initialize the bridges and be able to assert that any callee already exists (which makes
+    /// this task much easier).
+    pub fn instance_ids_sorted_by_bridge_dependencies(&self) -> Result<Vec<String>, HolochainError> {
+        let mut graph = DiGraph::<&str, &str>::new();
+
+        // Add instance ids to the graph which returns the indices the graph is using.
+        // Storing those in a map from ids to create edges from bridges below.
+        let index_map : HashMap<_,_> = self.instances
+            .iter()
+            .map(|instance| {
+                (instance.id.clone(), graph.add_node(&instance.id))
+            })
+            .collect();
+
+        // Reverse of graph indices to instance ids to create the return vector below.
+        let reverse_map : HashMap<_,_> = self.instances
+            .iter()
+            .map(|instance| {
+                (index_map.get(&instance.id).unwrap(), instance.id.clone())
+            })
+            .collect();
+
+        // Create vector of edges (with node indices) from bridges:
+        let edges: Vec<(&NodeIndex<u32>, &NodeIndex<u32>)> = self.bridges
+            .iter()
+            .map(|bridge| -> Result<(&NodeIndex<u32>, &NodeIndex<u32>), HolochainError> {
+                let start = index_map.get(&bridge.caller_id);
+                let end = index_map.get(&bridge.callee_id);
+                if start.is_none() || end.is_none() {
+                    Err(HolochainError::ConfigError(format!(
+                        "Instance configuration not found, mentioned in bridge configuration: {} -> {}",
+                        bridge.caller_id, bridge.callee_id,
+                    )))
+                } else {
+                    Ok((start.unwrap(), end.unwrap()))
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Add edges to graph:
+        for &(node_a, node_b) in edges.iter() {
+            graph.add_edge(node_a.clone(), node_b.clone(), "");
+        }
+
+        // Sort with petgraph::algo::toposort
+        let mut sorted_nodes = toposort(&graph, None)
+            .map_err(|_cycle_error|
+                HolochainError::ConfigError("Cyclic dependency in bridge configuration".to_string())
+            )?;
+
+        // REVERSE order because we want to the instance with NO dependencies first
+        // since that is the instance we should spawn first.
+        sorted_nodes.reverse();
+
+        // Map sorted vector of node indices back to instance ids
+        Ok(sorted_nodes
+            .iter()
+            .map(|node_index| reverse_map.get(node_index).unwrap())
+            .cloned()
+            .collect()
+        )
     }
 }
 
@@ -541,5 +629,117 @@ pub mod tests {
         } else {
             panic!("Should have failed!")
         }
+    }
+
+    fn bridges_config(bridges: &str) -> String {
+        format!(
+            r#"
+    [[agents]]
+    id = "test agent"
+    name = "Holo Tester 1"
+    public_address = "HoloTester1-------------------------------------------------------------------------AHi1"
+    key_file = "holo_tester.key"
+
+    [[dnas]]
+    id = "app spec rust"
+    file = "app-spec-rust.hcpkg"
+    hash = "Qm328wyq38924y"
+
+    [[instances]]
+    id = "app1"
+    dna = "app spec rust"
+    agent = "test agent"
+    [instances.logger]
+    type = "simple"
+    file = "app_spec.log"
+    [instances.storage]
+    type = "file"
+    path = "app_spec_storage"
+
+    [[instances]]
+    id = "app2"
+    dna = "app spec rust"
+    agent = "test agent"
+    [instances.logger]
+    type = "simple"
+    file = "app_spec.log"
+    [instances.storage]
+    type = "file"
+    path = "app_spec_storage"
+
+    [[instances]]
+    id = "app3"
+    dna = "app spec rust"
+    agent = "test agent"
+    [instances.logger]
+    type = "simple"
+    file = "app_spec.log"
+    [instances.storage]
+    type = "file"
+    path = "app_spec_storage"
+
+    {}
+    "#, bridges)
+    }
+
+    #[test]
+    fn test_bridge_config() {
+        let toml = bridges_config(
+            r#"
+    [[bridges]]
+    caller_id = "app1"
+    callee_id = "app2"
+
+    [[bridges]]
+    caller_id = "app2"
+    callee_id = "app3"
+    "#);
+        let config = load_configuration::<Configuration>(&toml).expect("Config should be syntactically correct");
+        assert_eq!(config.check_consistency(), Ok(()));
+
+        assert_eq!(
+            config.instance_ids_sorted_by_bridge_dependencies(),
+            Ok(vec![String::from("app3"), String::from("app2"), String::from("app1")])
+        );
+    }
+
+    #[test]
+    fn test_bridge_cycle() {
+        let toml = bridges_config(
+            r#"
+    [[bridges]]
+    caller_id = "app1"
+    callee_id = "app2"
+
+    [[bridges]]
+    caller_id = "app2"
+    callee_id = "app3"
+
+    [[bridges]]
+    caller_id = "app3"
+    callee_id = "app1"
+    "#);
+        let config = load_configuration::<Configuration>(&toml).expect("Config should be syntactically correct");
+        assert_eq!(config.check_consistency(), Err("Cyclic dependency in bridge configuration".to_string()));
+    }
+
+    #[test]
+    fn test_bridge_non_existent() {
+        let toml = bridges_config(
+            r#"
+    [[bridges]]
+    caller_id = "app1"
+    callee_id = "app2"
+
+    [[bridges]]
+    caller_id = "app2"
+    callee_id = "app3"
+
+    [[bridges]]
+    caller_id = "app9000"
+    callee_id = "app1"
+    "#);
+        let config = load_configuration::<Configuration>(&toml).expect("Config should be syntactically correct");
+        assert_eq!(config.check_consistency(), Err("Instance configuration \"app9000\" not found, mentioned in bridge".to_string()));
     }
 }

--- a/container_api/src/lib.rs
+++ b/container_api/src/lib.rs
@@ -101,12 +101,12 @@ extern crate tempfile;
 extern crate serde_derive;
 extern crate boolinator;
 extern crate jsonrpc_ws_server;
+extern crate petgraph;
 extern crate serde_json;
 #[cfg(test)]
 extern crate test_utils;
 extern crate tiny_http;
 extern crate toml;
-extern crate petgraph;
 
 pub mod config;
 pub mod container;

--- a/container_api/src/lib.rs
+++ b/container_api/src/lib.rs
@@ -106,6 +106,7 @@ extern crate serde_json;
 extern crate test_utils;
 extern crate tiny_http;
 extern crate toml;
+extern crate petgraph;
 
 pub mod config;
 pub mod container;


### PR DESCRIPTION
Setting up the interfaces for bridges gets a lot easier when we can assert that a bridge dependency (i.e. the *callee* of the bridge) is already instantiated when creating an interface to pass in as context when creating the *caller*.

This needs to happen on creation because we are going to need to add a genesis callback that uses the bridge (-> and thus the callee) during initialization.

With this new function `Configuration::instance_ids_sorted_by_bridge_dependencies()` I get all instances sorted in a way that I can iterate through to spawn them and set up bridges at the same time. -> next PR