### PR TITLE
bump scaffold dependencies and lock them

### DIFF
--- a/cmd/src/cli/js-tests-scaffold/index.js
+++ b/cmd/src/cli/js-tests-scaffold/index.js
@@ -4,7 +4,6 @@ const test = require('tape');
 
 const { Config, Container } = require("@holochain/holochain-nodejs")
 
-//const dnaPath = "./dist/app_spec.hcpkg"
 const dnaPath = "./dist/bundle.json"
 
 // closure to keep config-only stuff out of test scope

--- a/cmd/src/cli/js-tests-scaffold/package.json
+++ b/cmd/src/cli/js-tests-scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@holochain/holochain-nodejs": "0.2.0",
+    "@holochain/holochain-nodejs": "0.3.0",
     "json3": "*",
     "tape": "^4.9.1"
   }

--- a/cmd/src/cli/scaffold/rust.rs
+++ b/cmd/src/cli/scaffold/rust.rs
@@ -27,7 +27,7 @@ fn generate_cargo_toml(name: &str, contents: &str) -> DefaultResult<String> {
 
     let authors_default = Value::from("[\"TODO\"]");
     let edition_default = Value::from("\"TODO\"");
-    let branch_default = Value::from("master");
+    let version_default = Value::from("tag = 0.0.3");
     let maybe_package = config.get("package");
 
     let name = Value::from(name);
@@ -38,7 +38,7 @@ fn generate_cargo_toml(name: &str, contents: &str) -> DefaultResult<String> {
         .and_then(|p| p.get("edition"))
         .unwrap_or(&edition_default);
 
-    interpolate_cargo_template(&name, authors, edition, &branch_default)
+    interpolate_cargo_template(&name, authors, edition, &version_default)
 }
 
 /// Use the Cargo.toml.template file and interpolate values into the placeholders
@@ -47,14 +47,14 @@ fn interpolate_cargo_template(
     name: &Value,
     authors: &Value,
     edition: &Value,
-    branch: &Value,
+    version: &Value,
 ) -> DefaultResult<String> {
     let template = include_str!("rust/Cargo.template.toml");
     Ok(template
         .replace("<<NAME>>", toml::to_string(name)?.as_str())
         .replace("<<AUTHORS>>", toml::to_string(authors)?.as_str())
         .replace("<<EDITION>>", toml::to_string(edition)?.as_str())
-        .replace("<<BRANCH>>", toml::to_string(branch)?.as_str()))
+        .replace("<<VERSION>>", toml::to_string(version)?.as_str()))
 }
 
 impl RustScaffold {

--- a/cmd/src/cli/scaffold/rust/Cargo.template.toml
+++ b/cmd/src/cli/scaffold/rust/Cargo.template.toml
@@ -8,9 +8,9 @@ edition = <<EDITION>>
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-hdk = { git = "https://github.com/holochain/holochain-rust", branch = <<BRANCH>> }
-holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust", branch = <<BRANCH>> }
-holochain_core_types_derive = { git = "https://github.com/holochain/holochain-rust", branch = <<BRANCH>> }
+hdk = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
+holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
+holochain_core_types_derive = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
This assumes the creation of a tag called `0.0.3` 
and the publishing of holochain-nodejs as version `0.3.0`