### PR TITLE
Make MockSingleton multiply instantiable (rebased on #820)

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -205,7 +205,7 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(Address, Str
 /// create a test network
 #[cfg_attr(tarpaulin, skip)]
 pub fn mock_network_config() -> JsonString {
-    JsonString::from(P2pConfig::unique_mock())
+    JsonString::from(P2pConfig::named_mock("mock_network_config()"))
 }
 
 #[cfg(test)]

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -204,7 +204,8 @@ fn start_holochain_instance<T: Into<String>>(
         entry_types.insert(EntryType::from("link_validator"), link_validator);
     }
 
-    let (context, test_logger) = test_context_and_logger(&agent_name.into());
+    let (context, test_logger) =
+        test_context_and_logger_with_network_name(&agent_name.into(), Some(&dna.uuid));
     let mut hc =
         Holochain::new(dna.clone(), context).expect("could not create new Holochain instance.");
 
@@ -671,7 +672,7 @@ fn can_send_and_receive() {
     assert!(result.is_ok(), "result = {:?}", result);
     let agent_id = result.unwrap().to_string();
 
-    let (mut hc2, _) = start_holochain_instance("can_remove_modified_entry", "bob");
+    let (mut hc2, _) = start_holochain_instance("can_send_and_receive", "bob");
     let params = format!(r#"{{"to_agent": {}, "message": "TEST"}}"#, agent_id);
     let result = make_test_call(&mut hc2, "send_message", &params);
     assert!(result.is_ok(), "result = {:?}", result);

--- a/net/src/mock_worker.rs
+++ b/net/src/mock_worker.rs
@@ -280,7 +280,11 @@ impl NetWorker for MockWorker {
     /// forward to our mock singleton
     fn receive(&mut self, data: Protocol) -> NetResult<()> {
         let map_lock = MOCK_MAP.read().unwrap();
-        let mut mock = map_lock.get(&self.network_name).unwrap().lock().unwrap();
+        let mut mock = map_lock
+            .get(&self.network_name)
+            .expect("MockSystem should have been initialized by now")
+            .lock()
+            .unwrap();
         if let Ok(wrap) = ProtocolWrapper::try_from(&data) {
             if let ProtocolWrapper::TrackApp(app) = wrap {
                 let (tx, rx) = mpsc::channel();

--- a/net/src/mock_worker.rs
+++ b/net/src/mock_worker.rs
@@ -281,7 +281,7 @@ impl NetWorker for MockWorker {
     fn receive(&mut self, data: Protocol) -> NetResult<()> {
         if let Ok(wrap) = ProtocolWrapper::try_from(&data) {
             if let ProtocolWrapper::TrackApp(app) = wrap {
-                // Couldn't figure out lifetimes here, so accessing the mock is inlined.
+                // get a write lock first
                 let mut map_lock = MOCK_MAP.write().unwrap();
                 let mut mock = map_lock
                     .entry(self.network_name.clone())
@@ -292,9 +292,11 @@ impl NetWorker for MockWorker {
                 let (tx, rx) = mpsc::channel();
                 self.mock_msgs.push(rx);
                 mock.register(&app.dna_address, &app.agent_id, tx)?;
-                mock.handle(data)?;
             }
         }
+        let map_lock = MOCK_MAP.read().unwrap();
+        let mut mock = map_lock.get(&self.network_name).unwrap().lock().unwrap();
+        mock.handle(data)?;
         Ok(())
     }
 

--- a/net/src/mock_worker.rs
+++ b/net/src/mock_worker.rs
@@ -292,6 +292,7 @@ impl NetWorker for MockWorker {
                 let (tx, rx) = mpsc::channel();
                 self.mock_msgs.push(rx);
                 mock.register(&app.dna_address, &app.agent_id, tx)?;
+                return Ok(());
             }
         }
         let map_lock = MOCK_MAP.read().unwrap();

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -11,14 +11,14 @@ use holochain_container_api::{context_builder::ContextBuilder, error::HolochainR
 use holochain_core::{
     action::Action,
     context::Context,
-    signal::Signal,
     logger::{test_logger, TestLogger},
+    signal::Signal,
 };
 use holochain_core_types::{
-    cas::content::Address,
     agent::AgentId,
+    cas::content::Address,
     dna::{
-        capabilities::{Capability, FnDeclaration, CapabilityType, CapabilityCall},
+        capabilities::{Capability, CapabilityCall, CapabilityType, FnDeclaration},
         entry_types::{EntryTypeDef, LinkedFrom, LinksTo},
         wasm::DnaWasm,
         zome::{Config, Zome},
@@ -27,6 +27,7 @@ use holochain_core_types::{
     entry::entry_type::{AppEntryType, EntryType},
     json::JsonString,
 };
+use holochain_net::p2p_config::P2pConfig;
 
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap},
@@ -41,8 +42,8 @@ use wabt::Wat2Wasm;
 
 /// Load WASM from filesystem
 pub fn create_wasm_from_file(fname: &str) -> Vec<u8> {
-    let mut file = File::open(fname).unwrap_or_else(
-        |err| panic!( "Couldn't create WASM from file: {}; {}", fname, err ));
+    let mut file = File::open(fname)
+        .unwrap_or_else(|err| panic!("Couldn't create WASM from file: {}; {}", fname, err));
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).unwrap();
     buf
@@ -164,20 +165,33 @@ pub fn create_test_dna_with_cap(
 }
 
 #[cfg_attr(tarpaulin, skip)]
-pub fn test_context_and_logger(agent_name: &str) -> (Arc<Context>, Arc<Mutex<TestLogger>>) {
+pub fn test_context_and_logger_with_network_name(
+    agent_name: &str,
+    network_name: Option<&str>,
+) -> (Arc<Context>, Arc<Mutex<TestLogger>>) {
     let agent = AgentId::generate_fake(agent_name);
     let logger = test_logger();
     (
-        Arc::new(
-            ContextBuilder::new()
+        Arc::new({
+            let mut builder = ContextBuilder::new()
                 .with_agent(agent)
                 .with_logger(logger.clone())
                 .with_file_storage(tempdir().unwrap().path().to_str().unwrap())
-                .expect("Tempdir must be accessible")
-                .spawn()
-        ),
+                .expect("Tempdir must be accessible");
+            if let Some(network_name) = network_name {
+                let config =
+                    JsonString::from(String::from(P2pConfig::named_mock_config(network_name)));
+                builder = builder.with_network_config(config);
+            }
+            builder.spawn()
+        }),
         logger,
     )
+}
+
+#[cfg_attr(tarpaulin, skip)]
+pub fn test_context_and_logger(agent_name: &str) -> (Arc<Context>, Arc<Mutex<TestLogger>>) {
+    test_context_and_logger_with_network_name(agent_name, None)
 }
 
 pub fn test_context(agent_name: &str) -> Arc<Context> {
@@ -208,7 +222,16 @@ pub fn hc_setup_and_call_zome_fn(wasm_path: &str, fn_name: &str) -> HolochainRes
     // Run the holochain instance
     hc.start().expect("couldn't start");
     // Call the exposed wasm function
-    return hc.call("test_zome", Some(CapabilityCall::new("test_cap".to_string(), Address::from("test_token"),None)), fn_name, r#"{}"#);
+    return hc.call(
+        "test_zome",
+        Some(CapabilityCall::new(
+            "test_cap".to_string(),
+            Address::from("test_token"),
+            None,
+        )),
+        fn_name,
+        r#"{}"#,
+    );
 }
 
 /// create a test context and TestLogger pair so we can use the logger in assertions
@@ -219,7 +242,7 @@ pub fn create_test_context(agent_name: &str) -> Arc<Context> {
             .with_agent(agent)
             .with_file_storage(tempdir().unwrap().path().to_str().unwrap())
             .expect("Tempdir must be accessible")
-            .spawn()
+            .spawn(),
     )
 }
 


### PR DESCRIPTION
I cherry-picked commits from #815 onto `develop` to build this branch, rather than dealing with merge conflicts of a true rebase. It also has one extra commit to fix a mistake.