### PR TITLE
Add "network name" as mock network config

### DIFF
--- a/cmd/src/cli/run.rs
+++ b/cmd/src/cli/run.rs
@@ -49,7 +49,7 @@ pub fn run(package: bool, port: u16, persist: bool) -> DefaultResult<()> {
         agent: AGENT_CONFIG_ID.into(),
         logger: Default::default(),
         storage,
-        network: Some(P2pConfig::default_mock().as_str()),
+        network: Some(P2pConfig::default_mock("TODO give unique string").as_str()),
     };
 
     let interface_config = InterfaceConfiguration {

--- a/container_api/src/container.rs
+++ b/container_api/src/container.rs
@@ -23,7 +23,6 @@ use std::{
     thread,
 };
 
-use holochain_net::p2p_config::P2pConfig;
 use interface::{ContainerApiBuilder, InstanceMap, Interface};
 /// Main representation of the container.
 /// Holds a `HashMap` of Holochain instances referenced by ID.
@@ -46,8 +45,6 @@ pub struct Container {
 type SignalSender = SyncSender<Signal>;
 type InterfaceThreadHandle = thread::JoinHandle<Result<(), String>>;
 type DnaLoader = Arc<Box<FnMut(&String) -> Result<Dna, HolochainError> + Send>>;
-
-pub static DEFAULT_NETWORK_CONFIG: &'static str = P2pConfig::DEFAULT_MOCK_CONFIG;
 
 impl Container {
     /// Creates a new instance with the default DnaLoader that actually loads files.

--- a/container_api/src/context_builder.rs
+++ b/container_api/src/context_builder.rs
@@ -132,7 +132,7 @@ impl ContextBuilder {
             dht_storage,
             eav_storage,
             self.network_config.unwrap_or(JsonString::from(String::from(
-                P2pConfig::DEFAULT_MOCK_CONFIG,
+                P2pConfig::default_mock_config("todo make unique"),
             ))),
             self.container_api,
             self.signal_tx,
@@ -151,7 +151,9 @@ mod tests {
         assert_eq!(context.agent_id, AgentId::generate_fake("alice"));
         assert_eq!(
             context.network_config,
-            JsonString::from(String::from(P2pConfig::DEFAULT_MOCK_CONFIG))
+            JsonString::from(String::from(P2pConfig::default_mock_config(
+                "todo make unique"
+            )))
         );
     }
 
@@ -164,7 +166,9 @@ mod tests {
 
     #[test]
     fn with_network_config() {
-        let net = JsonString::from(String::from(P2pConfig::DEFAULT_MOCK_CONFIG));
+        let net = JsonString::from(String::from(P2pConfig::default_mock_config(
+            "todo make unique",
+        )));
         let context = ContextBuilder::new()
             .with_network_config(net.clone())
             .spawn();

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -205,7 +205,7 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(Address, Str
 /// create a test network
 #[cfg_attr(tarpaulin, skip)]
 pub fn mock_network_config() -> JsonString {
-    JsonString::from(P2pConfig::DEFAULT_MOCK_CONFIG)
+    JsonString::from(P2pConfig::default_mock_config("TODO make unique"))
 }
 
 #[cfg(test)]

--- a/net/src/p2p_config.rs
+++ b/net/src/p2p_config.rs
@@ -85,8 +85,8 @@ impl P2pConfig {
             .expect("file is not a proper JSON of a P2pConfig struct")
     }
 
-    pub fn default_mock() -> Self {
-        P2pConfig::from_str(P2pConfig::DEFAULT_MOCK_CONFIG)
+    pub fn default_mock(network_name: &str) -> Self {
+        P2pConfig::from_str(&P2pConfig::default_mock_config(network_name))
             .expect("Invalid backend_config json on P2pConfig creation.")
     }
 
@@ -98,10 +98,17 @@ impl P2pConfig {
 
 // statics
 impl P2pConfig {
-    pub const DEFAULT_MOCK_CONFIG: &'static str = r#"{
+    pub fn default_mock_config(network_name: &str) -> String {
+        format!(
+            r#"{{
     "backend_kind": "MOCK",
-    "backend_config": ""
-    }"#;
+    "backend_config": {{
+        "networkName": "{}"
+    }}
+}}"#,
+            network_name
+        )
+    }
 
     pub const DEFAULT_IPC_CONFIG: &'static str = r#"
     {
@@ -125,11 +132,15 @@ mod tests {
 
     #[test]
     fn it_can_json_round_trip() {
-        let p2p_config = P2pConfig::from_str(P2pConfig::DEFAULT_MOCK_CONFIG).unwrap();
+        let p2p_config =
+            P2pConfig::from_str(&P2pConfig::default_mock_config("it_can_json_round_trip")).unwrap();
         let json_str = p2p_config.as_str();
         let p2p_config_2 = P2pConfig::from_str(&json_str).unwrap();
         assert_eq!(p2p_config, p2p_config_2);
-        assert_eq!(p2p_config, P2pConfig::default_mock());
+        assert_eq!(
+            p2p_config,
+            P2pConfig::default_mock("it_can_json_round_trip")
+        );
     }
 
     #[test]

--- a/net/src/p2p_network.rs
+++ b/net/src/p2p_network.rs
@@ -50,7 +50,9 @@ impl P2pNetwork {
             }
             P2pBackendKind::MOCK => NetConnectionThread::new(
                 handler,
-                Box::new(move |h| Ok(Box::new(MockWorker::new(h)?) as Box<NetWorker>)),
+                Box::new(move |h| {
+                    Ok(Box::new(MockWorker::new(h, &network_config)?) as Box<NetWorker>)
+                }),
                 None,
             )?,
         };
@@ -84,7 +86,11 @@ mod tests {
 
     #[test]
     fn it_should_create_mock() {
-        let mut res = P2pNetwork::new(Box::new(|_r| Ok(())), &P2pConfig::default_mock()).unwrap();
+        let mut res = P2pNetwork::new(
+            Box::new(|_r| Ok(())),
+            &P2pConfig::default_mock("TODO give unique string"),
+        )
+        .unwrap();
         res.send(Protocol::P2pReady).unwrap();
         res.stop().unwrap();
     }

--- a/test_bin/src/test_bin_mock_net.rs
+++ b/test_bin/src/test_bin_mock_net.rs
@@ -41,7 +41,7 @@ fn exec() -> NetResult<()> {
             sender1.send(r?)?;
             Ok(())
         }),
-        &P2pConfig::default_mock(),
+        &P2pConfig::default_mock("TODO give unique string"),
     )?;
 
     let (sender2, receiver2) = mpsc::channel::<Protocol>();
@@ -51,7 +51,7 @@ fn exec() -> NetResult<()> {
             sender2.send(r?)?;
             Ok(())
         }),
-        &P2pConfig::default_mock(),
+        &P2pConfig::default_mock("TODO give unique string"),
     )?;
 
     con1.send(


### PR DESCRIPTION
This is a rewrite of #816 as a minimally invasive alternative. It doesn't convert network config to structs, it just adds another way to interpret the json blob, and lets `MockWorker` accept that blob of config. It's needed for #815 to allow multiple independent `MockSingletons` (soon to be called `MockSystem`s, or whatever else we want).

Main changes: 
- `MockWorker::new` has to take a `JsonString` of config (just like `IpcWorker`), and the `MockWorker` struct stores the network name.
- All places which create a mock network for testing or otherwise also need to pass a network name as a string.