### PR TITLE
fix template - reed solomon failing

### DIFF
--- a/container/example-config/basic.toml
+++ b/container/example-config/basic.toml
@@ -1,13 +1,13 @@
 [[agents]]
 id = "test agent 1"
 name = "Holo Tester 1"
-public_address = "HoloTester1-------------------------------------------------------------------------AHi1"
+public_address = "HoloTester1-----------------------------------------------------------------------AAACZp4xHB"
 key_file = "holo_tester.key"
 
 [[agents]]
 id = "test agent 2"
 name = "Holo Tester 2"
-public_address = "HoloTester2-------------------------------------------------------------------------AJmU"
+public_address = "HoloTester2-----------------------------------------------------------------------AAAGy4WW9e"
 key_file = "holo_tester.key"
 
 [[dnas]]


### PR DESCRIPTION
I guess this is outside of code coverage... I just copied the template and tried to run it, and got 

ReedSolomon too many errors. 

Luckily I knew enough about it to know where to look...  

I started by going to https://github.com/holochain/holochain-ui/blob/develop/container-config.tomla
and looking for differences...

Then I pulled these valid values from the test code. 