### PR TITLE
fixed duplicate named test container

### DIFF
--- a/container_api/src/container/admin.rs
+++ b/container_api/src/container/admin.rs
@@ -1085,7 +1085,7 @@ type = "websocket""#,
 
     #[test]
     fn test_add_and_remove_bridge() {
-        let mut container = create_test_container("test_add_agent");
+        let mut container = create_test_container("test_add_and_remove_bridge");
         let bridge = Bridge {
             caller_id: String::from("test-instance-1"),
             callee_id: String::from("test-instance-2"),


### PR DESCRIPTION
In my haste to get scenario api merged into develop, I missed CI failing because of a duplicated named test container.  This PR should fix that.