### PR TITLE
Tiny PR - change the default agent id used by `hc run`

### DIFF
--- a/cmd/src/cli/run.rs
+++ b/cmd/src/cli/run.rs
@@ -19,7 +19,7 @@ pub fn run(package: bool, port: u16, persist: bool) -> DefaultResult<()> {
         cli::package(true, Some(package::DEFAULT_BUNDLE_FILE_NAME.into()))?;
     }
 
-    let agent = AgentId::generate_fake("developer_test_agent");
+    let agent = AgentId::generate_fake("testAgent");
     let agent_config = AgentConfiguration {
         id: AGENT_CONFIG_ID.into(),
         name: agent.nick,


### PR DESCRIPTION
Changes in the requirements for agent IDs caused `hc run` to be unable to start. All that was required was changing the agent id to valid base64 (previously it included an underscore)