### PR TITLE
Update for futures-preview alpha 11 and nightly-2018-12-26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ _cargo_cache_template: &_cargo_cache_template
 _windows_template: &_windows_template
   os: windows
   language: rust
-  rust: nightly-2018-11-28-x86_64-pc-windows-msvc
+  rust: nightly-2018-12-26-x86_64-pc-windows-msvc
   before_install:
   - choco install nodist
   - PATH="/c/Program Files (x86)/Nodist/bin:$PATH"
@@ -67,12 +67,12 @@ _unix_nodejs_container_template: &_unix_nodejs_container_template
 _linux_nodejs_template: &_linux_nodejs_template
   os: linux
   language: rust
-  rust: nightly-2018-11-28
+  rust: nightly-2018-12-26
 
 _macosx_nodejs_template: &_macosx_nodejs_template
   os: osx
   language: rust
-  rust: nightly-2018-11-28
+  rust: nightly-2018-12-26
 
 _to_deploy_template: &_to_deploy_template
   if: tag =~ /^holochain-nodejs-v\d+\.\d+\.\d+/
@@ -130,7 +130,7 @@ _windows_nodejs_container_template: &_windows_nodejs_container_template
 # holochain-cmd deploy template
 _cmd_deploy_template: &_cmd_deploy_template
   language: rust
-  rust: nightly-2018-11-28
+  rust: nightly-2018-12-26
   if: tag =~ /^holochain-cmd-v\d+\.\d+\.\d+/
   before_script:
     - make install_system_libzmq
@@ -157,7 +157,7 @@ env:
 _windows_template_lite: &_windows_template_lite
   os: windows
   language: rust
-  rust: nightly-2018-11-28-x86_64-pc-windows-msvc
+  rust: nightly-2018-12-26-x86_64-pc-windows-msvc
   before_install:
    - PATH=$PATH:$TRAVIS_BUILD_DIR/vendor/zmq/bin
    - CARGO_INCREMENTAL=1
@@ -411,7 +411,7 @@ jobs:
     - name: "CMD DEPLOY - 64 bit Windows MSVC"
       <<: *_cmd_deploy_template
       os: windows
-      rust: nightly-2018-11-28-x86_64-pc-windows-msvc
+      rust: nightly-2018-12-26-x86_64-pc-windows-msvc
       env:
         - TARGET=x86_64-pc-windows-msvc
         - CRATE_NAME=hc
@@ -422,7 +422,7 @@ jobs:
     - name: "CMD DEPLOY - 64 bit Windows GNU"
       <<: *_cmd_deploy_template
       os: windows
-      rust: nightly-2018-11-28-x86_64-pc-windows-gnu
+      rust: nightly-2018-12-26-x86_64-pc-windows-gnu
       env:
         - TARGET=x86_64-pc-windows-gnu
         - CRATE_NAME=hc

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@
 
 all: lint build_holochain build_cmd
 
-CORE_RUST_VERSION ?= nightly-2018-11-28
-TOOLS_RUST_VERSION ?= nightly-2018-11-28
+CORE_RUST_VERSION ?= nightly-2018-12-26
+TOOLS_RUST_VERSION ?= nightly-2018-12-26
 CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(CORE_RUST_VERSION) cargo $(CARGO_ARGS)
 CARGO_TOOLS = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(TOOLS_RUST_VERSION) cargo $(CARGO_ARGS)
 CARGO_TARPULIN_INSTALL = RUSTFLAGS="--cfg procmacro2_semver_exempt -D warnings" RUST_BACKTRACE=1 cargo $(CARGO_ARGS) +$(CORE_RUST_VERSION)

--- a/container_api/Cargo.toml
+++ b/container_api/Cargo.toml
@@ -8,7 +8,7 @@ holochain_cas_implementations = { path = "../cas_implementations" }
 holochain_core = { path = "../core" }
 holochain_core_types = { path = "../core_types" }
 holochain_net = { path = "../net" }
-futures-preview = "0.3.0-alpha.10"
+futures-preview = "0.3.0-alpha.11"
 tempfile = "3"
 serde = "1.0"
 serde_derive = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@ multihash = "0.8.0"
 bitflags = "1.0"
 holochain_wasm_utils = { path = "../wasm_utils"}
 failure = "0.1.3"
-futures-preview = "0.3.0-alpha.10"
+futures-preview = "0.3.0-alpha.11"
 lazy_static = "1.1.0"
 unwrap_to = "0.1.0"
 num-traits = "0.2"

