### PR TITLE
rename entry! and entries to include types

### DIFF
--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -20,7 +20,7 @@ use hdk::{
 };
 
 define_zome! {
-    entries: [
+    entry_types: [
         post::definition()
     ]
 

--- a/app_spec/zomes/blog/code/src/post.rs
+++ b/app_spec/zomes/blog/code/src/post.rs
@@ -34,7 +34,7 @@ impl Post {
 }
 
 /// This is what creates the full definition of our entry type.
-/// The entry! macro is wrapped in a function so that we can have the content
+/// The entry_type! macro is wrapped in a function so that we can have the content
 /// in this file but call it from zome_setup() in lib.rs, which is like the
 /// zome's main().
 ///
@@ -43,7 +43,7 @@ impl Post {
 /// validation_package callback.
 /// The validation_function still has to be defined with the macro below.
 pub fn definition() -> ValidatingEntryType {
-    entry!(
+    entry_type!(
         name: "post",
         description: "blog entry post",
         sharing: Sharing::Public,

--- a/app_spec/zomes/summer/code/src/lib.rs
+++ b/app_spec/zomes/summer/code/src/lib.rs
@@ -15,7 +15,7 @@ fn handle_sum(num1: u32, num2: u32) -> JsonString {
 }
 
 define_zome! {
-    entries: []
+    entry_types: []
 
     genesis: || {
         Ok(())

--- a/cmd/src/cli/package.rs
+++ b/cmd/src/cli/package.rs
@@ -146,7 +146,7 @@ impl Packager {
                     // We just call into __hdk_get_json_definition() without any arguments.
                     // What we get back is a JSON string with all the entry types and zome functions
                     // defined in that WASM code, constructed through our Rust macros define_zome!
-                    // and entry!.
+                    // and entry_type!.
 
                     let call_result = ribosome::run_dna(
                         "HC",

--- a/cmd/src/cli/scaffold/rust/lib.rs
+++ b/cmd/src/cli/scaffold/rust/lib.rs
@@ -37,7 +37,7 @@ pub fn handle_get_my_entry(address: Address) -> ZomeApiResult<Option<Entry>> {
 }
 
 fn definition() -> ValidatingEntryType {
-    entry!(
+    entry_type!(
         name: "my_entry",
         description: "this is a same entry defintion",
         sharing: Sharing::Public,
@@ -52,7 +52,7 @@ fn definition() -> ValidatingEntryType {
     )
 }
 define_zome! {
-    entries: [
+    entry_types: [
        definition()
     ]
 

--- a/container_api/test-bridge-caller/src/lib.rs
+++ b/container_api/test-bridge-caller/src/lib.rs
@@ -11,7 +11,7 @@ fn handle_call_bridge() -> JsonString {
 }
 
 define_zome! {
-    entries: []
+    entry_types: []
 
     genesis: || {
         Ok(())

--- a/core/src/nucleus/actions/wasm-test/src/lib.rs
+++ b/core/src/nucleus/actions/wasm-test/src/lib.rs
@@ -21,8 +21,8 @@ struct TestEntryType {
 }
 
 define_zome! {
-    entries: [
-        entry!(
+    entry_types: [
+        entry_type!(
             name: "testEntryType",
             description: "asdfdaz",
             sharing: Sharing::Public,
@@ -37,7 +37,7 @@ define_zome! {
             }
         ),
 
-        entry!(
+        entry_type!(
             name: "package_entry",
             description: "asdfda",
             sharing: Sharing::Public,
@@ -52,7 +52,7 @@ define_zome! {
             }
         ),
 
-        entry!(
+        entry_type!(
             name: "package_chain_entries",
             description: "asdfda",
             sharing: Sharing::Public,
@@ -67,7 +67,7 @@ define_zome! {
             }
         ),
 
-        entry!(
+        entry_type!(
             name: "package_chain_headers",
             description: "asdfda",
             sharing: Sharing::Public,
@@ -82,7 +82,7 @@ define_zome! {
             }
         ),
 
-        entry!(
+        entry_type!(
             name: "package_chain_full",
             description: "asdfda",
             sharing: Sharing::Public,

--- a/core_types/src/validation.rs
+++ b/core_types/src/validation.rs
@@ -51,7 +51,7 @@ pub struct ValidationData {
     /// of a given entry.
     /// What specific data gets put into the validation package
     /// has to be defined throught the validation_package
-    /// callbacks in the [entry!](macro.entry.html) and
+    /// callbacks in the [entry_type!](macro.entry_type.html) and
     /// [link!](macro.link.html) macros.
     pub package: ValidationPackage,
     /// The list of authors that have signed this entry.

--- a/doc/holochain_101/src/alpha_migrate.md
+++ b/doc/holochain_101/src/alpha_migrate.md
@@ -48,7 +48,7 @@ struct Person {
 ```
 
 ```rust
-entry!(
+entry_type!(
     name: "person",
     description: "",
     sharing: Sharing::Public,

--- a/doc/holochain_101/src/zome/define_zome.md
+++ b/doc/holochain_101/src/zome/define_zome.md
@@ -36,7 +36,7 @@ The following is technically the most minimalistic Zome that could be implemente
 extern crate hdk;
 
 define_zome! {
-    entries: []
+    entry_types: []
 
     genesis: || {
         Ok(())

--- a/doc/holochain_101/src/zome/entry_type_definitions.md
+++ b/doc/holochain_101/src/zome/entry_type_definitions.md
@@ -53,7 +53,7 @@ Recall that in [define_zome!](./define_zome.md#building-in-rust-define_zome), th
 extern crate hdk;
 
 define_zome! {
-    entries: []
+    entry_types: []
 
     genesis: || {
         Ok(())
@@ -65,13 +65,13 @@ define_zome! {
 
 `entries` is where we will populate the Zome with entry type definitions. It expects an array of `ValidatingEntryType`. So how can one be created?
 
-Easy: the `entry!` macro. It can be used to encapsulate everything needed to define an entry type. All of the following must be defined:
+Easy: the `entry_type!` macro. It can be used to encapsulate everything needed to define an entry type. All of the following must be defined:
 
 ---
 
 __name__
 ```rust
-entry!(
+entry_type!(
     name: "post",
     ...
 )
@@ -83,7 +83,7 @@ This should be a machine-readable name for the entry type. Spaces should not be 
 
 __description__
 ```rust
-entry!(
+entry_type!(
     ...
     description: "A blog post entry which has an author",
     ...
@@ -98,7 +98,7 @@ __sharing__
 ```rust
 use hdk::holochain_core_types::dna::entry_types::Sharing;
 
-entry!(
+entry_type!(
     ...
     sharing: Sharing::Public,
     ...
@@ -125,7 +125,7 @@ struct Post {
     date_created: String,
 }
 
-entry!(
+entry_type!(
     ...
     native_type: Post,
     ...
@@ -161,7 +161,7 @@ __validation_package__
 ```rust
 use hdk::ValidationPackageDefinition;
 
-entry!(
+entry_type!(
     ...
     validation_package: || {
         ValidationPackageDefinition::Entry
@@ -182,7 +182,7 @@ __validation__
 ```rust
 use hdk::ValidationData;
 
-entry!(
+entry_type!(
     ...
     validation: |_post: Post, _validation_data: ValidationData| {
         Ok(())
@@ -190,7 +190,7 @@ entry!(
 )
 ```
 
-`validation` is the last required property of `entry!`. Because it is such an important aspect, it has [its' own in depth article](./entry_validation.md).
+`validation` is the last required property of `entry_type!`. Because it is such an important aspect, it has [its' own in depth article](./entry_validation.md).
 
 It is a callback that Holochain will call during different moments in the lifecycle of an entry, in order to confirm which action to take with the entry, depending on its' validity. It will be called with two arguments, the first representing the struct of the entry itself, and the second a struct holding extra metadata that can be used for validation, including, if it was requested, the `validation_package`.
 
@@ -208,11 +208,11 @@ Further reading can be found [here](./entry_validation.md).
 
 ### Putting It All Together
 
-Taken all together, use of the `entry!` macro may look something like the following:
+Taken all together, use of the `entry_type!` macro may look something like the following:
 
 ```rust
 ...
-entry!(
+entry_type!(
     name: "post",
     description: "A blog post entry which has an author",
     sharing: Sharing::Public,
@@ -230,8 +230,8 @@ This can be embedded directly inside of the entries array of the `define_zome!`,
 ```rust
 ...
 define_zome! {
-    entries: [
-        entry!(
+    entry_types: [
+        entry_type!(
             name: "post",
             description: "A blog post entry which has an author",
             sharing: Sharing::Public,
@@ -257,7 +257,7 @@ If there is only entry type, this can be fine, but if there are multiple, this c
 ```rust
 ...
 fn post_definition() -> ValidatingEntryType {
-    entry!(
+    entry_type!(
         name: "post",
         description: "A blog post entry which has an author",
         sharing: Sharing::Public,
@@ -274,7 +274,7 @@ fn post_definition() -> ValidatingEntryType {
 }
 
 define_zome! {
-    entries: [
+    entry_types: [
         post_definition()
     ]
 
@@ -288,7 +288,7 @@ define_zome! {
 
 Use of this technique can help you write clean, modular code.
 
-If you want to look closely at a complete example of the use of `entry!` in a Zome, check out the [API reference](https://developer.holochain.org/api/0.0.3/hdk/macro.entry.html), or the ["app-spec" example app](https://github.com/holochain/holochain-rust/blob/v0.0.3/app_spec/zomes/blog/code/src/post.rs).
+If you want to look closely at a complete example of the use of `entry_type!` in a Zome, check out the [API reference](https://developer.holochain.org/api/latest/hdk/macro.entry_type.html), or the ["app-spec" example app](https://github.com/holochain/holochain-rust/blob/v0.0.3/app_spec/zomes/blog/code/src/post.rs).
 
 #### Summary
 This is still a pretty minimal Zome, since it doesn't have any functions yet, and the most basic `genesis` behaviour, so read on to learn about how to work with those aspects of `define_zome!`.

--- a/doc/holochain_101/src/zome/genesis.md
+++ b/doc/holochain_101/src/zome/genesis.md
@@ -28,7 +28,7 @@ More complex capabilities will be possible during `genesis` in the future, yet f
 If `genesis` should succeed:
 ```rust
 define_zome! {
-    entries: []
+    entry_types: []
 
     genesis: || {
         Ok(())
@@ -41,7 +41,7 @@ define_zome! {
 If `genesis` should fail:
 ```rust
 define_zome! {
-    entries: []
+    entry_types: []
 
     genesis: || {
         Err("the error string".to_string())

--- a/doc/holochain_101/src/zome/zome_functions.md
+++ b/doc/holochain_101/src/zome/zome_functions.md
@@ -139,8 +139,8 @@ struct Post {
 }
 
 define_zome! {
-    entries: [
-        entry!(
+    entry_types: [
+        entry_type!(
             name: "post",
             description: "A blog post entry which has an author",
             sharing: Sharing::Public,

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -263,7 +263,7 @@ pub fn debug<J: TryInto<JsonString>>(msg: J) -> ZomeApiResult<()> {
 /// }
 ///
 /// define_zome! {
-///     entries: []
+///     entry_types: []
 ///
 ///     genesis: || {
 ///         Ok(())
@@ -338,7 +338,7 @@ pub fn debug<J: TryInto<JsonString>>(msg: J) -> ZomeApiResult<()> {
 /// }
 ///
 /// define_zome! {
-///     entries: []
+///     entry_types: []
 ///
 ///     genesis: || {
 ///         Ok(())
@@ -1066,7 +1066,7 @@ pub fn query(
 /// }
 ///
 /// define_zome! {
-///    entries: []
+///    entry_types: []
 ///
 ///    genesis: || { Ok(()) }
 ///

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -25,7 +25,7 @@ pub type LinkValidator =
 ///
 /// Instances of this struct are expected and used in the [define_zome! macro](macro.define_zome.html).
 /// Although possible, a DNA developer does not need to create these instances directly but instead
-/// should use the [entry! macro](macro.entry.html) for a clean syntax.
+/// should use the [entry_type! macro](macro.entry_type.html) for a clean syntax.
 pub struct ValidatingEntryType {
     /// Name of the entry type
     pub name: EntryType,
@@ -42,7 +42,7 @@ pub struct ValidatingEntryType {
 
 /// Similar to ValidatingEntryType, this provides the dynamic aspects of link definitions,
 /// the validation callbacks, and thus completes the structs in the DNA crate.
-/// The [entry! macro](macro.entry.html) expects an array of links that are represented by
+/// The [entry_type! macro](macro.entry_type.html) expects an array of links that are represented by
 /// instances of this struct.
 ///
 /// DNA developers don't need to use this type directly but instead should use the
@@ -62,7 +62,7 @@ pub struct ValidatingLinkDefinition {
     pub validator: LinkValidator,
 }
 
-/// The `entry` macro is a helper for creating `ValidatingEntryType` definitions
+/// The `entry_type` macro is a helper for creating `ValidatingEntryType` definitions
 /// for use within the [define_zome](macro.define_zome.html) macro.
 /// It has 7 component parts:
 /// 1. name: `name` is simply the descriptive name of the entry type, such as "post", or "user".
@@ -115,7 +115,7 @@ pub struct ValidatingLinkDefinition {
 /// }
 ///
 /// pub fn definition() -> ValidatingEntryType {
-///     entry!(
+///     entry_type!(
 ///         name: "post",
 ///         description: "a short social media style sharing of content",
 ///         sharing: Sharing::Public,
@@ -151,7 +151,7 @@ pub struct ValidatingLinkDefinition {
 /// ```
 
 #[macro_export]
-macro_rules! entry {
+macro_rules! entry_type {
     (
         name: $name:expr,
         description: $description:expr,
@@ -231,7 +231,7 @@ macro_rules! entry {
 }
 
 /// The `link` macro is a helper for creating `ValidatingEntryType` definitions
-/// for use within the [entry](macro.entry.html) macro.
+/// for use within the [entry](macro.entry_type.html) macro.
 /// It has 5 component parts:
 /// 1. direction: `direction` defines if this entry type (in which the link is defined) points
 ///     to another entry, or if it is referenced from another entry.
@@ -289,7 +289,7 @@ macro_rules! link {
 }
 
 /// The `to` macro is a helper for creating `ValidatingEntryType` definitions
-/// for use within the [entry](macro.entry.html) macro.
+/// for use within the [entry](macro.entry_type.html) macro.
 /// It is a convenience wrapper around [link!](macro.link.html) that has all the
 /// same properties except for the direction which gets set to `LinkDirection::To`.
 #[macro_export]
@@ -313,7 +313,7 @@ macro_rules! to {
 }
 
 /// The `from` macro is a helper for creating `ValidatingEntryType` definitions
-/// for use within the [entry](macro.entry.html) macro.
+/// for use within the [entry](macro.entry_type.html) macro.
 /// It is a convenience wrapper around [link!](macro.link.html) that has all the
 /// same properties except for the direction which gets set to `LinkDirection::From`.
 #[macro_export]

--- a/hdk-rust/src/macros.rs
+++ b/hdk-rust/src/macros.rs
@@ -30,7 +30,7 @@ macro_rules! load_string {
 /// Every Zome must utilize the `define_zome`
 /// macro in the main library file in their Zome.
 /// The `define_zome` macro has 4 component parts:
-/// 1. entries: an array of [ValidatingEntryType](entry_definition/struct.ValidatingEntryType.html) as returned by using the [entry](macro.entry.html) macro
+/// 1. entries: an array of [ValidatingEntryType](entry_definition/struct.ValidatingEntryType.html) as returned by using the [entry](macro.entry_type.html) macro
 /// 2. genesis: `genesis` is a callback called by Holochain to every Zome implemented within a DNA.
 ///     It gets called when a new agent is initializing an instance of the DNA for the first time, and
 ///     should return `Ok` or an `Err`, depending on whether the agent can join the network or not.
@@ -100,8 +100,8 @@ macro_rules! load_string {
 /// }
 ///
 /// define_zome! {
-///     entries: [
-///         entry!(
+///     entry_types: [
+///         entry_type!(
 ///             name: "post",
 ///             description: "",
 ///             sharing: Sharing::Public,
@@ -149,7 +149,7 @@ macro_rules! load_string {
 #[macro_export]
 macro_rules! define_zome {
     (
-        entries : [
+        entry_types : [
             $( $entry_expr:expr ),*
         ]
 

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -267,7 +267,7 @@ pub mod tests {
 
         let mut entry_types = BTreeMap::new();
 
-        let validating_entry_type = entry!(
+        let validating_entry_type = entry_type!(
             name: "post",
             description: "blog entry post",
             sharing: Sharing::Public,

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -373,8 +373,8 @@ fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<Stri
 }
 
 define_zome! {
-    entries: [
-        entry!(
+    entry_types: [
+        entry_type!(
             name: "testEntryType",
             description: "asdfda",
             sharing: Sharing::Public,
@@ -403,7 +403,7 @@ define_zome! {
             ]
         ),
 
-        entry!(
+        entry_type!(
             name: "validation_package_tester",
             description: "asdfda",
             sharing: Sharing::Public,
@@ -418,7 +418,7 @@ define_zome! {
             }
         ),
 
-        entry!(
+        entry_type!(
             name: "link_validator",
             description: "asdfda",
             sharing: Sharing::Public,


### PR DESCRIPTION
This is a proposal to rename 
`entries` in the define_zome macro to `entry_types` and the `entry!` macro to `entry_type!` because it's confusing to developers to conflate the 'class' and the 'instance'

This also brings the macros themselves further inline with the underlying DNA spec, which lists them as `entry_types`
https://github.com/holochain/holochain-rust/blame/develop/doc/specs/dna_manifest_specification.md#L112