### PR TITLE
WIP on making json string to JsonString conversion explicit

### DIFF
--- a/cas_implementations/src/cas/file.rs
+++ b/cas_implementations/src/cas/file.rs
@@ -67,7 +67,11 @@ impl ContentAddressableStorage for FilesystemStorage {
     fn fetch(&self, address: &Address) -> Result<Option<Content>, HolochainError> {
         let _guard = self.lock.read()?;
         if self.contains(&address)? {
-            Ok(Some(read_to_string(self.address_to_path(address))?.into()))
+            Ok(
+                Some(
+                    Content::from_json(&
+                    read_to_string(
+                        self.address_to_path(address))?)))
         } else {
             Ok(None)
         }

--- a/cas_implementations/src/eav/file.rs
+++ b/cas_implementations/src/eav/file.rs
@@ -160,7 +160,7 @@ impl EntityAttributeValueStorage for EavFileStorage {
                 .cloned()
                 .map(|maybe_eav_content|
                     // errors filtered out above... unwrap is safe.
-                    Content::from(maybe_eav_content.unwrap()))
+                    Content::from_json(&maybe_eav_content.unwrap()))
                 .map(|content| EntityAttributeValue::try_from_content(&content))
                 .collect::<HashSet<HcResult<EntityAttributeValue>>>();
 

--- a/cmd/src/cli/package.rs
+++ b/cmd/src/cli/package.rs
@@ -4,6 +4,7 @@ use colored::*;
 use holochain_core::nucleus::{ribosome, ZomeFnCall};
 use ignore::WalkBuilder;
 use serde_json::{self, Map, Value};
+use holochain_core_types::json::JsonString;
 use std::{
     fs::{self, File},
     io::{Read, Write},
@@ -152,7 +153,7 @@ impl Packager {
                         "HC",
                         context,
                         wasm_binary,
-                        &ZomeFnCall::new("", None, "__hdk_get_json_definition", ""),
+                        &ZomeFnCall::new("", None, "__hdk_get_json_definition", JsonString::null()),
                         Some("{}".as_bytes().to_vec()),
                     )?;
 

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -211,7 +211,7 @@ pub struct AgentConfiguration {
 
 impl From<AgentConfiguration> for AgentId {
     fn from(config: AgentConfiguration) -> Self {
-        AgentId::try_from(JsonString::try_from(config.id).expect("bad agent json"))
+        AgentId::try_from(JsonString::from_json(&config.id))
             .expect("bad agent json")
     }
 }
@@ -231,7 +231,7 @@ impl TryFrom<DnaConfiguration> for Dna {
         let mut f = File::open(dna_config.file)?;
         let mut contents = String::new();
         f.read_to_string(&mut contents)?;
-        Dna::try_from(JsonString::from(contents))
+        Dna::try_from(JsonString::from_json(&contents))
     }
 }
 

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -177,7 +177,7 @@ impl Container {
                 // Network config:
                 if let Some(network_config) = instance_config.network {
                     context_builder =
-                        context_builder.with_network_config(JsonString::from(network_config))
+                        context_builder.with_network_config(JsonString::from_json(&network_config))
                 };
 
                 // Storage:
@@ -245,7 +245,7 @@ impl Container {
         let mut f = File::open(file)?;
         let mut contents = String::new();
         f.read_to_string(&mut contents)?;
-        Dna::try_from(JsonString::from(contents))
+        Dna::try_from(JsonString::from_json(&contents))
     }
 
     fn make_interface_handler(&self, interface_config: &InterfaceConfiguration) -> IoHandler {

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -131,7 +131,7 @@ impl ContextBuilder {
             chain_storage,
             dht_storage,
             eav_storage,
-            self.network_config.unwrap_or(JsonString::from(String::from(
+            self.network_config.unwrap_or(JsonString::from_json(&String::from(
                 P2pConfig::DEFAULT_MOCK_CONFIG,
             ))),
             self.container_api,

--- a/container_api/src/holochain.rs
+++ b/container_api/src/holochain.rs
@@ -159,7 +159,7 @@ impl Holochain {
         if !self.active {
             return Err(HolochainInstanceError::InstanceNotActiveYet);
         }
-        let zome_call = ZomeFnCall::new(&zome, cap, &fn_name, String::from(params));
+        let zome_call = ZomeFnCall::new(&zome, cap, &fn_name, JsonString::from_json(&String::from(params)));
         Ok(call_and_wait_for_result(zome_call, &mut self.instance)?)
     }
 

--- a/container_api/wasm-test/src/lib.rs
+++ b/container_api/wasm-test/src/lib.rs
@@ -92,7 +92,7 @@ pub extern "C" fn debug_stacked_hello(encoded_allocation_of_input: usize) -> i32
             value: "fish".to_string(),
         },
     );
-    hdk_debug(&mut mem_stack, &JsonString::from("disruptive debug log"));
+    hdk_debug(&mut mem_stack, "disruptive debug log");
     fish
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -203,7 +203,7 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(String, Stri
 /// create a test network
 #[cfg_attr(tarpaulin, skip)]
 pub fn mock_network_config() -> JsonString {
-    JsonString::from(P2pConfig::DEFAULT_MOCK_CONFIG)
+    JsonString::from_json(&P2pConfig::DEFAULT_MOCK_CONFIG)
 }
 
 #[cfg(test)]

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -27,7 +27,7 @@ use wasmi::{RuntimeArgs, RuntimeValue};
 // ZomeFnCallArgs to ZomeFnCall
 impl ZomeFnCall {
     fn from_args(args: ZomeFnCallArgs) -> Self {
-        ZomeFnCall::new(&args.zome_name, args.cap, &args.fn_name, args.fn_args)
+        ZomeFnCall::new(&args.zome_name, args.cap, &args.fn_name, JsonString::from_json(&args.fn_args))
     }
 }
 
@@ -140,7 +140,7 @@ fn bridge_call(runtime: &mut Runtime, input: ZomeFnCallArgs) -> Result<JsonStrin
     let response = JsonRpc::parse(&response)?;
 
     match response {
-        JsonRpc::Success(_) => Ok(JsonString::from(
+        JsonRpc::Success(_) => Ok(JsonString::from_json(&
             serde_json::to_string(&response.get_result().unwrap()).unwrap(),
         )),
         JsonRpc::Error(_) => Err(HolochainError::ErrorGeneric(

--- a/core/src/nucleus/ribosome/api/send.rs
+++ b/core/src/nucleus/ribosome/api/send.rs
@@ -6,6 +6,7 @@ use futures::executor::block_on;
 use holochain_wasm_utils::api_serialization::send::SendArgs;
 use std::convert::TryFrom;
 use wasmi::{RuntimeArgs, RuntimeValue};
+use holochain_core_types::json::JsonString;
 
 /// ZomeApiFunction::Send function code
 /// args: [0] encoded MemoryAllocation as u32
@@ -26,5 +27,5 @@ pub fn invoke_send(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
 
     let result = block_on(custom_send(args.to_agent, message, &runtime.context));
 
-    runtime.store_result(result)
+    runtime.store_result(result.map(|j| JsonString::from_json(&j)))
 }

--- a/core/src/nucleus/ribosome/callback/receive.rs
+++ b/core/src/nucleus/ribosome/callback/receive.rs
@@ -30,7 +30,7 @@ pub fn receive(
         zome,
         None,
         &Callback::Receive.as_str().to_string(),
-        params.clone(),
+        JsonString::from_json(&params.clone()),
     );
 
     let dna = context.get_dna().expect("Callback called without DNA set!");

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -43,7 +43,7 @@ pub fn get_validation_package_definition(
                     &zome_name,
                     None,
                     "__hdk_get_validation_package_for_entry_type",
-                    app_entry_type.to_string(),
+                    JsonString::from_json(&app_entry_type.to_string()),
                 ),
                 Some(app_entry_type.to_string().into_bytes()),
             )?

--- a/core/src/nucleus/ribosome/run_dna.rs
+++ b/core/src/nucleus/ribosome/run_dna.rs
@@ -162,7 +162,7 @@ pub fn run_dna(
                 }
                 Ok(json_str) => {
                     return_log_msg = json_str.clone();
-                    return_result = Ok(JsonString::from(json_str));
+                    return_result = Ok(JsonString::from_json(&json_str));
                 }
             }
         }

--- a/core/src/nucleus/ribosome/runtime.rs
+++ b/core/src/nucleus/ribosome/runtime.rs
@@ -54,11 +54,11 @@ impl Runtime {
         let bin_arg = self.memory_manager.read(allocation);
 
         // convert complex argument
+        JsonString::from_json(&
         String::from_utf8(bin_arg)
             // @TODO don't panic in WASM
             // @see https://github.com/holochain/holochain-rust/issues/159
-            .unwrap()
-            .into()
+            .unwrap())
     }
 
     /// Store anything that implements Into<JsonString> in wasm memory.

--- a/core_types/src/entry/mod.rs
+++ b/core_types/src/entry/mod.rs
@@ -52,7 +52,7 @@ where
     let serialized_app_entry = SerializedAppEntry::deserialize(deserializer)?;
     Ok((
         AppEntryType::from(serialized_app_entry.0),
-        AppEntryValue::from(serialized_app_entry.1),
+        AppEntryValue::from_json(&serialized_app_entry.1),
     ))
 }
 
@@ -144,7 +144,7 @@ pub fn test_entry_value() -> JsonString {
 }
 
 pub fn test_entry_content() -> Content {
-    Content::from("{\"App\":[\"testEntryType\",\"\\\"test entry value\\\"\"]}")
+    Content::from_json("{\"App\":[\"testEntryType\",\"\\\"test entry value\\\"\"]}")
 }
 
 /// dummy entry content, same as test_entry_value()
@@ -175,7 +175,7 @@ pub fn test_entry() -> Entry {
 }
 
 pub fn expected_serialized_entry_content() -> JsonString {
-    JsonString::from("{\"App\":[\"testEntryType\",\"\\\"test entry value\\\"\"]}")
+    JsonString::from_json("{\"App\":[\"testEntryType\",\"\\\"test entry value\\\"\"]}")
 }
 
 /// the correct address for test_entry()

--- a/core_types/src/error/error.rs
+++ b/core_types/src/error/error.rs
@@ -61,7 +61,7 @@ impl ::std::convert::TryFrom<ZomeApiInternalResult> for CoreError {
                 "Attempted to deserialize CoreError from a non-error ZomeApiInternalResult".into(),
             ))
         } else {
-            CoreError::try_from(JsonString::from(zome_api_internal_result.error))
+            CoreError::try_from(JsonString::from_json(&zome_api_internal_result.error))
         }
     }
 }

--- a/core_types/src/error/ribosome_error.rs
+++ b/core_types/src/error/ribosome_error.rs
@@ -53,7 +53,7 @@ impl FromStr for RibosomeReturnCode {
 
 impl From<RibosomeReturnCode> for JsonString {
     fn from(ribosome_return_code: RibosomeReturnCode) -> JsonString {
-        JsonString::from(ribosome_return_code.to_string())
+        JsonString::from_json(&ribosome_return_code.to_string())
     }
 }
 

--- a/core_types_derive/src/lib.rs
+++ b/core_types_derive/src/lib.rs
@@ -15,7 +15,7 @@ fn impl_default_json_macro(ast: &syn::DeriveInput) -> TokenStream {
         impl<'a> From<&'a #name> for JsonString {
             fn from(v: &#name) -> JsonString {
                 match ::serde_json::to_string(v) {
-                    Ok(s) => Ok(JsonString::from(s)),
+                    Ok(s) => Ok(JsonString::from_json(&s)),
                     Err(e) => Err(HolochainError::SerializationError(e.to_string())),
                 }.expect(&format!("could not Jsonify {}: {:?}", stringify!(#name), v))
             }

--- a/dna_c_binding/src/lib.rs
+++ b/dna_c_binding/src/lib.rs
@@ -32,7 +32,7 @@ pub extern "C" fn holochain_dna_create_from_json(buf: *const c_char) -> *mut Dna
     match catch_unwind(|| {
         let json = unsafe { CStr::from_ptr(buf).to_string_lossy().into_owned() };
 
-        let dna = Dna::try_from(JsonString::from(json)).expect("could not restore DNA from JSON");
+        let dna = Dna::try_from(JsonString::from_json(&json)).expect("could not restore DNA from JSON");
 
         Box::into_raw(Box::new(dna))
     }) {

--- a/doc/holochain_101/src/json_string.md
+++ b/doc/holochain_101/src/json_string.md
@@ -366,7 +366,7 @@ JSON data by _wrapping_ already serialized data e.g. with `format!`.
 An example taken from core:
 
 ```rust
-impl<T: Into<JsonString>, E: Into<JsonString> + JsonError> From<Result<T, E>> for JsonString {
+impl<T: Into<JsonString>, E: Into<JsonString>> From<Result<T, E>> for JsonString {
     fn from(result: Result<T, E>) -> JsonString {
         let is_ok = result.is_ok();
         let inner_json: JsonString = match result {

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -200,10 +200,26 @@ pub enum BundleOnClose {
 ///
 /// # }
 /// ```
-pub fn debug<J: TryInto<JsonString>>(msg: J) -> ZomeApiResult<()> {
+pub fn debug_json<J: TryInto<JsonString>>(msg: J) -> ZomeApiResult<()> {
     let mut mem_stack = unsafe { G_MEM_STACK.unwrap() };
 
     let allocation_of_input = store_as_json(&mut mem_stack, msg)?;
+
+    unsafe {
+        hc_debug_json(allocation_of_input.encode());
+    }
+
+    mem_stack
+        .deallocate(allocation_of_input)
+        .expect("should be able to deallocate input that has been allocated on memory stack");
+
+    Ok(())
+}
+
+pub fn debug(msg: &str) -> ZomeApiResult<()> {
+    let mut mem_stack = unsafe { G_MEM_STACK.unwrap() };
+
+    let allocation_of_input = store_as_string(&mut mem_stack, msg)?;
 
     unsafe {
         hc_debug(allocation_of_input.encode());
@@ -399,7 +415,7 @@ pub fn call<S: Into<String>>(
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -474,7 +490,7 @@ pub fn commit_entry(entry: &Entry) -> ZomeApiResult<Address> {
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -567,7 +583,7 @@ pub fn get_entry_result(
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -657,7 +673,7 @@ pub fn link_entries<S: Into<String>>(
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -733,7 +749,7 @@ pub fn entry_address(entry: &Entry) -> ZomeApiResult<Address> {
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -782,7 +798,7 @@ pub fn update_entry(new_entry: Entry, address: Address) -> ZomeApiResult<Address
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -871,7 +887,7 @@ pub fn get_links_with_options<S: Into<String>>(
         .expect("deallocate failed");
 
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }
@@ -988,7 +1004,7 @@ pub fn query(
         .expect("deallocate failed");
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }

--- a/hdk-rust/src/error.rs
+++ b/hdk-rust/src/error.rs
@@ -2,7 +2,7 @@
 
 use crate::holochain_core_types::{
     error::{HolochainError, RibosomeErrorCode},
-    json::{JsonError, JsonString},
+    json::{JsonString},
 };
 use std::{error::Error, fmt};
 
@@ -16,8 +16,6 @@ pub enum ZomeApiError {
     ValidationFailed(String),
     Timeout,
 }
-
-impl JsonError for ZomeApiError {}
 
 impl From<ZomeApiError> for HolochainError {
     fn from(zome_api_error: ZomeApiError) -> Self {

--- a/hdk-rust/src/init_globals.rs
+++ b/hdk-rust/src/init_globals.rs
@@ -21,7 +21,7 @@ pub(crate) fn init_globals() -> ZomeApiResult<ZomeApiGlobals> {
     let result: ZomeApiInternalResult = load_json(encoded_allocation_of_result as u32)?;
     // Done
     if result.ok {
-        Ok(JsonString::from(result.value).try_into()?)
+        Ok(JsonString::from_json(&result.value).try_into()?)
     } else {
         Err(ZomeApiError::from(result.error))
     }

--- a/hdk-rust/src/macros.rs
+++ b/hdk-rust/src/macros.rs
@@ -205,7 +205,7 @@ macro_rules! define_zome {
                     $receive_expr
                 }
 
-                $crate::global_fns::store_and_return_output(execute(input))
+                $crate::global_fns::store_and_return_output(JsonString::from_json(&execute(input)))
             }
         )*
 

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -18,6 +18,7 @@ use holochain_wasm_utils::{
         EntryValidationArgs, LinkValidationArgs, LinkValidationPackageArgs,
     },
     holochain_core_types::error::RibosomeErrorCode,
+    holochain_core_types::json::RawString,
     memory_serialization::{load_json, load_string, store_string_into_encoded_allocation},
 };
 use std::collections::BTreeMap;
@@ -121,7 +122,7 @@ pub extern "C" fn __hdk_validate_app_entry(encoded_allocation_of_input: u32) -> 
 
             match validation_result {
                 Ok(()) => 0,
-                Err(fail_string) => crate::global_fns::store_and_return_output(fail_string),
+                Err(fail_string) => crate::global_fns::store_and_return_output(RawString::from(fail_string)),
             }
         }
     }
@@ -199,7 +200,7 @@ pub extern "C" fn __hdk_validate_link(encoded_allocation_of_input: u32) -> u32 {
             );
             Some(match validation_result {
                 Ok(()) => 0,
-                Err(fail_string) => ::global_fns::store_and_return_output(fail_string),
+                Err(fail_string) => ::global_fns::store_and_return_output(RawString::from(fail_string)),
             })
         })
         .unwrap_or(RibosomeErrorCode::CallbackFailed as u32)

--- a/net/src/p2p_network.rs
+++ b/net/src/p2p_network.rs
@@ -8,6 +8,7 @@ use holochain_net_connection::{
     protocol::Protocol,
     NetResult,
 };
+use holochain_core_types::json::JsonString;
 
 use super::{ipc_net_worker::IpcNetWorker, mock_worker::MockWorker, p2p_config::*};
 
@@ -34,7 +35,7 @@ impl P2pNetwork {
     pub fn new(handler: NetHandler, config: &P2pConfig) -> NetResult<Self> {
         // Create Config struct
         //let config: P2pConfig = serde_json::from_str(config_json.into())?;
-        let network_config = config.backend_config.to_string().into();
+        let network_config = JsonString::from_json(&config.backend_config.to_string());
         // so far, we have only implemented the "ipc" backend type
         let connection = match config.backend_kind {
             P2pBackendKind::IPC => {

--- a/net_connection/src/protocol.rs
+++ b/net_connection/src/protocol.rs
@@ -67,7 +67,7 @@ impl<'a> From<&'a NamedBinaryData> for Protocol {
                 let sub: NamedBinaryData = rmp_serde::from_slice(&nb.data).unwrap();
                 Protocol::NamedBinary(sub)
             }
-            b"json" => Protocol::Json(String::from_utf8_lossy(&nb.data).to_string().into()),
+            b"json" => Protocol::Json(JsonString::from_json(&String::from_utf8_lossy(&nb.data).to_string())),
             b"ping" => {
                 let sub: PingData = rmp_serde::from_slice(&nb.data).unwrap();
                 Protocol::Ping(sub)
@@ -90,7 +90,7 @@ impl From<NamedBinaryData> for Protocol {
 
 impl<'a> From<&'a str> for Protocol {
     fn from(s: &'a str) -> Self {
-        Protocol::Json(s.to_string().into())
+        Protocol::Json(JsonString::from_json(&s.to_string()))
     }
 }
 
@@ -135,7 +135,7 @@ impl Protocol {
     /// get a json string straight out of the Protocol enum
     pub fn as_json_string(&self) -> JsonString {
         if let Protocol::Json(data) = self {
-            String::from(data).into()
+            JsonString::from_json(&String::from(data))
         } else {
             panic!("as_json_string called with bad type");
         }

--- a/net_connection/src/protocol_wrapper.rs
+++ b/net_connection/src/protocol_wrapper.rs
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn it_can_convert_funky_state() {
-        let w = ProtocolWrapper::try_from(JsonString::from(
+        let w = ProtocolWrapper::try_from(JsonString::from_json(
             r#"{
             "method": "state",
             "state": "test_state"

--- a/wasm_utils/wasm-test/integration-test/src/lib.rs
+++ b/wasm_utils/wasm-test/integration-test/src/lib.rs
@@ -137,7 +137,7 @@ pub extern "C" fn test_load_json_from_raw_err(_: u32) -> u32 {
     let ptr = store_res.clone().unwrap().offset() as *mut c_char;
     let load_res: Result<OtherTestStruct, HolochainError> = load_json_from_raw(ptr);
     zome_assert!(stack, load_res.is_err());
-    let store_err_res = store_as_json(&mut stack, load_res.err().unwrap().to_string());
+    let store_err_res = store_as_json(&mut stack, JsonString::from_json(&load_res.err().unwrap().to_string()));
     store_err_res.unwrap().encode()
 }
 
@@ -188,8 +188,8 @@ pub extern "C" fn test_stacked_strings(_: u32) -> u32 {
 #[no_mangle]
 pub extern "C" fn test_stacked_json_str(_: u32) -> u32 {
     let mut stack = SinglePageStack::default();
-    let first = store_as_json_into_encoded_allocation(&mut stack, "first");
-    let _second = store_as_json_into_encoded_allocation(&mut stack, "second");
+    let first = store_as_json_into_encoded_allocation(&mut stack, RawString::from("first"));
+    let _second = store_as_json_into_encoded_allocation(&mut stack, RawString::from("second"));
     first as u32
 }
 
@@ -214,9 +214,9 @@ pub extern "C" fn test_stacked_mix(_: u32) -> u32 {
         value: "first".to_string(),
         list: vec!["hello".to_string(), "world!".to_string()],
     });
-    let _second = store_as_json_into_encoded_allocation(&mut stack, "second");
+    let _second = store_as_json_into_encoded_allocation(&mut stack, RawString::from("second"));
     let third = store_string_into_encoded_allocation(&mut stack, "third");
-    let _fourth = store_as_json_into_encoded_allocation(&mut stack, "fourth");
+    let _fourth = store_as_json_into_encoded_allocation(&mut stack, RawString::from("fourth"));
     let _fifth = store_as_json_into_encoded_allocation(&mut stack, TestStruct {
         value: "fifth".to_string(),
         list: vec!["fifthlist".to_string()],


### PR DESCRIPTION
## changes

- converting from `String` to `JsonString` is no long silent
  - `JsonString::from_json(&str)` replaces `JsonString::from(String)`
  - allows use of generic traits to convert to `JsonString`, e.g. `Result<T, E>`
    - could not be done before because `String` always gets in the way
  - highlights a lot of places that `JsonString::from()` was used for `String` values that are definitely not valid json :(
- implements generic `impl From<Result<T, E>> for JsonString {}` and `String` equivalents