### PR TITLE
Explicit mock network names where necessary

### DIFF
--- a/container_api/src/config.rs
+++ b/container_api/src/config.rs
@@ -389,10 +389,10 @@ where
 pub mod tests {
     use super::*;
     use crate::config::{load_configuration, Configuration, NetworkConfig};
-    use holochain_core::context::mock_network_config;
+    use holochain_core::context::unique_mock_config;
 
     pub fn example_serialized_network_config() -> String {
-        String::from(mock_network_config())
+        String::from(unique_mock_config())
     }
 
     #[test]

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -304,9 +304,10 @@ pub mod tests {
     /// test for reducing commit entry
     fn test_reduce_commit_entry() {
         let mut agent_state = test_agent_state();
-        let context = test_context("bob");
+        let netname = Some("test_reduce_commit_entry");
+        let context = test_context("bob", netname);
         let state = State::new_with_agent(context, Arc::new(agent_state.clone()));
-        let mut context = test_context("bob");
+        let mut context = test_context("bob", netname);
         Arc::get_mut(&mut context)
             .unwrap()
             .set_state(Arc::new(RwLock::new(state)));

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -208,10 +208,15 @@ pub fn unique_mock_config() -> JsonString {
     JsonString::from(P2pConfig::unique_mock())
 }
 
-/// create a named test network
+/// Create a named test network if name is Some, otherwise create a unique one using snowflake
+/// This is the base function that many other `text_context*` functions use, and hence they also
+/// require an optional network name. The reasoning for this is that tests which only require a
+/// single instance may simply pass None and get a unique network name, but tests which require two
+/// instances to be on the same network need to ensure both contexts use the same network name.
 #[cfg_attr(tarpaulin, skip)]
-pub fn test_mock_config(name: Option<&str>) -> JsonString {
-    name.map(|name| JsonString::from(P2pConfig::named_mock(name)))
+pub fn test_mock_config(network_name: Option<&str>) -> JsonString {
+    network_name
+        .map(|name| JsonString::from(P2pConfig::named_mock(name)))
         .unwrap_or(unique_mock_config())
 }
 

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -204,8 +204,8 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(Address, Str
 
 /// create a test network
 #[cfg_attr(tarpaulin, skip)]
-pub fn mock_network_config() -> JsonString {
-    JsonString::from(P2pConfig::named_mock("mock_network_config()"))
+pub fn unique_mock_config() -> JsonString {
+    JsonString::from(P2pConfig::unique_mock())
 }
 
 #[cfg(test)]
@@ -215,7 +215,7 @@ pub mod tests {
     use self::tempfile::tempdir;
     use super::*;
     use crate::{
-        context::mock_network_config, logger::test_logger, persister::SimplePersister, state::State,
+        context::unique_mock_config, logger::test_logger, persister::SimplePersister, state::State,
     };
     use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
     use holochain_core_types::agent::AgentId;
@@ -241,7 +241,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            unique_mock_config(),
             None,
             None,
         );
@@ -274,7 +274,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            unique_mock_config(),
             None,
             None,
         );

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -202,10 +202,17 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(Address, Str
     Ok((dna.address(), agent_id))
 }
 
-/// create a test network
+/// create a unique test network
 #[cfg_attr(tarpaulin, skip)]
 pub fn unique_mock_config() -> JsonString {
     JsonString::from(P2pConfig::unique_mock())
+}
+
+/// create a named test network
+#[cfg_attr(tarpaulin, skip)]
+pub fn test_mock_config(name: Option<&str>) -> JsonString {
+    name.map(|name| JsonString::from(P2pConfig::named_mock(name)))
+        .unwrap_or(unique_mock_config())
 }
 
 #[cfg(test)]

--- a/core/src/dht/actions/add_link.rs
+++ b/core/src/dht/actions/add_link.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn can_add_valid_link() {
-        let (_instance, context) = nucleus::actions::tests::instance();
+        let (_instance, context) = nucleus::actions::tests::instance(None);
 
         let base = test_entry();
         nucleus::actions::tests::commit(base.clone(), &context);
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn errors_when_link_base_not_present() {
-        let (_instance, context) = nucleus::actions::tests::instance();
+        let (_instance, context) = nucleus::actions::tests::instance(None);
 
         let base = test_entry();
         let target = base.clone();

--- a/core/src/dht/dht_reducers.rs
+++ b/core/src/dht/dht_reducers.rs
@@ -312,7 +312,7 @@ pub mod tests {
 
     #[test]
     fn reduce_hold_entry_test() {
-        let context = test_context("bob");
+        let context = test_context("bob", None);
         let store = test_store(context.clone());
 
         // test_entry is not sys so should do nothing
@@ -347,7 +347,7 @@ pub mod tests {
 
     #[test]
     fn can_add_links() {
-        let context = test_context("bob");
+        let context = test_context("bob", None);
         let store = test_store(context.clone());
         let entry = test_entry();
 
@@ -385,7 +385,7 @@ pub mod tests {
 
     #[test]
     fn does_not_add_link_for_missing_base() {
-        let context = test_context("bob");
+        let context = test_context("bob", None);
         let store = test_store(context.clone());
         let entry = test_entry();
 
@@ -421,7 +421,7 @@ pub mod tests {
 
     #[test]
     pub fn reduce_hold_test() {
-        let context = test_context("bill");
+        let context = test_context("bill", None);
         let store = test_store(context.clone());
 
         let entry = test_entry();

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -315,7 +315,7 @@ pub mod tests {
             chain_store::ChainStore,
             state::{ActionResponse, AgentState},
         },
-        context::{mock_network_config, Context},
+        context::{unique_mock_config, Context},
         logger::{test_logger, TestLogger},
     };
     use futures::executor::block_on;
@@ -369,7 +369,7 @@ pub mod tests {
                     EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                         .unwrap(),
                 )),
-                mock_network_config(),
+                unique_mock_config(),
                 None,
                 None,
             )),
@@ -409,7 +409,7 @@ pub mod tests {
                     EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                         .unwrap(),
                 )),
-                mock_network_config(),
+                unique_mock_config(),
             )
             .unwrap(),
         )
@@ -430,7 +430,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            unique_mock_config(),
             None,
             None,
         );
@@ -454,7 +454,7 @@ pub mod tests {
                 EavFileStorage::new(tempdir().unwrap().path().to_str().unwrap().to_string())
                     .unwrap(),
             )),
-            mock_network_config(),
+            unique_mock_config(),
             None,
             None,
         );

--- a/core/src/link_tests.rs
+++ b/core/src/link_tests.rs
@@ -47,14 +47,15 @@ pub mod tests {
     /// Committing a LinkEntry to source chain should work
     #[test]
     fn can_commit_link() {
+        let netname = Some("can_commit_link");
         // Create Context, Agent, Dna, and Commit AgentIdEntry Action
-        let context = test_context("alex");
+        let context = test_context("alex", netname);
         let link = create_example_link();
         let link_list = LinkList::new(&[link]);
         let link_list_entry = Entry::LinkList(link_list);
         let commit_action = ActionWrapper::new(Action::Commit((link_list_entry.clone(), None)));
         // Set up instance and process the action
-        let instance = Instance::new(test_context("jason"));
+        let instance = Instance::new(test_context("jason", netname));
         let state_observers: Vec<Observer> = Vec::new();
         let (_, rx_observer) = channel::<Observer>();
         let context = instance.initialize_context(context);
@@ -78,8 +79,9 @@ pub mod tests {
     /// Committing a LinkList to source chain should work
     #[test]
     fn can_commit_multilink() {
+        let netname = Some("can_commit_multilink");
         // Create Context, Agent, Dna, and Commit AgentIdEntry Action
-        let context = test_context("alex");
+        let context = test_context("alex", netname);
         let link_a = create_test_link_a();
         let link_b = create_test_link_b();
         let link_c = create_test_link_c();
@@ -88,7 +90,7 @@ pub mod tests {
         let commit_action = ActionWrapper::new(Action::Commit((link_list_entry.clone(), None)));
         println!("commit_multilink: {:?}", commit_action);
         // Set up instance and process the action
-        let instance = Instance::new(test_context("jason"));
+        let instance = Instance::new(test_context("jason", netname));
         let state_observers: Vec<Observer> = Vec::new();
         let (_, rx_observer) = channel::<Observer>();
         let context = instance.initialize_context(context);

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -33,10 +33,13 @@ pub mod tests {
 
     #[test]
     fn get_entry_roundtrip() {
+        let netname = Some("get_entry_roundtrip");
         let mut dna = create_test_dna_with_wat("test_zome", "test_cap", None);
         dna.uuid = String::from("get_entry_roundtrip");
-        let (_, context1) = test_instance_and_context_by_name(dna.clone(), "alice1").unwrap();
-        let (_, context2) = test_instance_and_context_by_name(dna.clone(), "bob1").unwrap();
+        let (_, context1) =
+            test_instance_and_context_by_name(dna.clone(), "alice1", netname).unwrap();
+        let (_, context2) =
+            test_instance_and_context_by_name(dna.clone(), "bob1", netname).unwrap();
 
         // Create Entry & crud-status metadata, and store it.
         let entry = test_entry();
@@ -59,10 +62,12 @@ pub mod tests {
 
     #[test]
     fn get_non_existant_entry() {
+        let netname = Some("get_non_existant_entry");
         let mut dna = create_test_dna_with_wat("test_zome", "test_cap", None);
         dna.uuid = String::from("get_non_existant_entry");
-        let (_, _) = test_instance_and_context_by_name(dna.clone(), "alice2").unwrap();
-        let (_, context2) = test_instance_and_context_by_name(dna.clone(), "bob2").unwrap();
+        let (_, _) = test_instance_and_context_by_name(dna.clone(), "alice2", netname).unwrap();
+        let (_, context2) =
+            test_instance_and_context_by_name(dna.clone(), "bob2", netname).unwrap();
 
         let entry = test_entry();
 
@@ -74,9 +79,11 @@ pub mod tests {
 
     #[test]
     fn get_when_alone() {
+        let netname = Some("get_when_alone");
         let mut dna = create_test_dna_with_wat("test_zome", "test_cap", None);
         dna.uuid = String::from("get_when_alone");
-        let (_, context1) = test_instance_and_context_by_name(dna.clone(), "bob3").unwrap();
+        let (_, context1) =
+            test_instance_and_context_by_name(dna.clone(), "bob3", netname).unwrap();
 
         let entry = test_entry();
 
@@ -88,11 +95,13 @@ pub mod tests {
 
     #[test]
     fn get_validation_package_roundtrip() {
+        let netname = Some("get_validation_package_roundtrip");
         let wat = &test_wat_always_valid();
 
         let mut dna = create_test_dna_with_wat("test_zome", "test_cap", Some(wat));
         dna.uuid = String::from("get_validation_package_roundtrip");
-        let (_, context1) = test_instance_and_context_by_name(dna.clone(), "alice1").unwrap();
+        let (_, context1) =
+            test_instance_and_context_by_name(dna.clone(), "alice1", netname).unwrap();
 
         let entry = test_entry();
         block_on(author_entry(&entry, None, &context1)).expect("Could not author entry");
@@ -102,7 +111,8 @@ pub mod tests {
             .get_header_for_entry(&entry)
             .expect("There must be a header in the author's source chain after commit");
 
-        let (_, context2) = test_instance_and_context_by_name(dna.clone(), "bob1").unwrap();
+        let (_, context2) =
+            test_instance_and_context_by_name(dna.clone(), "bob1", netname).unwrap();
         let result = block_on(get_validation_package(header.clone(), &context2));
 
         assert!(result.is_ok());
@@ -114,11 +124,13 @@ pub mod tests {
 
     #[test]
     fn get_links_roundtrip() {
+        let netname = Some("get_links_roundtrip");
         let wat = &test_wat_always_valid();
 
         let mut dna = create_test_dna_with_wat("test_zome", "test_cap", Some(wat));
         dna.uuid = String::from("get_links_roundtrip");
-        let (_, context1) = test_instance_and_context_by_name(dna.clone(), "alice1").unwrap();
+        let (_, context1) =
+            test_instance_and_context_by_name(dna.clone(), "alice1", netname).unwrap();
 
         let mut entry_addresses: Vec<Address> = Vec::new();
         for i in 0..3 {
@@ -134,7 +146,8 @@ pub mod tests {
         assert!(block_on(add_link(&link1, &context1)).is_ok());
         assert!(block_on(add_link(&link2, &context1)).is_ok());
 
-        let (_, context2) = test_instance_and_context_by_name(dna.clone(), "bob1").unwrap();
+        let (_, context2) =
+            test_instance_and_context_by_name(dna.clone(), "bob1", netname).unwrap();
 
         let maybe_links = block_on(get_links(
             &context2,

--- a/core/src/network/reducers/get_entry.rs
+++ b/core/src/network/reducers/get_entry.rs
@@ -72,7 +72,7 @@ mod tests {
 
     use crate::{
         action::{Action, ActionWrapper, NetworkSettings},
-        context::mock_network_config,
+        context::unique_mock_config,
         instance::tests::test_context,
         state::test_store,
     };
@@ -112,7 +112,7 @@ mod tests {
         let store = test_store(context.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: unique_mock_config(),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));
@@ -139,7 +139,7 @@ mod tests {
         Arc::get_mut(&mut context).unwrap().set_state(store.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: unique_mock_config(),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));

--- a/core/src/network/reducers/get_entry.rs
+++ b/core/src/network/reducers/get_entry.rs
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     pub fn reduce_get_entry_without_network_initialized() {
-        let context = test_context("alice");
+        let context = test_context("alice", None);
         let store = test_store(context.clone());
 
         let entry = test_entry();
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     pub fn reduce_get_entry_test() {
-        let context = test_context("alice");
+        let context = test_context("alice", None);
         let store = test_store(context.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     pub fn reduce_get_entry_timeout_test() {
-        let mut context = test_context("alice");
+        let mut context = test_context("alice", None);
         let store = test_store(context.clone());
         let store = Arc::new(RwLock::new(store));
 

--- a/core/src/network/reducers/get_links.rs
+++ b/core/src/network/reducers/get_links.rs
@@ -68,7 +68,7 @@ mod tests {
 
     use crate::{
         action::{Action, ActionWrapper, NetworkSettings},
-        context::mock_network_config,
+        context::unique_mock_config,
         instance::tests::test_context,
         state::test_store,
     };
@@ -107,7 +107,7 @@ mod tests {
         let store = test_store(context.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: unique_mock_config(),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));
@@ -136,7 +136,7 @@ mod tests {
         Arc::get_mut(&mut context).unwrap().set_state(store.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: unique_mock_config(),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));

--- a/core/src/network/reducers/get_links.rs
+++ b/core/src/network/reducers/get_links.rs
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     pub fn reduce_get_links_without_network_initialized() {
-        let context = test_context("alice");
+        let context = test_context("alice", None);
         let store = test_store(context.clone());
 
         let entry = test_entry();
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     pub fn reduce_get_links_test() {
-        let context = test_context("alice");
+        let context = test_context("alice", None);
         let store = test_store(context.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     pub fn reduce_get_links_timeout_test() {
-        let mut context = test_context("alice");
+        let mut context = test_context("alice", None);
         let store = test_store(context.clone());
         let store = Arc::new(RwLock::new(store));
 

--- a/core/src/network/reducers/publish.rs
+++ b/core/src/network/reducers/publish.rs
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     pub fn reduce_publish_test() {
-        let context = test_context("alice");
+        let context = test_context("alice", None);
         let store = test_store(context.clone());
 
         let entry = test_entry();

--- a/core/src/network/reducers/send_direct_message.rs
+++ b/core/src/network/reducers/send_direct_message.rs
@@ -71,7 +71,7 @@ mod tests {
 
     use crate::{
         action::{Action, ActionWrapper, DirectMessageData, NetworkSettings},
-        context::mock_network_config,
+        context::unique_mock_config,
         instance::tests::test_context,
         network::direct_message::{CustomDirectMessage, DirectMessage},
         state::test_store,
@@ -88,7 +88,7 @@ mod tests {
         Arc::get_mut(&mut context).unwrap().set_state(store.clone());
 
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(NetworkSettings {
-            config: mock_network_config(),
+            config: unique_mock_config(),
             dna_address: "abcd".into(),
             agent_id: String::from("abcd"),
         }));

--- a/core/src/network/reducers/send_direct_message.rs
+++ b/core/src/network/reducers/send_direct_message.rs
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     pub fn reduce_send_direct_message_timeout_test() {
-        let mut context = test_context("alice");
+        let mut context = test_context("alice", None);
         let store = test_store(context.clone());
         let store = Arc::new(RwLock::new(store));
 

--- a/core/src/network/test_utils.rs
+++ b/core/src/network/test_utils.rs
@@ -16,7 +16,7 @@ pub fn test_instance_with_spoofed_dna(
     name: &str,
 ) -> Result<(Instance, Arc<Context>), String> {
     // Create instance and plug in our DNA
-    let context = test_context(name);
+    let context = test_context(name, None);
     let mut instance = Instance::new(context.clone());
     instance.start_action_loop(context.clone());
     let context = instance.initialize_context(context);

--- a/core/src/nucleus/actions/build_validation_package.rs
+++ b/core/src/nucleus/actions/build_validation_package.rs
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_building_validation_package_entry() {
-        let (_instance, context) = instance();
+        let (_instance, context) = instance(None);
 
         // adding other entries to not have special case of empty chain
         commit(test_entry_package_chain_entries(), &context);
@@ -250,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_building_validation_package_chain_entries() {
-        let (_instance, context) = instance();
+        let (_instance, context) = instance(None);
 
         // adding other entries to not have special case of empty chain
         commit(test_entry_package_chain_entries(), &context);
@@ -277,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_building_validation_package_chain_headers() {
-        let (_instance, context) = instance();
+        let (_instance, context) = instance(None);
 
         // adding other entries to not have special case of empty chain
         commit(test_entry_package_chain_entries(), &context);
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_building_validation_package_chain_full() {
-        let (_instance, context) = instance();
+        let (_instance, context) = instance(None);
 
         // adding other entries to not have special case of empty chain
         commit(test_entry_package_chain_entries(), &context);

--- a/core/src/nucleus/actions/get_entry.rs
+++ b/core/src/nucleus/actions/get_entry.rs
@@ -117,7 +117,7 @@ pub mod tests {
     #[test]
     fn get_entry_from_dht_cas() {
         let entry = test_entry();
-        let context = test_context_with_state();
+        let context = test_context_with_state(None);
         let result = super::get_entry_from_dht(&context, entry.address());
         assert_eq!(Ok(None), result);
         let storage = &context.state().unwrap().dht().content_storage().clone();

--- a/core/src/nucleus/actions/mod.rs
+++ b/core/src/nucleus/actions/mod.rs
@@ -72,8 +72,8 @@ pub mod tests {
 
     #[cfg_attr(tarpaulin, skip)]
     pub fn instance_by_name(name: &str, dna: Dna) -> (Instance, Arc<Context>) {
-        let (instance, context) =
-            test_instance_and_context_by_name(dna, name).expect("Could not create test instance");
+        let (instance, context) = test_instance_and_context_by_name(dna, name, None)
+            .expect("Could not create test instance");
         let initialized_context = instance.initialize_context(context);
         (instance, initialized_context)
     }

--- a/core/src/nucleus/actions/mod.rs
+++ b/core/src/nucleus/actions/mod.rs
@@ -27,8 +27,8 @@ pub mod tests {
     use test_utils::*;
 
     #[cfg_attr(tarpaulin, skip)]
-    pub fn instance() -> (Instance, Arc<Context>) {
-        instance_by_name("jane", test_dna())
+    pub fn instance(network_name: Option<&str>) -> (Instance, Arc<Context>) {
+        instance_by_name("jane", test_dna(), network_name)
     }
 
     #[cfg_attr(tarpaulin, skip)]
@@ -71,8 +71,12 @@ pub mod tests {
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    pub fn instance_by_name(name: &str, dna: Dna) -> (Instance, Arc<Context>) {
-        let (instance, context) = test_instance_and_context_by_name(dna, name, None)
+    pub fn instance_by_name(
+        name: &str,
+        dna: Dna,
+        network_name: Option<&str>,
+    ) -> (Instance, Arc<Context>) {
+        let (instance, context) = test_instance_and_context_by_name(dna, name, network_name)
             .expect("Could not create test instance");
         let initialized_context = instance.initialize_context(context);
         (instance, initialized_context)
@@ -115,7 +119,7 @@ pub mod tests {
     // smoke test just to make sure our testing code works.
     #[test]
     pub fn can_instantiate_test_instance() {
-        let (instance, _context) = instance();
+        let (instance, _context) = instance(None);
         assert!(instance.state().nucleus().has_initialized());
     }
 

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -501,7 +501,7 @@ pub mod tests {
     #[test]
     /// test for returning zome function result actions
     fn test_reduce_return_zome_function_result() {
-        let context = test_context("jimmy");
+        let context = test_context("jimmy", None);
         let mut state = test_nucleus_state();
         let action_wrapper = test_action_wrapper_rzfr();
 
@@ -523,7 +523,7 @@ pub mod tests {
         let nucleus = Arc::new(NucleusState::new()); // initialize to bogus value
         let (sender, _receiver) = sync_channel::<ActionWrapper>(10);
         let (tx_observer, _observer) = sync_channel::<Observer>(10);
-        let context = test_context_with_channels("jimmy", &sender, &tx_observer);
+        let context = test_context_with_channels("jimmy", &sender, &tx_observer, None);
 
         // Reduce Init action
         let reduced_nucleus = reduce(context.clone(), nucleus.clone(), &action_wrapper);
@@ -543,7 +543,7 @@ pub mod tests {
         let nucleus = Arc::new(NucleusState::new()); // initialize to bogus value
         let (sender, _receiver) = sync_channel::<ActionWrapper>(10);
         let (tx_observer, _observer) = sync_channel::<Observer>(10);
-        let context = test_context_with_channels("jimmy", &sender, &tx_observer).clone();
+        let context = test_context_with_channels("jimmy", &sender, &tx_observer, None).clone();
 
         // Reduce Init action
         let initializing_nucleus = reduce(context.clone(), nucleus.clone(), &action_wrapper);
@@ -591,7 +591,7 @@ pub mod tests {
     /// tests that calling a valid zome function returns a valid result
     fn call_zome_function() {
         let dna = test_utils::create_test_dna_with_wat("test_zome", "test_cap", None);
-        let mut instance = test_instance(dna).expect("Could not initialize test instance");
+        let mut instance = test_instance(dna, None).expect("Could not initialize test instance");
 
         // Create zome function call
         let zome_call = ZomeFnCall::new("test_zome", Some(test_capability_call()), "main", "");
@@ -611,7 +611,7 @@ pub mod tests {
         let nucleus = Arc::new(NucleusState::new()); // initialize to bogus value
         let (sender, _receiver) = sync_channel::<ActionWrapper>(10);
         let (tx_observer, _observer) = sync_channel::<Observer>(10);
-        let context = test_context_with_channels("jimmy", &sender, &tx_observer);
+        let context = test_context_with_channels("jimmy", &sender, &tx_observer, None);
 
         let reduced_nucleus = reduce(context, nucleus.clone(), &action_wrapper);
         assert_eq!(nucleus, reduced_nucleus);
@@ -620,9 +620,10 @@ pub mod tests {
     #[test]
     /// tests that calling an invalid DNA returns the correct error
     fn call_ribosome_wrong_dna() {
-        let mut instance = Instance::new(test_context("janet"));
+        let netname = Some("call_ribosome_wrong_dna");
+        let mut instance = Instance::new(test_context("janet", netname));
 
-        instance.start_action_loop(test_context("jane"));
+        instance.start_action_loop(test_context("jane", netname));
 
         let call = ZomeFnCall::new("test_zome", Some(test_capability_call()), "main", "{}");
         let result = super::call_and_wait_for_result(call, &mut instance);
@@ -637,7 +638,7 @@ pub mod tests {
     /// tests that calling a valid zome with invalid function returns the correct error
     fn call_ribosome_wrong_function() {
         let dna = test_utils::create_test_dna_with_wat("test_zome", "test_cap", None);
-        let mut instance = test_instance(dna).expect("Could not initialize test instance");
+        let mut instance = test_instance(dna, None).expect("Could not initialize test instance");
 
         // Create zome function call:
         let call = ZomeFnCall::new("test_zome", Some(test_capability_call()), "xxx", "{}");
@@ -656,7 +657,7 @@ pub mod tests {
     /// tests that calling the wrong zome/capability returns the correct errors
     fn call_wrong_zome_function() {
         let dna = test_utils::create_test_dna_with_wat("test_zome", "test_cap", None);
-        let mut instance = test_instance(dna).expect("Could not initialize test instance");
+        let mut instance = test_instance(dna, None).expect("Could not initialize test instance");
 
         // Create bad zome function call
         let call = ZomeFnCall::new("xxx", Some(test_capability_call()), "main", "{}");

--- a/core/src/nucleus/ribosome/api/call.rs
+++ b/core/src/nucleus/ribosome/api/call.rs
@@ -354,7 +354,7 @@ pub mod tests {
 
     fn setup_test(dna: Dna) -> TestSetup {
         let (instance, context) =
-            test_instance_and_context(dna).expect("Could not initialize test instance");
+            test_instance_and_context(dna, None).expect("Could not initialize test instance");
         TestSetup {
             context: context,
             instance: instance,

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -169,14 +169,16 @@ pub mod tests {
     #[test]
     /// test that we can round trip bytes through a get action and it comes back from wasm
     fn test_get_round_trip() {
+        let netname = Some("test_get_round_trip");
         let wasm = test_get_round_trip_wat();
         let dna = test_utils::create_test_dna_with_wasm(
             &test_zome_name(),
             &test_capability_name(),
             wasm.clone(),
         );
-        let instance = test_instance(dna.clone()).expect("Could not initialize test instance");
-        let (context, _) = test_context_and_logger("joan");
+        let instance =
+            test_instance(dna.clone(), netname).expect("Could not initialize test instance");
+        let (context, _) = test_context_and_logger("joan", netname);
         let context = instance.initialize_context(context);
 
         println!("{:?}", instance.state().agent().top_chain_header());

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -99,9 +99,10 @@ pub mod tests {
         );
 
         let dna_name = &dna.name.to_string().clone();
-        let instance = test_instance(dna).expect("Could not create test instance");
+        let netname = Some("returns_list_of_links");
+        let instance = test_instance(dna, netname).expect("Could not create test instance");
 
-        let (context, _) = test_context_and_logger("joan");
+        let (context, _) = test_context_and_logger("joan", netname);
         let initialized_context = instance.initialize_context(context);
 
         let mut entry_addresses: Vec<Address> = Vec::new();

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -113,9 +113,10 @@ pub mod tests {
             wasm.clone(),
         );
 
-        let instance = test_instance(dna).expect("Could not create test instance");
+        let netname = Some("create_test_instance");
+        let instance = test_instance(dna, netname).expect("Could not create test instance");
 
-        let (context, _) = test_context_and_logger("joan");
+        let (context, _) = test_context_and_logger("joan", netname);
         let initialized_context = instance.initialize_context(context);
         (instance, initialized_context)
     }

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -400,7 +400,7 @@ pub mod tests {
 
         let dna_name = &dna.name.to_string().clone();
         let (instance, context) =
-            test_instance_and_context(dna).expect("Could not create test instance");
+            test_instance_and_context(dna, None).expect("Could not create test instance");
 
         let call_result =
             test_zome_api_function_call(&dna_name, context.clone(), &instance, &wasm, args_bytes);

--- a/core/src/nucleus/ribosome/callback/genesis.rs
+++ b/core/src/nucleus/ribosome/callback/genesis.rs
@@ -29,9 +29,10 @@ pub mod tests {
     #[test]
     fn pass() {
         let zome = "test_zome";
-        let instance = test_callback_instance(zome, Callback::Genesis.as_str(), 0)
+        let netname = Some("genesis::pass");
+        let instance = test_callback_instance(zome, Callback::Genesis.as_str(), 0, netname)
             .expect("Test callback instance could not be initialized");
-        let context = instance.initialize_context(test_context("test"));
+        let context = instance.initialize_context(test_context("test", netname));
 
         let result = genesis(context, zome, &CallbackParams::Genesis);
 
@@ -41,15 +42,17 @@ pub mod tests {
     #[test]
     fn not_implemented() {
         let zome = "test_zome";
+        let netname = Some("genesis::not_implemented");
         let instance = test_callback_instance(
             zome,
             // anything other than Genesis is fine here
             Callback::Receive.as_str(),
             0,
+            netname,
         )
         .expect("Test callback instance could not be initialized");
 
-        let context = instance.initialize_context(test_context("test"));
+        let context = instance.initialize_context(test_context("test", netname));
 
         let result = genesis(context, zome, &CallbackParams::Genesis);
 
@@ -63,7 +66,8 @@ pub mod tests {
     #[test]
     fn fail() {
         let zome = "test_zome";
-        let instance = test_callback_instance(zome, Callback::Genesis.as_str(), 1);
+        let netname = Some("genesis::fail");
+        let instance = test_callback_instance(zome, Callback::Genesis.as_str(), 1, netname);
         assert!(instance.is_err());
         let error = instance.err().unwrap();
         assert_eq!("\"".to_string(), error);

--- a/core/src/nucleus/ribosome/callback/mod.rs
+++ b/core/src/nucleus/ribosome/callback/mod.rs
@@ -325,6 +325,7 @@ pub mod tests {
         zome: &str,
         canonical_name: &str,
         result: i32,
+        network_name: Option<&str>,
     ) -> Result<Instance, String> {
         let dna = test_utils::create_test_dna_with_wasm(
             zome,
@@ -335,7 +336,7 @@ pub mod tests {
             test_callback_wasm(canonical_name, result),
         );
 
-        test_instance(dna)
+        test_instance(dna, network_name)
     }
 
     #[test]

--- a/core/src/nucleus/ribosome/callback/receive.rs
+++ b/core/src/nucleus/ribosome/callback/receive.rs
@@ -71,14 +71,16 @@ pub mod tests {
     #[test]
     fn not_implemented() {
         let zome = "test_zome";
+        let netname = Some("not_implemented test");
         let instance = test_callback_instance(
             zome,
             // anything other than Genesis is fine here
             Callback::MissingNo.as_str(),
             0,
+            netname,
         )
         .expect("Test callback instance could not be initialized");
-        let context = instance.initialize_context(test_context("test"));
+        let context = instance.initialize_context(test_context("test", netname));
 
         if let CallbackResult::NotImplemented(_) =
             receive(context, zome, &CallbackParams::Receive(String::from("")))
@@ -92,9 +94,10 @@ pub mod tests {
     #[test]
     fn implemented_with_null() {
         let zome = "test_zome";
-        let instance = test_callback_instance(zome, Callback::Receive.as_str(), 0)
+        let netname = Some("implemented_with_null");
+        let instance = test_callback_instance(zome, Callback::Receive.as_str(), 0, netname)
             .expect("Test callback instance could not be initialized");
-        let context = instance.initialize_context(test_context("test"));
+        let context = instance.initialize_context(test_context("test", netname));
 
         let result = receive(context, zome, &CallbackParams::Receive(String::from("")));
 

--- a/core/src/persister.rs
+++ b/core/src/persister.rs
@@ -74,11 +74,11 @@ mod tests {
     use std::fs::File;
 
     #[test]
-    fn persistance_round_trip() {
+    fn persistence_round_trip() {
         let dir = tempdir().unwrap();
         let temp_path = dir.path().join("test");
         let _tempfile = temp_path.to_str().unwrap();
-        let context = test_context_with_agent_state();
+        let context = test_context_with_agent_state(None);
         File::create(temp_path.clone()).unwrap();
         let mut persistance = SimplePersister::new(context.dht_storage.clone());
         let state = context.state().unwrap().clone();

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -89,8 +89,9 @@ pub mod tests {
     fn test_commit_with_dht_publish() {
         let mut dna = test_dna();
         dna.uuid = "test_commit_with_dht_publish".to_string();
-        let (_instance1, context1) = instance_by_name("jill", dna.clone());
-        let (_instance2, context2) = instance_by_name("jack", dna);
+        let netname = Some("test_commit_with_dht_publish, the network");
+        let (_instance1, context1) = instance_by_name("jill", dna.clone(), netname);
+        let (_instance2, context2) = instance_by_name("jack", dna, netname);
 
         let entry_address = block_on(author_entry(&test_entry(), None, &context1)).unwrap();
         thread::sleep(time::Duration::from_millis(500));


### PR DESCRIPTION
I discovered that we still have a bunch of test functions which create a mock network with a hard-coded name, meaning that a ton of our tests are all running on the same mock network. The first natural thought would be to change those functions to use snowflake names instead of a hard-coded name, but the problem is that many tests actually do require two nodes to communicate over the same network.

The only reasonable way to do deal with this is to require a network name to be passed in for every test function. This PR represents a half hour of busy work to do just that. Tests that use certain helper functions need to pass an `Option<&str>`, using None if they want a unique network, or Some if they need to pass the same name to two instance's contexts.