### PR TITLE
No rules -> no logs

### DIFF
--- a/container_api/src/logger.rs
+++ b/container_api/src/logger.rs
@@ -64,7 +64,7 @@ impl LogRules {
             color: None,
         };
         if self.rules.len() == 0 {
-            Some(message)
+            None
         } else {
             for r in &self.rules {
                 if r.pattern.is_match(&msg) {


### PR DESCRIPTION
Just a suggestion to change the behavior of an empty LogRules. We already have LogRules::default which causes full logging. This makes it a little easier to just not have logging, rather than having to make an exclude pattern.