--- a/core/src/agent/actions/commit.rs
+++ b/core/src/agent/actions/commit.rs
@@ -10,10 +10,7 @@ use futures::{
     task::{LocalWaker, Poll},
 };
 use holochain_core_types::{cas::content::Address, entry::Entry, error::HolochainError};
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-};
+use std::{pin::Pin, sync::Arc};
 //use core::mem::PinMut;
 
 /// Commit Action Creator
@@ -40,8 +37,6 @@ pub struct CommitFuture {
     context: Arc<Context>,
     action: ActionWrapper,
 }
-
-impl Unpin for CommitFuture {}
 
 impl Future for CommitFuture {
     type Output = Result<Address, HolochainError>;

--- a/core/src/agent/actions/update_entry.rs
+++ b/core/src/agent/actions/update_entry.rs
@@ -12,7 +12,7 @@ use futures::{
 };
 use holochain_core_types::{cas::content::Address, error::HolochainError};
 use std::{
-    pin::{Pin, Unpin},
+    pin::Pin,
     sync::{mpsc::SyncSender, Arc},
 };
 
@@ -39,8 +39,6 @@ pub struct UpdateEntryFuture {
     context: Arc<Context>,
     action: ActionWrapper,
 }
-
-impl Unpin for UpdateEntryFuture {}
 
 impl Future for UpdateEntryFuture {
     type Output = Result<Address, HolochainError>;

--- a/core/src/dht/actions/add_link.rs
+++ b/core/src/dht/actions/add_link.rs
@@ -10,10 +10,7 @@ use futures::{
     task::{LocalWaker, Poll},
 };
 use holochain_core_types::{error::HolochainError, link::Link};
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-};
+use std::{pin::Pin, sync::Arc};
 
 /// AddLink Action Creator
 /// This action creator dispatches an AddLink action which is consumed by the DHT reducer.
@@ -37,8 +34,6 @@ pub struct AddLinkFuture {
     context: Arc<Context>,
     action: ActionWrapper,
 }
-
-impl Unpin for AddLinkFuture {}
 
 impl Future for AddLinkFuture {
     type Output = Result<(), HolochainError>;

--- a/core/src/dht/actions/hold.rs
+++ b/core/src/dht/actions/hold.rs
@@ -14,10 +14,7 @@ use holochain_core_types::{
     entry::Entry,
     error::HolochainError,
 };
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-};
+use std::{pin::Pin, sync::Arc};
 
 pub async fn hold_entry<'a>(
     entry: &'a Entry,
@@ -36,8 +33,6 @@ pub struct HoldEntryFuture {
     context: Arc<Context>,
     address: Address,
 }
-
-impl Unpin for HoldEntryFuture {}
 
 impl Future for HoldEntryFuture {
     type Output = Result<Address, HolochainError>;

--- a/core/src/dht/actions/remove_entry.rs
+++ b/core/src/dht/actions/remove_entry.rs
@@ -11,7 +11,7 @@ use futures::{
 };
 use holochain_core_types::{cas::content::Address, error::HolochainError};
 use std::{
-    pin::{Pin, Unpin},
+    pin::Pin,
     sync::{mpsc::SyncSender, Arc},
 };
 
@@ -39,8 +39,6 @@ pub struct RemoveEntryFuture {
     context: Arc<Context>,
     action: ActionWrapper,
 }
-
-impl Unpin for RemoveEntryFuture {}
 
 impl Future for RemoveEntryFuture {
     type Output = Result<(), HolochainError>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,12 +1,5 @@
 //! The library implementing the holochain pattern of validation rules + local source chain + DHT
-#![feature(
-    try_from,
-    pin,
-    arbitrary_self_types,
-    futures_api,
-    async_await,
-    await_macro
-)]
+#![feature(try_from, arbitrary_self_types, futures_api, async_await, await_macro)]
 #[macro_use]
 extern crate serde_derive;
 extern crate chrono;

--- a/core/src/network/actions/custom_send.rs
+++ b/core/src/network/actions/custom_send.rs
@@ -11,12 +11,7 @@ use futures::{
 };
 use holochain_core_types::{cas::content::Address, error::HolochainError};
 use snowflake::ProcessUniqueId;
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-    thread::sleep,
-    time::Duration,
-};
+use std::{pin::Pin, sync::Arc};
 
 /// SendDirectMessage Action Creator for custom (=app) messages
 /// This triggers the network module to open a synchronous node-to-node connection
