### PR TITLE
Bridge API

### DIFF
--- a/cmd/src/cli/test_context.rs
+++ b/cmd/src/cli/test_context.rs
@@ -1,8 +1,5 @@
-use holochain_core::{
-    context::Context,
-    logger::Logger,
-};
 use holochain_container_api::context_builder::ContextBuilder;
+use holochain_core::{context::Context, logger::Logger};
 use holochain_core_types::agent::AgentId;
 use std::sync::{Arc, Mutex};
 
@@ -31,9 +28,9 @@ pub fn test_context(agent_name: &str) -> Arc<Context> {
     let agent = AgentId::generate_fake(agent_name);
     Arc::new(
         ContextBuilder::new()
-             .with_agent(agent)
-             .with_logger(test_logger())
-             .with_memory_storage()
-             .spawn()
+            .with_agent(agent)
+            .with_logger(test_logger())
+            .with_memory_storage()
+            .spawn(),
     )
 }

--- a/cmd/src/cli/test_context.rs
+++ b/cmd/src/cli/test_context.rs
@@ -1,16 +1,10 @@
-use tempfile::tempdir;
-
-use holochain_cas_implementations::{
-    cas::{file::FilesystemStorage, memory::MemoryStorage},
-    eav::memory::EavMemoryStorage,
-};
 use holochain_core::{
-    context::{mock_network_config, Context},
+    context::Context,
     logger::Logger,
-    persister::SimplePersister,
 };
+use holochain_container_api::context_builder::ContextBuilder;
 use holochain_core_types::agent::AgentId;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct TestLogger {
@@ -34,19 +28,12 @@ pub fn test_logger() -> Arc<Mutex<TestLogger>> {
 /// create a test context and TestLogger pair so we can use the logger in assertions
 #[cfg_attr(tarpaulin, skip)]
 pub fn test_context(agent_name: &str) -> Arc<Context> {
-    let tempdir = tempdir().unwrap();
     let agent = AgentId::generate_fake(agent_name);
-    let logger = test_logger();
-    let file_storage = Arc::new(RwLock::new(
-        FilesystemStorage::new(tempdir.path().to_str().unwrap()).unwrap(),
-    ));
-    Arc::new(Context::new(
-        agent,
-        logger.clone(),
-        Arc::new(Mutex::new(SimplePersister::new(file_storage.clone()))),
-        Arc::new(RwLock::new(MemoryStorage::new())),
-        Arc::new(RwLock::new(MemoryStorage::new())),
-        Arc::new(RwLock::new(EavMemoryStorage::new())),
-        mock_network_config(),
-    ))
+    Arc::new(
+        ContextBuilder::new()
+             .with_agent(agent)
+             .with_logger(test_logger())
+             .with_memory_storage()
+             .spawn()
+    )
 }

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -792,10 +792,7 @@ pub mod tests {
             .expect("Config should be syntactically correct");
         assert_eq!(
             config.bridge_dependencies(String::from("app1")),
-            vec![
-                String::from("app2"),
-                String::from("app3"),
-            ]
+            vec![String::from("app2"), String::from("app3"),]
         );
     }
 }

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -191,11 +191,11 @@ impl Configuration {
             .collect())
     }
 
-    pub fn bridge_dependencies(&self, caller_instance_id: String) -> Vec<String> {
+    pub fn bridge_dependencies(&self, caller_instance_id: String) -> Vec<Bridge> {
         self.bridges
             .iter()
             .filter(|bridge| bridge.caller_id == caller_instance_id)
-            .map(|bridge| bridge.callee_id.clone())
+            .cloned()
             .collect()
     }
 }
@@ -790,8 +790,12 @@ pub mod tests {
         );
         let config = load_configuration::<Configuration>(&toml)
             .expect("Config should be syntactically correct");
+        let bridged_ids: Vec<_> = config.bridge_dependencies(String::from("app1"))
+            .iter()
+            .map(|bridge| bridge.callee_id.clone())
+            .collect();
         assert_eq!(
-            config.bridge_dependencies(String::from("app1")),
+            bridged_ids,
             vec![String::from("app2"), String::from("app3"),]
         );
     }

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -790,7 +790,8 @@ pub mod tests {
         );
         let config = load_configuration::<Configuration>(&toml)
             .expect("Config should be syntactically correct");
