### PR TITLE
P2pConfig enum rather than serde_json::Value

### DIFF
--- a/cmd/src/cli/run.rs
+++ b/cmd/src/cli/run.rs
@@ -49,7 +49,7 @@ pub fn run(package: bool, port: u16, persist: bool) -> DefaultResult<()> {
         agent: AGENT_CONFIG_ID.into(),
         logger: Default::default(),
         storage,
-        network: Some(P2pConfig::default_mock().as_str()),
+        network: Some(P2pConfig::default_mock("mock@cmd::run").as_str()),
     };
 
     let interface_config = InterfaceConfiguration {

--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -342,7 +342,7 @@ pub mod tests {
     use holochain_core::context::mock_network_config;
 
     pub fn example_serialized_network_config() -> String {
-        String::from(mock_network_config())
+        String::from(mock_network_config("TODO give unique string"))
     }
 
     #[test]

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -23,7 +23,6 @@ use std::{
     thread,
 };
 
-use holochain_net::p2p_config::P2pConfig;
 use interface::{ContainerApiBuilder, InstanceMap, Interface};
 /// Main representation of the container.
 /// Holds a `HashMap` of Holochain instances referenced by ID.
@@ -46,8 +45,6 @@ pub struct Container {
 type SignalSender = SyncSender<Signal>;
 type InterfaceThreadHandle = thread::JoinHandle<Result<(), String>>;
 type DnaLoader = Arc<Box<FnMut(&String) -> Result<Dna, HolochainError> + Send>>;
-
-pub static DEFAULT_NETWORK_CONFIG: &'static str = P2pConfig::DEFAULT_MOCK_CONFIG;
 
 impl Container {
     /// Creates a new instance with the default DnaLoader that actually loads files.

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -132,7 +132,7 @@ impl ContextBuilder {
             dht_storage,
             eav_storage,
             self.network_config.unwrap_or(JsonString::from(String::from(
-                P2pConfig::DEFAULT_MOCK_CONFIG,
+                P2pConfig::default_mock_config("mock@ContextBuilder::spawn"),
             ))),
             self.container_api,
             self.signal_tx,
@@ -151,7 +151,7 @@ mod tests {
         assert_eq!(context.agent_id, AgentId::generate_fake("alice"));
         assert_eq!(
             context.network_config,
-            JsonString::from(String::from(P2pConfig::DEFAULT_MOCK_CONFIG))
+            JsonString::from(String::from(P2pConfig::default_mock_config("vanilla")))
         );
     }
 
@@ -164,7 +164,9 @@ mod tests {
 
     #[test]
     fn with_network_config() {
-        let net = JsonString::from(String::from(P2pConfig::DEFAULT_MOCK_CONFIG));
+        let net = JsonString::from(String::from(P2pConfig::default_mock_config(
+            "with_network_config",
+        )));
         let context = ContextBuilder::new()
             .with_network_config(net.clone())
             .spawn();

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -151,7 +151,9 @@ mod tests {
         assert_eq!(context.agent_id, AgentId::generate_fake("alice"));
         assert_eq!(
             context.network_config,
-            JsonString::from(String::from(P2pConfig::default_mock_config("vanilla")))
+            JsonString::from(String::from(P2pConfig::default_mock_config(
+                "mock@ContextBuilder::spawn"
+            )))
         );
     }
 

--- a/container_api/src/holochain.rs
+++ b/container_api/src/holochain.rs
@@ -85,15 +85,7 @@ pub struct Holochain {
 impl Holochain {
     /// create a new Holochain instance
     pub fn new(dna: Dna, context: Arc<Context>) -> HolochainResult<Self> {
-        let instance = Instance::new(context.clone());
-        Self::from_dna_and_context_and_instance(dna, context, instance)
-    }
-
-    fn from_dna_and_context_and_instance(
-        dna: Dna,
-        context: Arc<Context>,
-        mut instance: Instance,
-    ) -> HolochainResult<Self> {
+        let mut instance = Instance::new(context.clone());
         let name = dna.name.clone();
         instance.start_action_loop(context.clone());
         let result = block_on(application::initialize(

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -204,8 +204,8 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(Address, Str
 
 /// create a test network
 #[cfg_attr(tarpaulin, skip)]
-pub fn mock_network_config() -> JsonString {
-    JsonString::from(P2pConfig::DEFAULT_MOCK_CONFIG)
+pub fn mock_network_config(network_name: &'static str) -> JsonString {
+    JsonString::from(P2pConfig::default_mock_config(network_name))
 }
 
 #[cfg(test)]
@@ -242,7 +242,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            mock_network_config("state_test"),
             None,
             None,
         );
@@ -275,7 +275,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            mock_network_config("test_deadlock"),
             None,
             None,
         );

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -389,7 +389,7 @@ pub mod tests {
                     EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                         .unwrap(),
                 )),
-                mock_network_config(),
+                mock_network_config("TODO give unique string"),
                 None,
                 None,
             )),
@@ -429,7 +429,7 @@ pub mod tests {
                     EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                         .unwrap(),
                 )),
-                mock_network_config(),
+                mock_network_config("TODO give unique string"),
             )
             .unwrap(),
         )
@@ -450,7 +450,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            mock_network_config("TODO give unique string"),
             None,
             None,
         );
@@ -474,7 +474,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            mock_network_config("TODO give unique string"),
             None,
             None,
         );

--- a/core/src/network/reducers/get_entry.rs
+++ b/core/src/network/reducers/get_entry.rs
@@ -112,7 +112,7 @@ mod tests {
         let store = test_store(context.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: mock_network_config("TODO give unique string"),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));
@@ -139,7 +139,7 @@ mod tests {
         Arc::get_mut(&mut context).unwrap().set_state(store.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: mock_network_config("TODO give unique string"),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));

--- a/core/src/network/reducers/init.rs
+++ b/core/src/network/reducers/init.rs
@@ -22,7 +22,7 @@ pub fn reduce_init(
     let network_settings = unwrap_to!(action => Action::InitNetwork);
     let p2p_config = P2pConfig::from_str(&network_settings.config.to_string())
         .expect("network settings failed to deserialize");
-    let mut network = P2pNetwork::new(create_handler(&context), &p2p_config).unwrap();
+    let mut network = P2pNetwork::new(create_handler(&context), p2p_config).unwrap();
 
     let _ = network
         .send(

--- a/core/src/network/reducers/send_direct_message.rs
+++ b/core/src/network/reducers/send_direct_message.rs
@@ -85,7 +85,7 @@ mod tests {
         Arc::get_mut(&mut context).unwrap().set_state(store.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: mock_network_config("TODO give unique string"),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));

--- a/net/src/p2p_config.rs
+++ b/net/src/p2p_config.rs
@@ -1,5 +1,5 @@
 use holochain_core_types::{error::HolochainError, json::JsonString};
-use std::{fs::File, str::FromStr};
+use std::{collections::HashMap, fs::File, str::FromStr};
 
 //--------------------------------------------------------------------------------------------------
 // P2pBackendKind
@@ -48,9 +48,44 @@ impl From<&'static str> for P2pBackendKind {
 //--------------------------------------------------------------------------------------------------
 
 #[derive(Deserialize, Serialize, Clone, Debug, DefaultJson, PartialEq)]
-pub struct P2pConfig {
-    pub backend_kind: P2pBackendKind,
-    pub backend_config: serde_json::Value,
+#[serde(tag = "backend_kind", content = "backend_config")]
+pub enum P2pConfig {
+    #[serde(rename = "IPC")]
+    Ipc(P2pIpcConfig),
+    #[serde(rename = "MOCK")]
+    Mock(P2pMockConfig),
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, DefaultJson, PartialEq)]
+pub struct P2pMockConfig {
+    pub network_name: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, DefaultJson, PartialEq)]
+pub struct P2pIpcConfig {
+    #[serde(default)]
+    pub spawn: Option<P2pIpcSpawnConfig>,
+
+    #[serde(rename = "socketType")]
+    pub socket_type: String,
+
+    #[serde(rename = "ipcUri", default)]
+    pub ipc_uri: Option<String>,
+
+    #[serde(rename = "blockConnect", default)]
+    pub block_connect: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, DefaultJson, PartialEq)]
+pub struct P2pIpcSpawnConfig {
+    pub cmd: String,
+    pub env: HashMap<String, String>,
+
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    #[serde(rename = "workDir", default)]
+    pub work_dir: String,
 }
 
 // Conversions
@@ -70,14 +105,6 @@ impl P2pConfig {
 
 // Constructors
 impl P2pConfig {
-    pub fn new(backend_kind: P2pBackendKind, backend_config: &str) -> Self {
-        P2pConfig {
-            backend_kind,
-            backend_config: serde_json::from_str(backend_config)
-                .expect("Invalid backend_config json on P2pConfig creation."),
-        }
-    }
-
     pub fn from_file(filepath: &str) -> Self {
         let config_file =
             File::open(filepath).expect("Failed to open filepath on P2pConfig creation.");
@@ -85,8 +112,8 @@ impl P2pConfig {
             .expect("file is not a proper JSON of a P2pConfig struct")
     }
 
-    pub fn default_mock() -> Self {
-        P2pConfig::from_str(P2pConfig::DEFAULT_MOCK_CONFIG)
+    pub fn default_mock(network_name: &'static str) -> Self {
+        P2pConfig::from_str(&P2pConfig::default_mock_config(network_name))
             .expect("Invalid backend_config json on P2pConfig creation.")
     }
 
@@ -98,10 +125,17 @@ impl P2pConfig {
 
 // statics
 impl P2pConfig {
-    pub const DEFAULT_MOCK_CONFIG: &'static str = r#"{
-    "backend_kind": "MOCK",
-    "backend_config": ""
-    }"#;
+    pub fn default_mock_config(network_name: &'static str) -> String {
+        format!(
+            r#"{{
+            "backend_kind": "MOCK",
+            "backend_config": {{
+                "network_name": "{}"
+            }}
+        }}"#,
+            network_name
+        )
+    }
 
     pub const DEFAULT_IPC_CONFIG: &'static str = r#"
     {
@@ -125,11 +159,15 @@ mod tests {
 
     #[test]
     fn it_can_json_round_trip() {
-        let p2p_config = P2pConfig::from_str(P2pConfig::DEFAULT_MOCK_CONFIG).unwrap();
+        let p2p_config =
+            P2pConfig::from_str(&P2pConfig::default_mock_config("it_can_json_round_trip")).unwrap();
         let json_str = p2p_config.as_str();
         let p2p_config_2 = P2pConfig::from_str(&json_str).unwrap();
         assert_eq!(p2p_config, p2p_config_2);
-        assert_eq!(p2p_config, P2pConfig::default_mock());
+        assert_eq!(
+            p2p_config,
+            P2pConfig::default_mock("it_can_json_round_trip")
+        );
     }
 
     #[test]

--- a/net/src/p2p_config.rs
+++ b/net/src/p2p_config.rs
@@ -2,48 +2,6 @@ use holochain_core_types::{error::HolochainError, json::JsonString};
 use std::{collections::HashMap, fs::File, str::FromStr};
 
 //--------------------------------------------------------------------------------------------------
-// P2pBackendKind
-//--------------------------------------------------------------------------------------------------
-
-#[derive(Deserialize, Serialize, Clone, Debug, DefaultJson, PartialEq, Eq)]
-pub enum P2pBackendKind {
-    MOCK,
-    IPC,
-}
-
-impl FromStr for P2pBackendKind {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "MOCK" => Ok(P2pBackendKind::MOCK),
-            "IPC" => Ok(P2pBackendKind::IPC),
-            _ => Err(()),
-        }
-    }
-}
-
-impl From<P2pBackendKind> for String {
-    fn from(kind: P2pBackendKind) -> String {
-        String::from(match kind {
-            P2pBackendKind::MOCK => "MOCK",
-            P2pBackendKind::IPC => "IPC",
-        })
-    }
-}
-
-impl From<String> for P2pBackendKind {
-    fn from(s: String) -> P2pBackendKind {
-        P2pBackendKind::from_str(&s).expect("could not convert String to P2pBackendKind")
-    }
-}
-
-impl From<&'static str> for P2pBackendKind {
-    fn from(s: &str) -> P2pBackendKind {
-        P2pBackendKind::from(String::from(s))
-    }
-}
-
-//--------------------------------------------------------------------------------------------------
 // P2pConfig
 //--------------------------------------------------------------------------------------------------
 

--- a/nodejs_container/native/src/config.rs
+++ b/nodejs_container/native/src/config.rs
@@ -58,7 +58,9 @@ fn make_config(instance_data: Vec<InstanceData>) -> Configuration {
             logger_type: String::from("DONTCARE"),
             file: None,
         };
-        let network_mock = Some(P2pConfig::DEFAULT_MOCK_CONFIG.to_string());
+        let network_mock = Some(P2pConfig::default_mock_config(
+            "TODO make unique every time",
+        ));
         let agent_id = agent_config.id.clone();
         let dna_id = dna_config.id.clone();
         let instance = InstanceConfiguration {

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]
+failure = "0.1.3"
 holochain_core = { path = "../core" }
 holochain_container_api = { path = "../container_api" }
 holochain_cas_implementations = { path="../cas_implementations" }

--- a/test_bin/src/test_bin_mock_net.rs
+++ b/test_bin/src/test_bin_mock_net.rs
@@ -34,6 +34,7 @@ fn exec() -> NetResult<()> {
 
     // use a mpsc channel for messaging
     let (sender1, receiver1) = mpsc::channel::<Protocol>();
+    let network_name = "test_bin_mock_net";
 
     // create a new ipc P2pNetwork instance
     let mut con1 = P2pNetwork::new(
@@ -41,7 +42,7 @@ fn exec() -> NetResult<()> {
             sender1.send(r?)?;
             Ok(())
         }),
-        &P2pConfig::default_mock(),
+        P2pConfig::default_mock(network_name),
     )?;
 
     let (sender2, receiver2) = mpsc::channel::<Protocol>();
@@ -51,7 +52,7 @@ fn exec() -> NetResult<()> {
             sender2.send(r?)?;
             Ok(())
         }),
-        &P2pConfig::default_mock(),
+        P2pConfig::default_mock(network_name),
     )?;
 
     con1.send(


### PR DESCRIPTION
### part 1

Use an enum of structs instead of a `serde_json::Value` for P2pConfig. The hope is that the struct will give documentation of valid configuration and provide total compatibility with existing network configs. This should make it easier to safely add new config later (which I'll be doing in #815)