### PR TITLE
hdk::query API documentation improvements

### DIFF
--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -159,7 +159,7 @@ Consumes three values, two of which are the addresses of entries, and one of whi
 
 Canonical name: `query`
 
-Returns a list of addresses of entries from your local source chain, that match a given type. You can optionally limit the number of results.
+Returns a list of addresses of entries from your local source chain, that match a given entry type name, or a vector of names. You can optionally limit the number of results, and you can use "glob" patterns such as "prefix/*" to specify the entry type names desired.
 
 [View it in the Rust HDK](https://developer.holochain.org/api/latest/hdk/api/fn.query.html)
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -953,12 +953,13 @@ pub fn get_links_and_load<S: Into<String>>(
 
 /// Returns a list of entries from your local source chain, that match a given entry type name or names.
 ///
-/// Each name may be a "glob" pattern such as "prefix/*" (matches all entry types starting with
-/// "prefix/"), or "[!%]*e" (matches all non-system non-name-spaced entry types ending in "e").
+/// Each name may be a plain entry type name, or a "glob" pattern such as "prefix/*" (matches all
+/// entry types starting with "prefix/"), or "[!%]*e" (matches all non-system non-name-spaced entry
+/// types ending in "e").  All names and patterns are merged into a single efficient Regular
+/// Expression for scanning.
 ///
-/// Entry type name-spaces are supported by including "/" in your entry type names; use [], "", or
-/// "**" to match all names in all name-spaces, "*" to match all non-namespaced names. All names and
-/// patterns are merged into a single efficient Regular Expression for scanning.
+/// Entry type name-spaces are supported by including "/" in your entry type names; use vec![], "",
+/// or "**" to match all names in all name-spaces, "*" to match all non-namespaced names.
 ///
 /// entry_type_names: Specify type of entry(s) to retrieve, as a String or Vec<String> of 0 or more names, converted into the QueryArgNames type
 /// start: First entry in result list to retrieve

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -826,8 +826,8 @@ pub fn remove_entry(address: &Address) -> ZomeApiResult<()> {
     res
 }
 
-/// Consumes three values, the address of an entry get get links from (the base); the tag of the links
-/// to be retrieved, and an options struct for selecting what meta data, and crud staus links to retrieve.
+/// Consumes three values; the address of an entry get get links from (the base), the tag of the links
+/// to be retrieved, and an options struct for selecting what meta data and crud status links to retrieve.
 /// Note: the tag is intended to describe the relationship between the `base` and other entries you wish to lookup.
 /// This function returns a list of addresses of other entries which matched as being linked by the given `tag`.
 /// Links are created using the Zome API function [link_entries](fn.link_entries.html).
@@ -952,11 +952,14 @@ pub fn get_links_and_load<S: Into<String>>(
 }
 
 /// Returns a list of entries from your local source chain, that match a given entry type name or names.
+///
 /// Each name may be a "glob" pattern such as "prefix/*" (matches all entry types starting with
 /// "prefix/"), or "[!%]*e" (matches all non-system non-name-spaced entry types ending in "e").
-/// Simple entry type name-spacing is supported by including "/" in your entry type names; use [], "",
-/// or "**" to match all names in all name-spaces. All names and patterns are merged into a single
-/// efficient Regular Expression for scanning.
+///
+/// Entry type name-spaces are supported by including "/" in your entry type names; use [], "", or
+/// "**" to match all names in all name-spaces, "*" to match all non-namespaced names. All names and
+/// patterns are merged into a single efficient Regular Expression for scanning.
+///
 /// entry_type_names: Specify type of entry(s) to retrieve, as a String or Vec<String> of 0 or more names, converted into the QueryArgNames type
 /// start: First entry in result list to retrieve
 /// limit: Max number of entries to retrieve

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -943,8 +943,14 @@ pub fn get_links_and_load<S: Into<String>>(
     Ok(entries)
 }
 
-/// Returns a list of entries from your local source chain, that match a given type.
-/// entry_type_names: Specify type of entry(s) to retrieve, as a Vec<String> of 0 or more names.
+/// Returns a list of entries from your local source chain, that match a given entry type name or names.
+/// Each name may be a "glob" pattern such as "prefix/*" (matches all entry types starting with
+/// "prefix/"), or "[!%]*e" (matches all non-system non-name-spaced entry types ending in "e").
+/// Simple entry type name-spacing is supported by including "/" in your entry type names; use [], "",
+/// or "**" to match all names in all name-spaces. All names and patterns are merged into a single
+/// efficient Regular Expression for scanning.
+/// entry_type_names: Specify type of entry(s) to retrieve, as a String or Vec<String> of 0 or more names, converted into the QueryArgNames type
+/// start: First entry in result list to retrieve
 /// limit: Max number of entries to retrieve
 /// # Examples
 /// ```rust
@@ -957,6 +963,12 @@ pub fn get_links_and_load<S: Into<String>>(
 /// # fn main() {
 /// pub fn handle_my_posts_as_commited() -> ZomeApiResult<Vec<Address>> {
 ///     hdk::query("post".into(), 0, 0)
+/// }
+/// pub fn all_system_plus_mine() -> ZomeApiResult<Vec<Address>> {
+///     hdk::query(vec!["[%]*","mine"].into(), 0, 0)
+/// }
+/// pub fn everything_including_namespaced_except_system() -> ZomeApiResult<Vec<Address>> {
+///     hdk::query("**/[!%]*".into(), 0, 0)
 /// }
 /// # }
 /// ```


### PR DESCRIPTION
A bit more documentation of the hdk::query API, describing a bit about handling single or vectors of Strings (`"someting".into()` or `vec!["something", another].into()`), of its "glob" pattern matching capability, and a brief hint about name-spacing entry types.