### PR TITLE
add temporary checks in network handler to filter messages to others

### DIFF
--- a/core/src/network/handler/mod.rs
+++ b/core/src/network/handler/mod.rs
@@ -9,6 +9,30 @@ use crate::{
 use holochain_net_connection::{net_connection::NetHandler, protocol_wrapper::ProtocolWrapper};
 use std::{convert::TryFrom, sync::Arc};
 
+// FIXME: Temporary hack to ignore messages incorrectly sent to us by the networking
+// module that aren't really meant for us:
+fn is_me(c: &Arc<Context>, dna_hash: &str, agent_id: &str) -> bool {
+    // TODO: we also need a better way to easily get the DNA hash!!
+    let state = c
+        .state()
+        .ok_or("is_me could not get application state".to_string())
+        .unwrap();
+    let dna = state
+        .nucleus()
+        .dna()
+        .ok_or("is_me called without DNA".to_string())
+        .unwrap();
+    let my_dna_hash = base64::encode(&dna.multihash().unwrap());
+
+    if my_dna_hash != dna_hash {
+        return false;
+    }
+    if agent_id != "" && c.agent_id.key != agent_id {
+        return false;
+    }
+    true
+}
+
 /// Creates the network handler.
 /// The returned closure is called by the network thread for every network event that core
 /// has to handle.
@@ -18,20 +42,42 @@ pub fn create_handler(c: &Arc<Context>) -> NetHandler {
         let message = message.unwrap();
         let protocol_wrapper = ProtocolWrapper::try_from(message);
         match protocol_wrapper {
-            Ok(ProtocolWrapper::StoreDht(dht_data)) => handle_store_dht(dht_data, context.clone()),
+            Ok(ProtocolWrapper::StoreDht(dht_data)) => {
+                // NOTE data in message doesn't allow us to confirm agent!
+                if !is_me(&context, &dht_data.dna_hash, "") {
+                    return Ok(());
+                }
+                handle_store_dht(dht_data, context.clone())
+            }
             Ok(ProtocolWrapper::StoreDhtMeta(dht_meta_data)) => {
+                if !is_me(&context, &dht_meta_data.dna_hash, &dht_meta_data.agent_id) {
+                    return Ok(());
+                }
                 handle_store_dht_meta(dht_meta_data, context.clone())
             }
             Ok(ProtocolWrapper::GetDht(get_dht_data)) => {
+                // NOTE data in message doesn't allow us to confirm agent!
+                if !is_me(&context, &get_dht_data.dna_hash, "") {
+                    return Ok(());
+                }
                 handle_get_dht(get_dht_data, context.clone())
             }
             Ok(ProtocolWrapper::GetDhtResult(dht_data)) => {
+                if !is_me(&context, &dht_data.dna_hash, &dht_data.agent_id) {
+                    return Ok(());
+                }
                 handle_get_dht_result(dht_data, context.clone())
             }
             Ok(ProtocolWrapper::HandleSend(message_data)) => {
+                if !is_me(&context, &message_data.dna_hash, &message_data.to_agent_id) {
+                    return Ok(());
+                }
                 handle_send(message_data, context.clone())
             }
             Ok(ProtocolWrapper::SendResult(message_data)) => {
+                if !is_me(&context, &message_data.dna_hash, &message_data.to_agent_id) {
+                    return Ok(());
+                }
                 handle_send_result(message_data, context.clone())
             }
             _ => {}

--- a/core/src/network/handler/mod.rs
+++ b/core/src/network/handler/mod.rs
@@ -50,7 +50,7 @@ pub fn create_handler(c: &Arc<Context>) -> NetHandler {
                 handle_store_dht(dht_data, context.clone())
             }
             Ok(ProtocolWrapper::StoreDhtMeta(dht_meta_data)) => {
-                if !is_me(&context, &dht_meta_data.dna_hash, &dht_meta_data.agent_id) {
+                if !is_me(&context, &dht_meta_data.dna_hash, "") {
                     return Ok(());
                 }
                 handle_store_dht_meta(dht_meta_data, context.clone())


### PR DESCRIPTION
Currently a single process instance of the networking doesn't multi-plex correctly, and our code is assuming one spawn per systems.  This pr adds checks to filter messages so an instance doesn't processes messages intended for others.