-        let bridged_ids: Vec<_> = config.bridge_dependencies(String::from("app1"))
+        let bridged_ids: Vec<_> = config
+            .bridge_dependencies(String::from("app1"))
             .iter()
             .map(|bridge| bridge.callee_id.clone())
             .collect();

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -311,8 +311,19 @@ pub struct InstanceReferenceConfiguration {
 /// It is basically an internal interface.
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
 pub struct Bridge {
+    /// ID of the instance that calls the other one.
+    /// This instance depends on the callee.
     pub caller_id: String,
+
+    /// ID of the instance that exposes capabilities through this bridge.
+    /// This instance is used by the caller.
     pub callee_id: String,
+
+    /// The caller's local handle of this bridge and the callee.
+    /// A caller can have many bridges to other DNAs and those DNAs could
+    /// by bound dynamically.
+    /// Callers reference callees by this arbitrary but unique local name.
+    pub handle: String,
 }
 
 /// Use this function to load a `Configuration` from a string.
@@ -696,10 +707,12 @@ pub mod tests {
     [[bridges]]
     caller_id = "app1"
     callee_id = "app2"
+    handle = "happ-store"
 
     [[bridges]]
     caller_id = "app2"
     callee_id = "app3"
+    handle = "DPKI"
     "#,
         );
         let config = load_configuration::<Configuration>(&toml)
@@ -728,14 +741,17 @@ pub mod tests {
     [[bridges]]
     caller_id = "app1"
     callee_id = "app2"
+    handle = "happ-store"
 
     [[bridges]]
     caller_id = "app2"
     callee_id = "app3"
+    handle = "DPKI"
 
     [[bridges]]
     caller_id = "app3"
     callee_id = "app1"
+    handle = "something"
     "#,
         );
         let config = load_configuration::<Configuration>(&toml)
@@ -753,14 +769,17 @@ pub mod tests {
     [[bridges]]
     caller_id = "app1"
     callee_id = "app2"
+    handle = "happ-store"
 
     [[bridges]]
     caller_id = "app2"
     callee_id = "app3"
+    handle = "DPKI"
 
     [[bridges]]
     caller_id = "app9000"
     callee_id = "app1"
+    handle = "something"
     "#,
         );
         let config = load_configuration::<Configuration>(&toml)
@@ -778,14 +797,17 @@ pub mod tests {
     [[bridges]]
     caller_id = "app1"
     callee_id = "app2"
+    handle = "happ-store"
 
     [[bridges]]
     caller_id = "app1"
     callee_id = "app3"
+    handle = "happ-store"
 
     [[bridges]]
     caller_id = "app2"
     callee_id = "app1"
+    handle = "happ-store"
     "#,
         );
         let config = load_configuration::<Configuration>(&toml)

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -38,7 +38,7 @@ use interface_impls;
 /// Dna object for a given path string) has to be injected on creation.
 pub struct Container {
     pub instances: InstanceMap,
-    pub config: Configuration,
+    config: Configuration,
     interface_threads: HashMap<String, InterfaceThreadHandle>,
     dna_loader: DnaLoader,
     signal_tx: Option<SignalSender>,
@@ -68,6 +68,10 @@ impl Container {
         }
         self.signal_tx = Some(signal_tx);
         self
+    }
+
+    pub fn config(&self) -> Configuration {
+        self.config.clone()
     }
 
     pub fn start_all_interfaces(&mut self) {

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -195,9 +195,9 @@ impl Container {
                     );
 
                     api_builder = api_builder
-                        .with_named_instance(bridge.callee_id.clone(), callee_instance.clone());
+                        .with_named_instance(bridge.handle.clone(), callee_instance.clone());
                     api_builder = api_builder
-                        .with_named_instance_config(bridge.callee_id.clone(), callee_config);
+                        .with_named_instance_config(bridge.handle.clone(), callee_config);
                 }
                 context_builder.with_container_api(api_builder.spawn());
 
@@ -390,14 +390,17 @@ pub mod tests {
     [[bridges]]
     caller_id = "test-instance-2"
     callee_id = "test-instance-1"
+    handle = "DPKI"
 
     [[bridges]]
     caller_id = "test-instance-3"
     callee_id = "test-instance-2"
+    handle = "happ-store"
 
     [[bridges]]
     caller_id = "test-instance-3"
     callee_id = "test-instance-1"
+    handle = "DPKI"
     "#
         .to_string()
     }

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -27,9 +27,9 @@ use std::sync::{Arc, Mutex, RwLock};
 /// `spawn()` to retrieve the context.
 pub struct ContextBuilder {
     agent_id: Option<AgentId>,
-    // Logger and persister are currently set to a reasonable default in spawn().
-    // TODO: add with_logger() and with_persister() functions to ContextBuilder.
     logger: Option<Arc<Mutex<Logger>>>,
+    // Persister is currently set to a reasonable default in spawn().
+    // TODO: add with_persister() function to ContextBuilder.
     //persister: Option<Arc<Mutex<Persister>>>,
     chain_storage: Option<Arc<RwLock<ContentAddressableStorage>>>,
     dht_storage: Option<Arc<RwLock<ContentAddressableStorage>>>,

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -3,12 +3,14 @@ use holochain_cas_implementations::{
     eav::{file::EavFileStorage, memory::EavMemoryStorage},
     path::create_path_if_not_exists,
 };
-use holochain_core::{context::Context, logger::SimpleLogger, persister::SimplePersister};
+
+use holochain_core::{context::Context, logger::{Logger, SimpleLogger}, persister::SimplePersister};
 use holochain_core_types::{
     agent::AgentId, cas::storage::ContentAddressableStorage, eav::EntityAttributeValueStorage,
     error::HolochainError, json::JsonString,
 };
 use holochain_net::p2p_config::P2pConfig;
+use jsonrpc_ws_server::jsonrpc_core::IoHandler;
 use std::sync::{Arc, Mutex, RwLock};
 
 /// This type helps building [context objects](struct.Context.html) that need to be
@@ -23,22 +25,25 @@ pub struct ContextBuilder {
     agent_id: Option<AgentId>,
     // Logger and persister are currently set to a reasonable default in spawn().
     // TODO: add with_logger() and with_persister() functions to ContextBuilder.
-    //logger: Option<Arc<Mutex<Logger>>>,
+    logger: Option<Arc<Mutex<Logger>>>,
     //persister: Option<Arc<Mutex<Persister>>>,
     chain_storage: Option<Arc<RwLock<ContentAddressableStorage>>>,
     dht_storage: Option<Arc<RwLock<ContentAddressableStorage>>>,
     eav_storage: Option<Arc<RwLock<EntityAttributeValueStorage>>>,
     network_config: Option<JsonString>,
+    container_api: Option<Arc<RwLock<IoHandler>>>,
 }
 
 impl ContextBuilder {
     pub fn new() -> Self {
         ContextBuilder {
             agent_id: None,
+            logger: None,
             chain_storage: None,
             dht_storage: None,
             eav_storage: None,
             network_config: None,
+            container_api: None,
         }
     }
 
@@ -86,6 +91,16 @@ impl ContextBuilder {
         self
     }
 
+    pub fn with_container_api(&mut self, api_handler: IoHandler) -> &mut Self {
+        self.container_api = Some(Arc::new(RwLock::new(api_handler)));
+        self
+    }
+
+    pub fn with_logger(&mut self, logger: Arc<Mutex<Logger>>) -> &mut Self {
+        self.logger = Some(logger);
+        self
+    }
+
     /// Actually creates the context.
     /// Defaults to memory storages, a mock network config and a fake agent called "alice".
     /// The logger gets set to SimpleLogger.
@@ -107,7 +122,7 @@ impl ContextBuilder {
             self.agent_id
                 .clone()
                 .unwrap_or(AgentId::generate_fake("alice")),
-            Arc::new(Mutex::new(SimpleLogger {})),
+            self.logger.clone().unwrap_or(Arc::new(Mutex::new(SimpleLogger {}))),
             Arc::new(Mutex::new(SimplePersister::new(chain_storage.clone()))),
             chain_storage,
             dht_storage,
@@ -117,6 +132,7 @@ impl ContextBuilder {
                 .unwrap_or(JsonString::from(String::from(
                     P2pConfig::DEFAULT_MOCK_CONFIG,
                 ))),
+            self.container_api.clone(),
         )
     }
 }

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -4,7 +4,11 @@ use holochain_cas_implementations::{
     path::create_path_if_not_exists,
 };
 
-use holochain_core::{context::Context, logger::{Logger, SimpleLogger}, persister::SimplePersister};
+use holochain_core::{
+    context::Context,
+    logger::{Logger, SimpleLogger},
+    persister::SimplePersister,
+};
 use holochain_core_types::{
     agent::AgentId, cas::storage::ContentAddressableStorage, eav::EntityAttributeValueStorage,
     error::HolochainError, json::JsonString,
@@ -122,7 +126,9 @@ impl ContextBuilder {
             self.agent_id
                 .clone()
                 .unwrap_or(AgentId::generate_fake("alice")),
-            self.logger.clone().unwrap_or(Arc::new(Mutex::new(SimpleLogger {}))),
+            self.logger
+                .clone()
+                .unwrap_or(Arc::new(Mutex::new(SimpleLogger {}))),
             Arc::new(Mutex::new(SimplePersister::new(chain_storage.clone()))),
             chain_storage,
             dht_storage,

--- a/container_api/src/holochain.rs
+++ b/container_api/src/holochain.rs
@@ -188,8 +188,8 @@ impl Holochain {
 mod tests {
     extern crate holochain_cas_implementations;
 
-    use context_builder::ContextBuilder;
     use super::*;
+    use context_builder::ContextBuilder;
     use holochain_core::{
         action::Action,
         context::Context,
@@ -216,8 +216,9 @@ mod tests {
                 ContextBuilder::new()
                     .with_agent(agent)
                     .with_logger(logger.clone())
-                    .with_file_storage(tempdir().unwrap().path().to_str().unwrap()).unwrap()
-                    .spawn()
+                    .with_file_storage(tempdir().unwrap().path().to_str().unwrap())
+                    .unwrap()
+                    .spawn(),
             ),
             logger,
         )

--- a/container_api/src/holochain.rs
+++ b/container_api/src/holochain.rs
@@ -188,28 +188,21 @@ impl Holochain {
 mod tests {
     extern crate holochain_cas_implementations;
 
-    use self::holochain_cas_implementations::{
-        cas::file::FilesystemStorage, eav::file::EavFileStorage,
-    };
-
+    use context_builder::ContextBuilder;
     use super::*;
     use holochain_core::{
         action::Action,
-        context::{mock_network_config, Context},
+        context::Context,
         nucleus::ribosome::{callback::Callback, Defn},
-        persister::SimplePersister,
         signal::{signal_channel, Signal},
     };
     use holochain_core_types::{agent::AgentId, cas::content::AddressableContent, dna::Dna};
-
-    use std::sync::{Arc, Mutex, RwLock};
+    use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
     use test_utils::{
         create_test_cap_with_fn_name, create_test_dna_with_cap, create_test_dna_with_wat,
         create_wasm_from_file, expect_action, hc_setup_and_call_zome_fn,
     };
-
-    use std::{fs::File, io::prelude::*, path::MAIN_SEPARATOR};
 
     // TODO: TestLogger duplicated in test_utils because:
     //  use holochain_core::{instance::tests::TestLogger};
@@ -217,26 +210,20 @@ mod tests {
     // @see https://github.com/holochain/holochain-rust/issues/185
     fn test_context(agent_name: &str) -> (Arc<Context>, Arc<Mutex<test_utils::TestLogger>>) {
         let agent = AgentId::generate_fake(agent_name);
-        let file_storage = Arc::new(RwLock::new(
-            FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap(),
-        ));
         let logger = test_utils::test_logger();
         (
-            Arc::new(Context::new(
-                agent,
-                logger.clone(),
-                Arc::new(Mutex::new(SimplePersister::new(file_storage.clone()))),
-                file_storage.clone(),
-                file_storage.clone(),
-                Arc::new(RwLock::new(
-                    EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
-                        .unwrap(),
-                )),
-                mock_network_config(),
-            )),
+            Arc::new(
+                ContextBuilder::new()
+                    .with_agent(agent)
+                    .with_logger(logger.clone())
+                    .with_file_storage(tempdir().unwrap().path().to_str().unwrap()).unwrap()
+                    .spawn()
+            ),
             logger,
         )
     }
+
+    use std::{fs::File, io::prelude::*, path::MAIN_SEPARATOR};
 
     fn example_api_wasm_path() -> String {
         "wasm-test/target/wasm32-unknown-unknown/release/example_api_wasm.wasm".into()

--- a/container_api/src/interface.rs
+++ b/container_api/src/interface.rs
@@ -30,14 +30,7 @@ pub trait DispatchRpc {
 /// This builder makes it convenient to create handlers with different configurations.
 ///
 /// Call any sequence of with_* functions on a ContainerApiBuilder object and finalize
-/// with spawn() to retrieve the IoHandler:
-/// # Example
-/// ```rust
-/// let handler = ContainerApiBuilder::new()
-//            .with_instances(instances.clone())
-//            .with_instance_configs(config.instances)
-//            .spawn();
-/// ```
+/// with spawn() to retrieve the IoHandler.
 pub struct ContainerApiBuilder {
     instances: InstanceMap,
     instance_configs: HashMap<String, InstanceConfiguration>,

--- a/container_api/src/interface.rs
+++ b/container_api/src/interface.rs
@@ -37,7 +37,6 @@ pub struct ContainerApiBuilder {
     io: Box<IoHandler>,
 }
 
-
 impl ContainerApiBuilder {
     pub fn new() -> Self {
         ContainerApiBuilder {
@@ -156,16 +155,11 @@ pub trait Interface {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{
-        config::Configuration,
-        container::tests::test_container,
-    };
+    use crate::{config::Configuration, container::tests::test_container};
 
     fn example_config_and_instances() -> (Configuration, InstanceMap) {
         let container = test_container();
-        let holochain = container.instances.get("test-instance-1")
-            .unwrap()
-            .clone();
+        let holochain = container.instances.get("test-instance-1").unwrap().clone();
         let mut instances = InstanceMap::new();
         instances.insert("test-instance-1".into(), holochain);
         (container.config, instances)
@@ -189,8 +183,14 @@ pub mod tests {
     fn test_named_instances() {
         let (config, instances) = example_config_and_instances();
         let handler = ContainerApiBuilder::new()
-            .with_named_instance(String::from("happ-store"), instances.iter().nth(0).unwrap().1.clone())
-            .with_named_instance_config(String::from("happ-store"), config.instances.iter().nth(0).unwrap().clone())
+            .with_named_instance(
+                String::from("happ-store"),
+                instances.iter().nth(0).unwrap().1.clone(),
+            )
+            .with_named_instance_config(
+                String::from("happ-store"),
+                config.instances.iter().nth(0).unwrap().clone(),
+            )
             .spawn();
         let result = format!("{:?}", handler).to_string();
         println!("{}", result);

--- a/container_api/src/interface.rs
+++ b/container_api/src/interface.rs
@@ -162,7 +162,7 @@ pub mod tests {
         let holochain = container.instances.get("test-instance-1").unwrap().clone();
         let mut instances = InstanceMap::new();
         instances.insert("test-instance-1".into(), holochain);
-        (container.config, instances)
+        (container.config(), instances)
     }
 
     #[test]

--- a/container_api/src/interface_impls/http.rs
+++ b/container_api/src/interface_impls/http.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 use tiny_http::{Response, Server};
-
+use jsonrpc_ws_server::jsonrpc_core::{self, IoHandler, Value};
 use interface::{DispatchRpc, Interface};
 
 pub struct HttpInterface {
@@ -17,7 +17,7 @@ impl HttpInterface {
 }
 
 impl Interface for HttpInterface {
-    fn run(&self, _dispatcher: Arc<DispatchRpc>) -> Result<(), String> {
+    fn run(&self, _handlerr: IoHandler) -> Result<(), String> {
         let server_url = format!("0.0.0.0:{}", self.port);
         let server = Server::http(server_url.as_str()).unwrap();
         for request in server.incoming_requests() {

--- a/container_api/src/interface_impls/websocket.rs
+++ b/container_api/src/interface_impls/websocket.rs
@@ -1,6 +1,5 @@
-use jsonrpc_ws_server::ServerBuilder;
-
-use interface::{ContainerApiDispatcher, DispatchRpc, Interface};
+use interface::Interface;
+use jsonrpc_ws_server::{jsonrpc_core::IoHandler, ServerBuilder};
 
 pub struct WebsocketInterface {
     port: u16,
@@ -12,11 +11,10 @@ impl WebsocketInterface {
     }
 }
 
-impl Interface<ContainerApiDispatcher> for WebsocketInterface {
-    fn run(&self, dispatcher: ContainerApiDispatcher) -> Result<(), String> {
-        let io = dispatcher.handler();
+impl Interface for WebsocketInterface {
+    fn run(&self, handler: IoHandler) -> Result<(), String> {
         let url = format!("0.0.0.0:{}", self.port);
-        let server = ServerBuilder::new(io)
+        let server = ServerBuilder::new(handler)
             .start(&url.parse().expect("Invalid URL!"))
             .map_err(|e| e.to_string())?;
         server.wait().map_err(|e| e.to_string())?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,6 +31,7 @@ holochain_cas_implementations = { path = "../cas_implementations" }
 holochain_net_connection = { path = "../net_connection" }
 base64 = "*"
 boolinator = "2.4.0"
+jsonrpc-ws-server = { git = "https://github.com/paritytech/jsonrpc" }
 
 [dev-dependencies]
 wabt = "0.7.2"

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -2,7 +2,6 @@ use crate::{
     action::ActionWrapper, instance::Observer, logger::Logger, persister::Persister,
     signal::Signal, state::State,
 };
-use jsonrpc_ws_server::jsonrpc_core::IoHandler;
 use holochain_core_types::{
     agent::AgentId,
     cas::storage::ContentAddressableStorage,
@@ -12,6 +11,7 @@ use holochain_core_types::{
     json::JsonString,
 };
 use holochain_net::p2p_config::P2pConfig;
+use jsonrpc_ws_server::jsonrpc_core::IoHandler;
 use std::{
     sync::{mpsc::SyncSender, Arc, Mutex, RwLock, RwLockReadGuard},
     thread::sleep,

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -2,6 +2,7 @@ use crate::{
     action::ActionWrapper, instance::Observer, logger::Logger, persister::Persister,
     signal::Signal, state::State,
 };
+use jsonrpc_ws_server::jsonrpc_core::IoHandler;
 use holochain_core_types::{
     agent::AgentId,
     cas::storage::ContentAddressableStorage,
@@ -34,6 +35,7 @@ pub struct Context {
     pub dht_storage: Arc<RwLock<ContentAddressableStorage>>,
     pub eav_storage: Arc<RwLock<EntityAttributeValueStorage>>,
     pub network_config: JsonString,
+    pub container_api: Option<Arc<RwLock<IoHandler>>>,
 }
 
 impl Context {
@@ -49,6 +51,7 @@ impl Context {
         dht_storage: Arc<RwLock<ContentAddressableStorage>>,
         eav: Arc<RwLock<EntityAttributeValueStorage>>,
         network_config: JsonString,
+        container_api: Option<Arc<RwLock<IoHandler>>>,
     ) -> Self {
         Context {
             agent_id,
@@ -62,6 +65,7 @@ impl Context {
             dht_storage,
             eav_storage: eav,
             network_config,
+            container_api,
         }
     }
 
@@ -88,6 +92,7 @@ impl Context {
             dht_storage: cas,
             eav_storage: eav,
             network_config,
+            container_api: None,
         })
     }
 
@@ -231,6 +236,7 @@ pub mod tests {
                     .unwrap(),
             )),
             mock_network_config(),
+            None,
         );
 
         assert!(maybe_context.state().is_none());
@@ -262,6 +268,7 @@ pub mod tests {
                     .unwrap(),
             )),
             mock_network_config(),
+            None,
         );
 
         let global_state = Arc::new(RwLock::new(State::new(Arc::new(context.clone()))));

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -411,6 +411,7 @@ pub mod tests {
                         .unwrap(),
                 )),
                 mock_network_config(),
+                None,
             )),
             logger,
         )
@@ -470,6 +471,7 @@ pub mod tests {
                     .unwrap(),
             )),
             mock_network_config(),
+            None,
         );
         let global_state = Arc::new(RwLock::new(State::new(Arc::new(context.clone()))));
         context.set_state(global_state.clone());
@@ -492,6 +494,7 @@ pub mod tests {
                     .unwrap(),
             )),
             mock_network_config(),
+            None,
         );
         let chain_store = ChainStore::new(cas.clone());
         let chain_header = test_chain_header();

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -240,6 +240,7 @@ pub mod tests {
                     .unwrap(),
             )),
             mock_network_config(),
+            None,
         ))
     }
 

--- a/core_api_c_binding/src/lib.rs
+++ b/core_api_c_binding/src/lib.rs
@@ -5,21 +5,17 @@ extern crate holochain_core;
 extern crate holochain_core_types;
 extern crate holochain_net;
 
-use holochain_cas_implementations::{
-    cas::file::FilesystemStorage, eav::file::EavFileStorage, path::create_path_if_not_exists,
-};
-use holochain_container_api::Holochain;
-use holochain_core::context::{mock_network_config, Context};
+use holochain_container_api::{context_builder::ContextBuilder, Holochain};
+use holochain_core::context::Context;
 use holochain_core_types::{dna::Dna, error::HolochainError};
 
 use std::sync::Arc;
 
-use holochain_core::{logger::Logger, persister::SimplePersister};
+use holochain_core::logger::Logger;
 use holochain_core_types::agent::AgentId;
 use std::{
     ffi::{CStr, CString},
     os::raw::c_char,
-    sync::{Mutex, RwLock},
 };
 
 #[derive(Clone, Debug)]
@@ -62,21 +58,11 @@ pub unsafe extern "C" fn holochain_load(storage_path: CStrPtr) -> *mut Holochain
 
 fn get_context(path: &String) -> Result<Context, HolochainError> {
     let agent = AgentId::generate_fake("c_bob");
-    let cas_path = format!("{}/cas", path);
-    let eav_path = format!("{}/eav", path);
-    let _agent_path = format!("{}/state", path);
-    create_path_if_not_exists(&cas_path)?;
-    create_path_if_not_exists(&eav_path)?;
-    let file_storage = Arc::new(RwLock::new(FilesystemStorage::new(&cas_path)?));
-    Ok(Context::new(
-        agent,
-        Arc::new(Mutex::new(NullLogger {})),
-        Arc::new(Mutex::new(SimplePersister::new(file_storage.clone()))),
-        Arc::new(RwLock::new(FilesystemStorage::new(&cas_path)?)),
-        Arc::new(RwLock::new(FilesystemStorage::new(&cas_path)?)),
-        Arc::new(RwLock::new(EavFileStorage::new(eav_path)?)),
-        mock_network_config(),
-    ))
+    Ok(ContextBuilder::new()
+        .with_agent(agent)
+        .with_file_storage(path.clone())?
+        .spawn()
+    )
 }
 
 #[no_mangle]

--- a/core_api_c_binding/src/lib.rs
+++ b/core_api_c_binding/src/lib.rs
@@ -61,8 +61,7 @@ fn get_context(path: &String) -> Result<Context, HolochainError> {
     Ok(ContextBuilder::new()
         .with_agent(agent)
         .with_file_storage(path.clone())?
-        .spawn()
-    )
+        .spawn())
 }
 
 #[no_mangle]

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -6,12 +6,9 @@ extern crate holochain_net;
 extern crate serde_json;
 extern crate tempfile;
 
-use holochain_container_api::{*, context_builder::ContextBuilder};
+use holochain_container_api::{context_builder::ContextBuilder, *};
 use holochain_core_types::{agent::AgentId, dna::Dna};
-use std::{
-    env,
-    sync::Arc,
-};
+use std::{env, sync::Arc};
 
 use tempfile::tempdir;
 

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -6,17 +6,11 @@ extern crate holochain_net;
 extern crate serde_json;
 extern crate tempfile;
 
-use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
-use holochain_container_api::*;
-use holochain_core::{
-    context::{mock_network_config, Context},
-    logger::SimpleLogger,
-    persister::SimplePersister,
-};
+use holochain_container_api::{*, context_builder::ContextBuilder};
 use holochain_core_types::{agent::AgentId, dna::Dna};
 use std::{
     env,
-    sync::{Arc, Mutex, RwLock},
+    sync::Arc,
 };
 
 use tempfile::tempdir;
@@ -46,24 +40,11 @@ fn main() {
     let tempdir = tempdir().unwrap();
     let dna = Dna::new();
     let agent = AgentId::generate_fake(identity);
-    let file_storage = Arc::new(RwLock::new(
-        FilesystemStorage::new(tempdir.path().to_str().unwrap()).unwrap(),
-    ));
-    let context = Context::new(
-        agent,
-        Arc::new(Mutex::new(SimpleLogger {})),
-        Arc::new(Mutex::new(SimplePersister::new(file_storage.clone()))),
-        Arc::new(RwLock::new(
-            FilesystemStorage::new(tempdir.path().to_str().unwrap()).unwrap(),
-        )),
-        Arc::new(RwLock::new(
-            FilesystemStorage::new(tempdir.path().to_str().unwrap()).unwrap(),
-        )),
-        Arc::new(RwLock::new(
-            EavFileStorage::new(tempdir.path().to_str().unwrap().to_string()).unwrap(),
-        )),
-        mock_network_config(),
-    );
+    let context = ContextBuilder::new()
+        .with_agent(agent)
+        .with_file_storage(tempdir.path().to_str().unwrap())
+        .expect("Tempdir must be accessible")
+        .spawn();
 
     // Create Holochain Instance
     let mut hc =

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -7,13 +7,11 @@ extern crate serde_json;
 extern crate tempfile;
 extern crate wabt;
 
-use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
-use holochain_container_api::{error::HolochainResult, Holochain};
+use holochain_container_api::{context_builder::ContextBuilder, error::HolochainResult, Holochain};
 use holochain_core::{
     action::Action,
-    context::{mock_network_config, Context},
+    context::Context,
     logger::Logger,
-    persister::SimplePersister,
     signal::Signal,
 };
 use holochain_core_types::{
@@ -35,7 +33,7 @@ use std::{
     fs::File,
     hash::{Hash, Hasher},
     io::prelude::*,
-    sync::{mpsc::Receiver, Arc, Mutex, RwLock},
+    sync::{mpsc::Receiver, Arc, Mutex},
     time::Duration,
 };
 use tempfile::tempdir;
@@ -195,24 +193,15 @@ pub fn test_logger() -> Arc<Mutex<TestLogger>> {
 #[cfg_attr(tarpaulin, skip)]
 pub fn test_context_and_logger(agent_name: &str) -> (Arc<Context>, Arc<Mutex<TestLogger>>) {
     let agent = AgentId::generate_fake(agent_name);
-    let file_storage = Arc::new(RwLock::new(
-        FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap(),
-    ));
     let logger = test_logger();
     (
         Arc::new(
-            Context::new(
-                agent,
-                logger.clone(),
-                Arc::new(Mutex::new(SimplePersister::new(file_storage.clone()))),
-                file_storage.clone(),
-                file_storage.clone(),
-                Arc::new(RwLock::new(
-                    EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
-                        .unwrap(),
-                )),
-                mock_network_config(),
-            )
+            ContextBuilder::new()
+                .with_agent(agent)
+                .with_logger(logger.clone())
+                .with_file_storage(tempdir().unwrap().path().to_str().unwrap())
+                .expect("Tempdir must be accessible")
+                .spawn()
         ),
         logger,
     )
@@ -252,24 +241,12 @@ pub fn hc_setup_and_call_zome_fn(wasm_path: &str, fn_name: &str) -> HolochainRes
 /// create a test context and TestLogger pair so we can use the logger in assertions
 pub fn create_test_context(agent_name: &str) -> Arc<Context> {
     let agent = AgentId::generate_fake(agent_name);
-    let logger = test_logger();
-
-    let file_storage = Arc::new(RwLock::new(
-        FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap(),
-    ));
     Arc::new(
-        Context::new(
-            agent,
-            logger.clone(),
-            Arc::new(Mutex::new(SimplePersister::new(file_storage.clone()))),
-            file_storage.clone(),
-            file_storage.clone(),
-            Arc::new(RwLock::new(
-                EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
-                    .unwrap(),
-            )),
-            mock_network_config(),
-        )
+        ContextBuilder::new()
+            .with_agent(agent)
+            .with_file_storage(tempdir().unwrap().path().to_str().unwrap())
+            .expect("Tempdir must be accessible")
+            .spawn()
     )
 }
 


### PR DESCRIPTION
## Context
This is about exposing the container API to instances for the purpose of bridging.
This SoA in the tree:
![screenshot 2018-12-18 at 18 45 09](https://user-images.githubusercontent.com/311749/50172312-125f7680-02f5-11e9-93be-34aed0aef763.png)

## `ContainerApiDispatcher` -> Builder
The main changes here are to what was `ContainerApiDispatcher` before and is now `ContainerApiBuilder`. The main thing used outside was the `IoHandler` anyway. I am using the same thing that gets exposed to (external) interfaces now also for interfacing from instances. But for that we need more control over the methods that get registered in a particular interface context. Hence the transformation to a builder.

## `Container::instantiate_from_config()`
That function moved into `Container` and makes use of the `ContainerApiBuilder` to add each instance that the current instance depends on. This relies on my last PR https://github.com/holochain/holochain-rust/pull/773 that makes sure that we have a topological ordering of instances so we can expect dependencies to have spawned before. (See those `expect()` statements there).

## Changes around `Context`
Since I had to change `Context::new` again to include the `container_api: IoHandler` I couldn't resist but apply the `ContextBuilder` in all those places that I had to touch again. Sorry for the noise.