### PR TITLE
NodeJS Container ready for 0.0.3

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -8,12 +8,12 @@ const dnaPath = "./dist/app_spec.hcpkg"
 // IIFE to keep config-only stuff out of test scope
 const container = (() => {
   const agentAlice = Config.agent("alice")
-  const agentBob = Config.agent("bob")
+  const agentTash = Config.agent("tash")
 
   const dna = Config.dna(dnaPath)
 
   const instanceAlice = Config.instance(agentAlice, dna)
-  const instanceBob = Config.instance(agentBob, dna)
+  const instanceBob = Config.instance(agentTash, dna)
 
   const containerConfig = Config.container(instanceAlice, instanceBob)
   return new Container(containerConfig)
@@ -22,13 +22,13 @@ const container = (() => {
 // Initialize the Container
 container.start()
 
-const app = container.makeCaller('alice', dnaPath)
-const app2 = container.makeCaller('bob', dnaPath)
+const alice = container.makeCaller('alice', dnaPath)
+const tash = container.makeCaller('tash', dnaPath)
 
 test('agentId', (t) => {
   t.plan(2)
-  t.ok(app.agentId)
-  t.notEqual(app.agentId, app2.agentId)
+  t.ok(alice.agentId)
+  t.notEqual(alice.agentId, tash.agentId)
 })
 
 test('call', (t) => {
@@ -37,7 +37,7 @@ test('call', (t) => {
   const num1 = 2
   const num2 = 2
   const params = { num1, num2 }
-  const result = app.call("blog", "main", "check_sum", params)
+  const result = alice.call("blog", "main", "check_sum", params)
 
   t.deepEqual(result.Ok, { "sum": "4" })
 })
@@ -46,7 +46,7 @@ test('hash_post', (t) => {
   t.plan(1)
 
   const params = { content: "Holo world" }
-  const result = app.call("blog", "main", "post_address", params)
+  const result = alice.call("blog", "main", "post_address", params)
 
   t.equal(result.Ok, "QmY6MfiuhHnQ1kg7RwNZJNUQhwDxTFL45AAPnpJMNPEoxk")
 })
@@ -57,7 +57,7 @@ test('create_post', (t) => {
   const content = "Holo world"
   const in_reply_to = null
   const params = { content, in_reply_to }
-  const result = app.call("blog", "main", "create_post", params)
+  const result = alice.call("blog", "main", "create_post", params)
 
   t.ok(result.Ok)
   t.notOk(result.Err)
@@ -70,7 +70,7 @@ test('create_post with bad reply to', (t) => {
   const content = "Holo world"
   const in_reply_to = "bad"
   const params = { content, in_reply_to }
-  const result = app.call("blog", "main", "create_post", params)
+  const result = alice.call("blog", "main", "create_post", params)
 
   // bad in_reply_to is an error condition
   t.ok(result.Err)
@@ -87,7 +87,7 @@ test('post max content size 280 characters', (t) => {
   const content = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
   const in_reply_to = null
   const params = { content, in_reply_to }
-  const result = app.call("blog", "main", "create_post", params)
+  const result = alice.call("blog", "main", "create_post", params)
 
   // result should be an error
   t.ok(result.Err);
@@ -106,7 +106,7 @@ test('posts_by_agent', (t) => {
   const agent = "Bob"
   const params = { agent }
 
-  const result = app.call("blog", "main", "posts_by_agent", params)
+  const result = alice.call("blog", "main", "posts_by_agent", params)
 
   t.deepEqual(result.Ok, { "addresses": [] })
 })
@@ -114,16 +114,16 @@ test('posts_by_agent', (t) => {
 test('my_posts', async (t) => {
   t.plan(1)
 
-  app.call("blog", "main", "create_post",
+  alice.call("blog", "main", "create_post",
     { "content": "Holo world", "in_reply_to": "" }
   )
 
-  app.call("blog", "main", "create_post",
+  alice.call("blog", "main", "create_post",
     { "content": "Another post", "in_reply_to": "" }
   )
 
   const result = await pollFor(
-    () => app.call("blog", "main", "my_posts", {}),
+    () => alice.call("blog", "main", "my_posts", {}),
     (result) => {
       return result &&
         result.Ok &&
@@ -141,11 +141,11 @@ test('create/get_post roundtrip', (t) => {
   const content = "Holo world"
   const in_reply_to = null
   const params = { content, in_reply_to }
-  const create_post_result = app.call("blog", "main", "create_post", params)
+  const create_post_result = alice.call("blog", "main", "create_post", params)
   const post_address = create_post_result.Ok
 
   const params_get = { post_address }
-  const result = app.call("blog", "main", "get_post", params_get)
+  const result = alice.call("blog", "main", "get_post", params_get)
 
   const entry_value = JSON.parse(result.Ok.App[1])
   t.comment("get_post() entry_value = " + entry_value + "")
@@ -159,7 +159,7 @@ test('get_post with non-existant address returns null', (t) => {
 
   const post_address = "RANDOM"
   const params_get = { post_address }
-  const result = app.call("blog", "main", "get_post", params_get)
+  const result = alice.call("blog", "main", "get_post", params_get)
 
   // should be Ok value but null
   // lookup did not error
@@ -174,12 +174,12 @@ test('scenario test create & publish post -> get from other instance', async (t)
   const content = "Holo world"
   const in_reply_to = null
   const params = { content, in_reply_to }
-  const create_result = app.call("blog", "main", "create_post", params)
+  const create_result = alice.call("blog", "main", "create_post", params)
   t.comment("create_result = " + create_result.address + "")
 
   const content2 = "post 2"
   const params2 = { content2, in_reply_to }
-  const create_result2 = app2.call("blog", "main", "create_post", params2)
+  const create_result2 = tash.call("blog", "main", "create_post", params2)
   t.comment("create_result2 = " + create_result2.address + "")
 
   t.equal(create_result.Ok.length, 46)
@@ -189,7 +189,7 @@ test('scenario test create & publish post -> get from other instance', async (t)
   const params_get = { post_address }
 
   const result = await pollFor(
-    () => app2.call("blog", "main", "get_post", params_get)
+    () => tash.call("blog", "main", "get_post", params_get)
   ).catch(t.fail)
   const value = JSON.parse(result.Ok.App[1])
   t.equal(value.content, content)

--- a/nodejs_container/README.md
+++ b/nodejs_container/README.md
@@ -20,16 +20,16 @@ After installing via npm the module can be used in a node script as follows:
 const dnaPath = "path/to/happ.hcpkg"
 const aliceAgentId = "alice"
 const tashAgentId = "tash"
-// destructure to get ConfigBuilder and Container off the main import, which is an object now
-const { ConfigBuilder, Container } = require('@holochain/holochain-nodejs')
+// destructure to get Config and Container off the main import, which is an object now
+const { Config, Container } = require('@holochain/holochain-nodejs')
 
 // build up a configuration for the container, step by step
-const agentAlice = ConfigBuilder.agent(aliceAgentId)
-const agentTash = ConfigBuilder.agent(tashAgentId)
-const dna = ConfigBuilder.dna(dnaPath)
-const instanceAlice = ConfigBuilder.instance(agentAlice, dna)
-const instanceTash = ConfigBuilder.instance(agentTash, dna)
-const config = ConfigBuilder.container(instanceAlice, instanceTash)
+const agentAlice = Config.agent(aliceAgentId)
+const agentTash = Config.agent(tashAgentId)
+const dna = Config.dna(dnaPath)
+const instanceAlice = Config.instance(agentAlice, dna)
+const instanceTash = Config.instance(agentTash, dna)
+const config = Config.container(instanceAlice, instanceTash)
 
 // create a new instance of a Container, from the config
 const container = new Container(config)
@@ -37,9 +37,10 @@ const container = new Container(config)
 // this starts all the configured instances
 container.start()
 
-// note that in the following examples, an "instance id" is
-// considered to be the given agent ID plus a dash plus the given dnaPath
-const aliceInstanceId = aliceAgentId + '-' + dnaPath
+// When building up a config using `Config`, the instance ID is automatically assigned
+// as the given agent ID plus a double colon plus the given dnaPath.
+// We'll need this to call the instance later.
+const aliceInstanceId = aliceAgentId + '::' + dnaPath
 
 // zome functions can be called using the following
 const callResult = container.call(aliceInstanceId, zome, capability, fnName, paramsAsObject)
@@ -60,21 +61,21 @@ Prior to version ???, a container would only return a single instance of an app.
 const callResult = container.call(someInstanceId, someZome, someCapability, someFunction, someParams)
 ```
 
-If you wanted to go on using the old syntax of individuating the apps, you could use the following, after the container has been setup and started:
+If you wanted to go on using the old syntax of individuating the apps, you could use the following
+helper function which is exposed on `Container`:
 
 ```
-const dnaPath = "./dist/app_spec.hcpkg"
-const makeCaller = (agentId) => {
-  const instanceId = agentId + '-' + dnaPath
-  return {
-    call: (zome, cap, fn, params) => container.call(instanceId, zome, cap, fn, params),
-    agentId: container.agent_id(instanceId)
-  }
-}
+const dnaPath = "path/to/happ.hcpkg"
+...
+const container = new Container(config)
+const alice = container.makeCaller('alice', dnaPath)
 
-const app = makeCaller('alice')
-// the following four params would need to be replaced with valid values
-app.call(someZome, someCapability, someFunction, someParams)
+// now you can use `alice` as a slightly more convenient way of calling this instance
+// (the following four params would need to be replaced with valid values)
+alice.call(someZome, someCapability, someFunction, someParams)
+
+// you can also get the agent's address this way:
+alice.agentId
 ```
 
 ## Deployment

--- a/nodejs_container/index.js
+++ b/nodejs_container/index.js
@@ -6,9 +6,10 @@ const path = require('path');
 // deals with ensuring the correct version for the machine/node version
 const binding_path = binary.find(path.resolve(path.join(__dirname, './package.json')));
 
-const { ConfigBuilder, Container } = require(binding_path);
+const { makeConfig, Container } = require(binding_path);
 
 Container.prototype.callRaw = Container.prototype.call
+
 Container.prototype.call = function (id, zome, trait, fn, params) {
     const stringInput = JSON.stringify(params);
     const rawResult = this.callRaw(id, zome, trait, fn, stringInput);
@@ -22,7 +23,26 @@ Container.prototype.call = function (id, zome, trait, fn, params) {
     return result;
 }
 
-module.exports = {
-    ConfigBuilder: new ConfigBuilder(),
-    Container: Container,
-};
+// Convenience function for making an object that can call into the container
+// in the context of a particular instance. This may be temporary.
+Container.prototype.makeCaller = function (agentId, dnaPath) {
+  const instanceId = agentId + '::' + dnaPath
+  return {
+    call: (zome, cap, fn, params) => this.call(instanceId, zome, cap, fn, params),
+    agentId: this.agent_id(instanceId)
+  }
+}
+
+const Config = {
+    agent: name => ({ name }),
+    dna: (path) => ({ path }),
+    instance: (agent, dna, name) => {
+        if (!name) {
+            name = agent.name
+        }
+        return { agent, dna, name }
+    },
+    container: (...instances) => makeConfig(...instances),
+}
+
+module.exports = { Config, Container };

--- a/nodejs_container/native/src/config.rs
+++ b/nodejs_container/native/src/config.rs
@@ -7,78 +7,41 @@ use holochain_net::p2p_config::P2pConfig;
 use neon::prelude::*;
 use std::{collections::HashMap, path::PathBuf};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct AgentData {
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct DnaData {
     pub path: PathBuf,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct InstanceData {
     pub agent: AgentData,
     pub dna: DnaData,
 }
 
-/// Provides functions for create the building blocks of configuration.
-/// These pieces can be assembled together to create different configurations
-/// which can be used to create Containers
-pub struct ConfigBuilder;
-
-declare_types! {
-
-    pub class JsConfigBuilder for ConfigBuilder {
-
-        init(_cx) {
-            Ok(ConfigBuilder)
-        }
-
-        method agent(mut cx) {
-            let name = cx.argument::<JsString>(0)?.to_string(&mut cx)?.value();
-            let obj = AgentData { name };
-            Ok(neon_serde::to_value(&mut cx, &obj)?)
-        }
-
-        method dna(mut cx) {
-            let path = cx.argument::<JsString>(0)?.to_string(&mut cx)?.value();
-            let path = PathBuf::from(path);
-            let obj = DnaData { path };
-            Ok(neon_serde::to_value(&mut cx, &obj)?)
-        }
-
-        method instance(mut cx) {
-            let agent_data = cx.argument(0)?;
-            let dna_data = cx.argument(1)?;
-            let agent: AgentData = neon_serde::from_value(&mut cx, agent_data)?;
-            let dna: DnaData = neon_serde::from_value(&mut cx, dna_data)?;
-            let obj = InstanceData { agent, dna };
-            Ok(neon_serde::to_value(&mut cx, &obj)?)
-        }
-
-        method container(mut cx) {
-            let mut i = 0;
-            let mut instances = Vec::<InstanceData>::new();
-            while let Some(arg) = cx.argument_opt(i) {
-                instances.push(neon_serde::from_value(&mut cx, arg)?);
-                i += 1;
-            };
-            let config = make_config(instances);
-            Ok(neon_serde::to_value(&mut cx, &config)?)
-        }
+pub fn js_make_config(mut cx: FunctionContext) -> JsResult<JsValue> {
+    let mut i = 0;
+    let mut instances = Vec::<InstanceData>::new();
+    while let Some(arg) = cx.argument_opt(i) {
+        instances.push(neon_serde::from_value(&mut cx, arg)?);
+        i += 1;
     }
+    let config = make_config(instances);
+    Ok(neon_serde::to_value(&mut cx, &config)?)
 }
 
-pub fn make_config(instance_data: Vec<InstanceData>) -> Configuration {
+fn make_config(instance_data: Vec<InstanceData>) -> Configuration {
     let mut agent_configs = HashMap::new();
     let mut dna_configs = HashMap::new();
     let mut instance_configs = Vec::new();
     for instance in instance_data {
         let agent_name = instance.agent.name;
-        let dna_path = PathBuf::from(instance.dna.path);
-        let agent = agent_configs.entry(agent_name.clone()).or_insert_with(|| {
+        let mut dna_data = instance.dna;
+        let agent_config = agent_configs.entry(agent_name.clone()).or_insert_with(|| {
             let agent_key = AgentId::generate_fake(&agent_name);
             AgentConfiguration {
                 id: agent_name.clone(),
@@ -87,17 +50,17 @@ pub fn make_config(instance_data: Vec<InstanceData>) -> Configuration {
                 key_file: format!("fake/key/{}", agent_name),
             }
         });
-        let dna = dna_configs
-            .entry(dna_path.clone())
-            .or_insert_with(|| make_dna_config(dna_path).expect("DNA file not found"));
+        let dna_config = dna_configs
+            .entry(dna_data.path.clone())
+            .or_insert_with(|| make_dna_config(dna_data).expect("DNA file not found"));
 
         let logger_mock = LoggerConfiguration {
             logger_type: String::from("DONTCARE"),
             file: None,
         };
         let network_mock = Some(P2pConfig::DEFAULT_MOCK_CONFIG.to_string());
-        let agent_id = agent.id.clone();
-        let dna_id = dna.id.clone();
+        let agent_id = agent_config.id.clone();
+        let dna_id = dna_config.id.clone();
         let instance = InstanceConfiguration {
             id: instance_id(&agent_id, &dna_id),
             agent: agent_id,
@@ -120,11 +83,11 @@ pub fn make_config(instance_data: Vec<InstanceData>) -> Configuration {
 }
 
 fn instance_id(agent_id: &str, dna_id: &str) -> String {
-    format!("{}-{}", agent_id, dna_id)
+    format!("{}::{}", agent_id, dna_id)
 }
 
-fn make_dna_config(path: PathBuf) -> Result<DnaConfiguration, String> {
-    let path = path.to_string_lossy().to_string();
+fn make_dna_config(dna: DnaData) -> Result<DnaConfiguration, String> {
+    let path = dna.path.to_string_lossy().to_string();
     Ok(DnaConfiguration {
         id: path.clone(),
         hash: String::from("DONTCARE"),

--- a/nodejs_container/native/src/container.rs
+++ b/nodejs_container/native/src/container.rs
@@ -1,15 +1,12 @@
 use holochain_container_api::{
     config::{load_configuration, Configuration},
-    container::{Container as RustContainer},
+    container::Container as RustContainer,
 };
 use holochain_core::{
     logger::Logger,
     signal::{signal_channel, SignalReceiver},
 };
-use holochain_core_types::{
-    cas::content::Address,
-    dna::{capabilities::CapabilityCall},
-};
+use holochain_core_types::{cas::content::Address, dna::capabilities::CapabilityCall};
 use neon::{context::Context, prelude::*};
 
 use crate::config::*;
@@ -141,6 +138,6 @@ declare_types! {
 
 register_module!(mut cx, {
     cx.export_class::<JsContainer>("Container")?;
-    cx.export_class::<JsConfigBuilder>("ConfigBuilder")?;
+    cx.export_function("makeConfig", js_make_config)?;
     Ok(())
 });


### PR DESCRIPTION
This gets the NodeJS Container stuff ready for 0.0.3, since the actual Scenario API stuff won't be ready for that release:

- Backports some future improvements to the nodejs container API from #797
- Adds `makeCaller` convenience function to `Container.prototype`
- Changes instance ID delimiter from `-` to `::` (hey why not?)
- Updates README