@@ -37,11 +32,11 @@ pub async fn custom_send(
     let action_wrapper = ActionWrapper::new(Action::SendDirectMessage(direct_message_data));
     dispatch_action(context.action_channel(), action_wrapper);
 
-    async {
+    /* async {
         sleep(Duration::from_secs(60));
         let action_wrapper = ActionWrapper::new(Action::SendDirectMessageTimeout(id.clone()));
         dispatch_action(context.action_channel(), action_wrapper.clone());
-    };
+    };*/
 
     await!(SendResponseFuture {
         context: context.clone(),
@@ -54,8 +49,6 @@ pub struct SendResponseFuture {
     context: Arc<Context>,
     id: String,
 }
-
-impl Unpin for SendResponseFuture {}
 
 impl Future for SendResponseFuture {
     type Output = Result<String, HolochainError>;

--- a/core/src/network/actions/get_entry.rs
+++ b/core/src/network/actions/get_entry.rs
@@ -9,12 +9,7 @@ use futures::{
     task::{LocalWaker, Poll},
 };
 use holochain_core_types::{cas::content::Address, entry::EntryWithMeta, error::HcResult};
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-    thread::sleep,
-    time::Duration,
-};
+use std::{pin::Pin, sync::Arc};
 
 /// GetEntry Action Creator
 /// This is the network version of get_entry that makes the network module start
@@ -27,11 +22,11 @@ pub async fn get_entry<'a>(
 ) -> HcResult<Option<EntryWithMeta>> {
     let action_wrapper = ActionWrapper::new(Action::GetEntry(address.clone()));
     dispatch_action(context.action_channel(), action_wrapper.clone());
-    async {
+    /*    async {
         sleep(Duration::from_secs(60));
         let action_wrapper = ActionWrapper::new(Action::GetEntryTimeout(address.clone()));
         dispatch_action(context.action_channel(), action_wrapper.clone());
-    };
+    };*/
     await!(GetEntryFuture {
         context: context.clone(),
         address: address.clone(),
@@ -44,8 +39,6 @@ pub struct GetEntryFuture {
     context: Arc<Context>,
     address: Address,
 }
-
-impl Unpin for GetEntryFuture {}
 
 impl Future for GetEntryFuture {
     type Output = HcResult<Option<EntryWithMeta>>;

--- a/core/src/network/actions/get_validation_package.rs
+++ b/core/src/network/actions/get_validation_package.rs
@@ -12,10 +12,7 @@ use holochain_core_types::{
     cas::content::Address, chain_header::ChainHeader, error::HcResult,
     validation::ValidationPackage,
 };
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-};
+use std::{pin::Pin, sync::Arc};
 
 /// GetValidationPackage Action Creator
 /// This triggers the network module to retrieve the validation package for the
@@ -43,8 +40,6 @@ pub struct GetValidationPackageFuture {
     context: Arc<Context>,
     address: Address,
 }
-
-impl Unpin for GetValidationPackageFuture {}
 
 impl Future for GetValidationPackageFuture {
     type Output = HcResult<Option<ValidationPackage>>;

--- a/core/src/network/actions/initialize_network.rs
+++ b/core/src/network/actions/initialize_network.rs
@@ -10,10 +10,7 @@ use futures::{
     Future,
 };
 use holochain_core_types::error::HcResult;
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-};
+use std::{pin::Pin, sync::Arc};
 
 /// Creates a network proxy object and stores DNA and agent hash in the network state.
 pub async fn initialize_network(context: &Arc<Context>) -> HcResult<()> {
@@ -53,8 +50,6 @@ pub async fn initialize_network_with_spoofed_dna(
 pub struct InitNetworkFuture {
     context: Arc<Context>,
 }
-
-impl Unpin for InitNetworkFuture {}
 
 impl Future for InitNetworkFuture {
     type Output = HcResult<()>;

--- a/core/src/network/actions/publish.rs
+++ b/core/src/network/actions/publish.rs
@@ -10,10 +10,7 @@ use futures::{
     task::{LocalWaker, Poll},
 };
 use holochain_core_types::{cas::content::Address, error::HcResult};
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-};
+use std::{pin::Pin, sync::Arc};
 
 /// Publish Action Creator
 /// This is the high-level publish function that wraps the whole publish process and is what should
@@ -35,8 +32,6 @@ pub struct PublishFuture {
     context: Arc<Context>,
     action: ActionWrapper,
 }
-
-impl Unpin for PublishFuture {}
 
 impl Future for PublishFuture {
     type Output = HcResult<Address>;

--- a/core/src/nucleus/actions/build_validation_package.rs
+++ b/core/src/nucleus/actions/build_validation_package.rs
@@ -19,12 +19,7 @@ use holochain_core_types::{
     validation::{ValidationPackage, ValidationPackageDefinition::*},
 };
 use snowflake;
-use std::{
-    convert::TryInto,
-    pin::{Pin, Unpin},
-    sync::Arc,
-    thread,
-};
+use std::{convert::TryInto, pin::Pin, sync::Arc, thread};
 
 pub fn build_validation_package(entry: &Entry, context: &Arc<Context>) -> ValidationPackageFuture {
     let id = snowflake::ProcessUniqueId::new();
@@ -185,8 +180,6 @@ pub struct ValidationPackageFuture {
     key: snowflake::ProcessUniqueId,
     error: Option<HolochainError>,
 }
-
-impl Unpin for ValidationPackageFuture {}
 
 impl Future for ValidationPackageFuture {
     type Output = Result<ValidationPackage, HolochainError>;

--- a/core/src/nucleus/actions/initialize.rs
+++ b/core/src/nucleus/actions/initialize.rs
@@ -14,11 +14,7 @@ use futures::{
     task::{LocalWaker, Poll},
 };
 use holochain_core_types::{dna::Dna, entry::Entry, error::HolochainError};
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-    time::*,
-};
+use std::{pin::Pin, sync::Arc, time::*};
 
 /// Timeout in seconds for initialization process.
 /// Future will resolve to an error after this duration.
@@ -123,8 +119,6 @@ pub struct InitializationFuture {
     context: Arc<Context>,
     created_at: Instant,
 }
-
-impl Unpin for InitializationFuture {}
 
 impl Future for InitializationFuture {
     type Output = Result<NucleusStatus, HolochainError>;

--- a/core/src/nucleus/actions/validate.rs
+++ b/core/src/nucleus/actions/validate.rs
@@ -17,11 +17,7 @@ use holochain_core_types::{
     validation::ValidationData,
 };
 use snowflake;
-use std::{
-    pin::{Pin, Unpin},
-    sync::Arc,
-    thread,
-};
+use std::{pin::Pin, sync::Arc, thread};
 
 /// ValidateEntry Action Creator
 /// This is the high-level validate function that wraps the whole validation process and is what should
@@ -125,8 +121,6 @@ pub struct ValidationFuture {
     context: Arc<Context>,
     key: (snowflake::ProcessUniqueId, HashString),
 }
-
-impl Unpin for ValidationFuture {}
 
 impl Future for ValidationFuture {
     type Output = Result<HashString, HolochainError>;

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -168,7 +168,7 @@ pub fn validate_call(
             return Err(HolochainError::Dna(DnaError::ZomeNotFound(format!(
                 "Zome '{}' not found",
                 fn_call.zome_name.clone()
-            ))))
+            ))));
         }
         Some(zome) => zome,
     };

--- a/core_api_c_binding/src/lib.rs
+++ b/core_api_c_binding/src/lib.rs
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn holochain_call(
     ) {
         Ok(json_string_result) => {
             let string_result = String::from(json_string_result);
-            let string_trim = string_result.trim_right_matches(char::from(0));
+            let string_trim = string_result.trim_end_matches(char::from(0));
             match CString::new(string_trim) {
                 Ok(s) => s.into_raw(),
                 Err(_) => std::ptr::null_mut(),

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -10,7 +10,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 multihash = "0.8.0"
-futures-preview = "0.2.2"
+futures-preview = "0.3.0-alpha.11"
 reed-solomon = "0.2.1"
 rust-base58 = "0.0.4"
 snowflake = "1.2"

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let
     overlays = [ moz_overlay ];
   };
 
-  date = "2018-11-28";
+  date = "2018-12-26";
   wasmTarget = "wasm32-unknown-unknown";
 
   rust-build = (nixpkgs.rustChannelOfTargets "nightly" date [ wasmTarget ]);


### PR DESCRIPTION
currently this comments out the async timeouts in:
`core/src/network/actions/get_entry.rs` and `core/src/network/actions/custom_sent.rs` because I'm not sure how to get them to work given the new changes, but I don't think we have any tests that test them either.

Adding that to the SoA as a follow up.