### PR TITLE
Helper function to get `Vec<Entry>` from `Vec<Address>`

### DIFF
--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -905,7 +905,7 @@ pub fn get_links<S: Into<String>>(base: &Address, tag: S) -> ZomeApiResult<GetLi
 /// #    get_links::GetLinksOptions};
 ///
 /// # fn main() {
-/// fn hangle_get_links_result(address: Address) -> ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>> {
+/// fn handle_get_links_result(address: Address) -> ZomeApiResult<Vec<GetEntryResult>> {
 ///    hdk::get_links_result(&address, "test-tag", GetLinksOptions::default(), GetEntryOptions::default())
 /// }
 /// # }

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -501,8 +501,8 @@ fn can_roundtrip_links() {
             address_1.clone(),
             address_2.clone(),
         ]));
-        let expected_entries: ZomeApiResult<Vec<ZomeApiResult<Entry>>> =
-            Ok(vec![Ok(entry_1.clone()), Ok(entry_2.clone())]);
+        let expected_entries: ZomeApiResult<Vec<Entry>> =
+            Ok(vec![entry_1.clone(), entry_2.clone()]);
 
         println!(
             "can_roundtrip_links result_string - try {}:\n {:?}\n expecting:\n {:?}",

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -168,7 +168,7 @@ fn handle_links_roundtrip_get(address: Address) -> ZomeApiResult<GetLinksResult>
     hdk::get_links(&address, "test-tag")
 }
 
-fn handle_links_roundtrip_get_and_load(address: Address) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
+fn handle_links_roundtrip_get_and_load(address: Address) -> ZomeApiResult<Vec<Entry>> {
     hdk::get_links_and_load(&address, "test-tag")
 }
 
@@ -186,7 +186,12 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     }
 
     // Query AgentId entry
-    let addresses = hdk::query(QueryArgsNames::QueryList(vec![EntryType::AgentId.to_string()]), 0, 0).unwrap();
+    let addresses = hdk::query(
+        QueryArgsNames::QueryList(vec![EntryType::AgentId.to_string()]),
+        0,
+        0,
+    )
+    .unwrap();
 
     if !addresses.len() == 1 {
         return err("AgentId Addresses not length 1");
@@ -208,7 +213,8 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
         .into(),
     ))
     .unwrap();
-    let addresses = hdk::query(QueryArgsNames::QueryName("testEntryType".to_string()), 0, 1).unwrap();
+    let addresses =
+        hdk::query(QueryArgsNames::QueryName("testEntryType".to_string()), 0, 1).unwrap();
 
     if !addresses.len() == 1 {
         return err("testEntryType Addresses not length 1");
@@ -243,7 +249,7 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     if !addresses.len() == 2 {
         return err("System Addresses not length 3");
     }
-    let addresses = hdk::query(vec!["[%]*","testEntryType"].into(), 0, 0).unwrap();
+    let addresses = hdk::query(vec!["[%]*", "testEntryType"].into(), 0, 0).unwrap();
     if !addresses.len() == 5 {
         return err("System Addresses not length 3");
     }
@@ -368,7 +374,7 @@ fn hdk_test_entry() -> Entry {
     Entry::App(hdk_test_app_entry_type(), hdk_test_entry_value())
 }
 
-fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String>  {
+fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String> {
     hdk::send(to_agent, message)
 }
 
@@ -523,7 +529,7 @@ define_zome! {
 
             links_roundtrip_get_and_load: {
                 inputs: |address: Address|,
-                outputs: |result: ZomeApiResult<Vec<ZomeApiResult<Entry>>>|,
+                outputs: |result: ZomeApiResult<Vec<Entry>>|,
                 handler: handle_links_roundtrip_get_and_load
             }
 


### PR DESCRIPTION
Can simplify the return type of `get_links_and_load`, and can also be used for `query`