### PR TITLE
Use tap-summary instead of faucet

### DIFF
--- a/app_spec/build_and_test.sh
+++ b/app_spec/build_and_test.sh
@@ -11,6 +11,4 @@ echo "Running test.js in node"
 echo "------------------------------------------------------------------------------------"
 cd test
 npm install
-cd ..
-node test/test.js | test/node_modules/faucet/bin/cmd.js
-node test/regressions.js | test/node_modules/faucet/bin/cmd.js
+npm test

--- a/app_spec/test/package.json
+++ b/app_spec/test/package.json
@@ -1,10 +1,9 @@
 {
-  "devDependencies": {
-    "faucet": "0.0.1"
-  },
+  "devDependencies": {},
   "dependencies": {
     "json3": "*",
     "sleep": "^5.2.3",
+    "tap-summary": "^4.0.0",
     "tape": "^4.9.1"
   },
   "scripts": {

--- a/app_spec/test/package.json
+++ b/app_spec/test/package.json
@@ -8,6 +8,6 @@
     "tape": "^4.9.1"
   },
   "scripts": {
-    "test": "node test.js"
+    "test": "./run.sh"
   }
 }

--- a/app_spec/test/regressions.js
+++ b/app_spec/test/regressions.js
@@ -1,11 +1,12 @@
 
-const sleep = require('sleep');
+const path = require('path')
+const sleep = require('sleep')
 const test = require('tape')
 const { pollFor } = require('./util')
 
 const { Config, Container } = require('../../nodejs_container')
 
-const dnaPath = "./dist/app_spec.hcpkg"
+const dnaPath = path.join(__dirname, "../dist/app_spec.hcpkg")
 const aliceName = "alice"
 const tashName = "tash"
 

--- a/app_spec/test/run.sh
+++ b/app_spec/test/run.sh
@@ -1,0 +1,7 @@
+if [ -z $1 ] 
+then
+	node test.js | faucet
+	node regressions.js | faucet
+else
+	node $1 | faucet
+fi

--- a/app_spec/test/run.sh
+++ b/app_spec/test/run.sh
@@ -1,7 +1,7 @@
 if [ -z $1 ] 
 then
-	node test.js | faucet
-	node regressions.js | faucet
+	node test.js | tap-summary
+	node regressions.js | tap-summary
 else
-	node $1 | faucet
+	node $1 | tap-summary
 fi

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -1,11 +1,12 @@
 
-const sleep = require('sleep');
+const path = require('path')
+const sleep = require('sleep')
 const test = require('tape')
 const { pollFor } = require('./util')
 
 const { Config, Container } = require('../../nodejs_container')
 
-const dnaPath = "./dist/app_spec.hcpkg"
+const dnaPath = path.join(__dirname, "../dist/app_spec.hcpkg")
 const aliceName = "alice"
 const tashName = "tash"
 


### PR DESCRIPTION
Now that we have two test files, faucet sometimes complains with: `not ok 7 assert out of order`.

According to [this issue](https://github.com/substack/tape/issues/215#issuecomment-271470048), tap-summary can handle this better.