### PR TITLE
 Add Timeout option to get_entry, get_links, and send

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -107,6 +107,20 @@ scenario1.runTape('my_posts', async (t, { alice }) => {
   t.equal(result.Ok.addresses.length, 2)
 })
 
+
+scenario1.runTape('my_posts_immediate_timeout', async (t, { alice }) => {
+
+  alice.call("blog", "main", "create_post",
+    { "content": "Holo world", "in_reply_to": "" }
+  )
+
+  const result = alice.call("blog", "main", "my_posts_immediate_timeout", {})
+
+  t.ok(result.Err)
+  console.log(result)
+  t.equal(JSON.parse(result.Err.Internal).kind, "Timeout")
+})
+
 scenario1.runTape('create/get_post roundtrip', async (t, { alice }) => {
 
   const content = "Holo world"

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -5,7 +5,8 @@ use hdk::{
         cas::content::Address, entry::Entry, error::HolochainError, json::JsonString,
     },
     holochain_wasm_utils::api_serialization::{
-        get_entry::GetEntryOptions, get_links::GetLinksResult,
+        get_entry::GetEntryOptions,
+        get_links::{GetLinksOptions, GetLinksResult},
     },
     AGENT_ADDRESS,
 };
@@ -59,6 +60,17 @@ pub fn handle_posts_by_agent(agent: Address) -> ZomeApiResult<GetLinksResult> {
 
 pub fn handle_my_posts() -> ZomeApiResult<GetLinksResult> {
     hdk::get_links(&AGENT_ADDRESS, "authored_posts")
+}
+
+pub fn handle_my_posts_immediate_timeout() -> ZomeApiResult<GetLinksResult> {
+    hdk::get_links_with_options(
+        &AGENT_ADDRESS,
+        "authored_posts",
+        GetLinksOptions {
+            timeout: 0.into(),
+            ..Default::default()
+        },
+    )
 }
 
 pub fn handle_my_posts_as_commited() -> ZomeApiResult<Vec<Address>> {

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -66,6 +66,12 @@ define_zome! {
                 handler: blog::handle_my_posts
             }
 
+            my_posts_immediate_timeout: {
+                inputs: | |,
+                outputs: |post_hashes: ZomeApiResult<GetLinksResult>|,
+                handler: blog::handle_my_posts_immediate_timeout
+            }
+
             my_posts_as_committed: {
                 inputs: | |,
                 outputs: |post_hashes: ZomeApiResult<Vec<Address>>|,

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -77,7 +77,7 @@ impl AgentState {
         let agent_entry_address = self.get_agent_address()?;
         let entry_args = GetEntryArgs {
             address: agent_entry_address,
-            options: GetEntryOptions::default(),
+            options: Default::default(),
         };
         let agent_entry_result = await!(get_entry_result_workflow(context, &entry_args))?;
         let agent_entry = agent_entry_result.latest();

--- a/core/src/network/actions/custom_send.rs
+++ b/core/src/network/actions/custom_send.rs
@@ -11,7 +11,7 @@ use futures::{
 };
 use holochain_core_types::{cas::content::Address, error::HolochainError};
 use snowflake::ProcessUniqueId;
-use std::{pin::Pin, sync::Arc};
+use std::{pin::Pin, sync::Arc, thread::sleep, time::Duration};
 
 /// SendDirectMessage Action Creator for custom (=app) messages
 /// This triggers the network module to open a synchronous node-to-node connection
@@ -32,11 +32,11 @@ pub async fn custom_send(
     let action_wrapper = ActionWrapper::new(Action::SendDirectMessage(direct_message_data));
     dispatch_action(context.action_channel(), action_wrapper);
 
-    /* async {
+    let _ = async {
         sleep(Duration::from_secs(60));
         let action_wrapper = ActionWrapper::new(Action::SendDirectMessageTimeout(id.clone()));
         dispatch_action(context.action_channel(), action_wrapper.clone());
-    };*/
+    };
 
     await!(SendResponseFuture {
         context: context.clone(),

--- a/core/src/network/actions/get_entry.rs
+++ b/core/src/network/actions/get_entry.rs
@@ -11,31 +11,33 @@ use futures::{
 use holochain_core_types::{
     cas::content::Address, entry::EntryWithMeta, error::HcResult, time::Timeout,
 };
-use std::{pin::Pin, sync::Arc, thread::sleep};
+use std::{pin::Pin, sync::Arc, thread};
 
 /// GetEntry Action Creator
 /// This is the network version of get_entry that makes the network module start
 /// a look-up process.
 ///
 /// Returns a future that resolves to an ActionResponse.
-pub async fn get_entry<'a>(
-    context: &'a Arc<Context>,
-    address: &'a Address,
-    timeout: &'a Timeout,
+pub async fn get_entry(
+    context: Arc<Context>,
+    address: Address,
+    timeout: Timeout,
 ) -> HcResult<Option<EntryWithMeta>> {
     let key = GetEntryKey {
-        address: address.clone(),
+        address: address,
         id: snowflake::ProcessUniqueId::new().to_string(),
     };
 
     let action_wrapper = ActionWrapper::new(Action::GetEntry(key.clone()));
     dispatch_action(context.action_channel(), action_wrapper.clone());
 
-    let _ = async {
-        sleep(timeout.into());
-        let action_wrapper = ActionWrapper::new(Action::GetEntryTimeout(key.clone()));
-        dispatch_action(context.action_channel(), action_wrapper.clone());
-    };
+    let key_inner = key.clone();
+    let context_inner = context.clone();
+    let _ = thread::spawn(move || {
+        thread::sleep(timeout.into());
+        let action_wrapper = ActionWrapper::new(Action::GetEntryTimeout(key_inner));
+        dispatch_action(context_inner.action_channel(), action_wrapper.clone());
+    });
 
     await!(GetEntryFuture {
         context: context.clone(),

--- a/core/src/network/actions/get_entry.rs
+++ b/core/src/network/actions/get_entry.rs
@@ -8,8 +8,10 @@ use futures::{
     future::Future,
     task::{LocalWaker, Poll},
 };
-use holochain_core_types::{cas::content::Address, entry::EntryWithMeta, error::HcResult};
-use std::{pin::Pin, sync::Arc, thread::sleep, time::Duration};
+use holochain_core_types::{
+    cas::content::Address, entry::EntryWithMeta, error::HcResult, time::Timeout,
+};
+use std::{pin::Pin, sync::Arc, thread::sleep};
 
 /// GetEntry Action Creator
 /// This is the network version of get_entry that makes the network module start
@@ -19,6 +21,7 @@ use std::{pin::Pin, sync::Arc, thread::sleep, time::Duration};
 pub async fn get_entry<'a>(
     context: &'a Arc<Context>,
     address: &'a Address,
+    timeout: &'a Timeout,
 ) -> HcResult<Option<EntryWithMeta>> {
     let key = GetEntryKey {
         address: address.clone(),
@@ -29,7 +32,7 @@ pub async fn get_entry<'a>(
     dispatch_action(context.action_channel(), action_wrapper.clone());
 
     let _ = async {
-        sleep(Duration::from_secs(60));
+        sleep(timeout.into());
         let action_wrapper = ActionWrapper::new(Action::GetEntryTimeout(key.clone()));
         dispatch_action(context.action_channel(), action_wrapper.clone());
     };

--- a/core/src/network/actions/get_links.rs
+++ b/core/src/network/actions/get_links.rs
@@ -8,9 +8,9 @@ use futures::{
     future::Future,
     task::{LocalWaker, Poll},
 };
-use holochain_core_types::{cas::content::Address, error::HcResult};
+use holochain_core_types::{cas::content::Address, error::HcResult, time::Timeout};
 use snowflake::ProcessUniqueId;
-use std::{pin::Pin, sync::Arc, thread::sleep, time::Duration};
+use std::{pin::Pin, sync::Arc, thread::sleep};
 
 /// GetLinks Action Creator
 /// This is the network version of get_links that makes the network module start
@@ -19,6 +19,7 @@ pub async fn get_links<'a>(
     context: &'a Arc<Context>,
     address: &'a Address,
     tag: String,
+    timeout: &'a Timeout,
 ) -> HcResult<Vec<Address>> {
     let key = GetLinksKey {
         base_address: address.clone(),
@@ -29,7 +30,7 @@ pub async fn get_links<'a>(
     dispatch_action(context.action_channel(), action_wrapper.clone());
 
     let _ = async {
-        sleep(Duration::from_secs(60));
+        sleep(timeout.into());
         let action_wrapper = ActionWrapper::new(Action::GetLinksTimeout(key.clone()));
         dispatch_action(context.action_channel(), action_wrapper.clone());
     };

--- a/core/src/network/actions/get_links.rs
+++ b/core/src/network/actions/get_links.rs
@@ -10,16 +10,16 @@ use futures::{
 };
 use holochain_core_types::{cas::content::Address, error::HcResult, time::Timeout};
 use snowflake::ProcessUniqueId;
-use std::{pin::Pin, sync::Arc, thread::sleep};
+use std::{pin::Pin, sync::Arc, thread};
 
 /// GetLinks Action Creator
 /// This is the network version of get_links that makes the network module start
 /// a look-up process.
-pub async fn get_links<'a>(
-    context: &'a Arc<Context>,
-    address: &'a Address,
+pub async fn get_links(
+    context: Arc<Context>,
+    address: Address,
     tag: String,
-    timeout: &'a Timeout,
+    timeout: Timeout,
 ) -> HcResult<Vec<Address>> {
     let key = GetLinksKey {
         base_address: address.clone(),
@@ -29,11 +29,13 @@ pub async fn get_links<'a>(
     let action_wrapper = ActionWrapper::new(Action::GetLinks(key.clone()));
     dispatch_action(context.action_channel(), action_wrapper.clone());
 
-    let _ = async {
-        sleep(timeout.into());
-        let action_wrapper = ActionWrapper::new(Action::GetLinksTimeout(key.clone()));
-        dispatch_action(context.action_channel(), action_wrapper.clone());
-    };
+    let key_inner = key.clone();
+    let context_inner = context.clone();
+    let _ = thread::spawn(move || {
+        thread::sleep(timeout.into());
+        let action_wrapper = ActionWrapper::new(Action::GetLinksTimeout(key_inner));
+        dispatch_action(context_inner.action_channel(), action_wrapper.clone());
+    });
 
     await!(GetLinksFuture {
         context: context.clone(),

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -51,7 +51,7 @@ pub mod tests {
         assert!(result.is_ok());
 
         // Get it.
-        let result = block_on(get_entry(&context2, &entry.address(), &Default::default()));
+        let result = block_on(get_entry(context2, entry.address(), Default::default()));
         assert!(result.is_ok());
         let maybe_entry_with_meta = result.unwrap();
         assert!(maybe_entry_with_meta.is_some());
@@ -71,7 +71,7 @@ pub mod tests {
 
         let entry = test_entry();
 
-        let result = block_on(get_entry(&context2, &entry.address(), &Default::default()));
+        let result = block_on(get_entry(context2, entry.address(), Default::default()));
         assert!(result.is_ok());
         let maybe_entry_with_meta = result.unwrap();
         assert!(maybe_entry_with_meta.is_none());
@@ -87,7 +87,7 @@ pub mod tests {
 
         let entry = test_entry();
 
-        let result = block_on(get_entry(&context1, &entry.address(), &Default::default()));
+        let result = block_on(get_entry(context1, entry.address(), Default::default()));
         assert!(result.is_ok());
         let maybe_entry_with_meta = result.unwrap();
         assert!(maybe_entry_with_meta.is_none());
@@ -150,10 +150,10 @@ pub mod tests {
             test_instance_and_context_by_name(dna.clone(), "bob1", netname).unwrap();
 
         let maybe_links = block_on(get_links(
-            &context2,
-            &entry_addresses[0],
+            context2,
+            entry_addresses[0].clone(),
             String::from("test-tag"),
-            &Default::default(),
+            Default::default(),
         ));
 
         assert!(maybe_links.is_ok());

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -51,7 +51,7 @@ pub mod tests {
         assert!(result.is_ok());
 
         // Get it.
-        let result = block_on(get_entry(&context2, &entry.address()));
+        let result = block_on(get_entry(&context2, &entry.address(), &Default::default()));
         assert!(result.is_ok());
         let maybe_entry_with_meta = result.unwrap();
         assert!(maybe_entry_with_meta.is_some());
@@ -71,7 +71,7 @@ pub mod tests {
 
         let entry = test_entry();
 
-        let result = block_on(get_entry(&context2, &entry.address()));
+        let result = block_on(get_entry(&context2, &entry.address(), &Default::default()));
         assert!(result.is_ok());
         let maybe_entry_with_meta = result.unwrap();
         assert!(maybe_entry_with_meta.is_none());
@@ -87,7 +87,7 @@ pub mod tests {
 
         let entry = test_entry();
 
-        let result = block_on(get_entry(&context1, &entry.address()));
+        let result = block_on(get_entry(&context1, &entry.address(), &Default::default()));
         assert!(result.is_ok());
         let maybe_entry_with_meta = result.unwrap();
         assert!(maybe_entry_with_meta.is_none());
@@ -153,6 +153,7 @@ pub mod tests {
             &context2,
             &entry_addresses[0],
             String::from("test-tag"),
+            &Default::default(),
         ));
 
         assert!(maybe_links.is_ok());

--- a/core/src/nucleus/ribosome/api/get_entry.rs
+++ b/core/src/nucleus/ribosome/api/get_entry.rs
@@ -65,7 +65,13 @@ pub mod tests {
     pub fn test_get_args_bytes() -> Vec<u8> {
         let entry_args = GetEntryArgs {
             address: test_entry().address(),
-            options: GetEntryOptions::new(StatusRequestKind::Latest, true, false, false),
+            options: GetEntryOptions::new(
+                StatusRequestKind::Latest,
+                true,
+                false,
+                false,
+                Default::default(),
+            ),
         };
         JsonString::from(entry_args).into_bytes()
     }
@@ -74,7 +80,13 @@ pub mod tests {
     pub fn test_get_args_unknown() -> Vec<u8> {
         let entry_args = GetEntryArgs {
             address: Address::from("xxxxxxxxx"),
-            options: GetEntryOptions::new(StatusRequestKind::Latest, true, false, false),
+            options: GetEntryOptions::new(
+                StatusRequestKind::Latest,
+                true,
+                false,
+                false,
+                Default::default(),
+            ),
         };
         JsonString::from(entry_args).into_bytes()
     }

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -43,10 +43,10 @@ pub fn invoke_get_links(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiRes
 
     // Get links from DHT
     let maybe_links = block_on(get_links(
-        &runtime.context,
-        &input.entry_address,
+        runtime.context.clone(),
+        input.entry_address,
         input.tag,
-        &input.options.timeout,
+        input.options.timeout,
     ));
 
     runtime.store_result(match maybe_links {

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -42,7 +42,12 @@ pub fn invoke_get_links(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiRes
     }
 
     // Get links from DHT
-    let maybe_links = block_on(get_links(&runtime.context, &input.entry_address, input.tag));
+    let maybe_links = block_on(get_links(
+        &runtime.context,
+        &input.entry_address,
+        input.tag,
+        &input.options.timeout,
+    ));
 
     runtime.store_result(match maybe_links {
         Ok(links) => Ok(GetLinksResult::new(links)),
@@ -74,7 +79,7 @@ pub mod tests {
         json::JsonString,
         link::Link,
     };
-    use holochain_wasm_utils::api_serialization::get_links::{GetLinksArgs, GetLinksOptions};
+    use holochain_wasm_utils::api_serialization::get_links::GetLinksArgs;
     use serde_json;
 
     /// dummy link_entries args from standard test entry
@@ -82,7 +87,7 @@ pub mod tests {
         let args = GetLinksArgs {
             entry_address: base.clone(),
             tag: String::from(tag),
-            options: GetLinksOptions::default(),
+            options: Default::default(),
         };
         serde_json::to_string(&args)
             .expect("args should serialize")

--- a/core/src/nucleus/ribosome/api/remove_entry.rs
+++ b/core/src/nucleus/ribosome/api/remove_entry.rs
@@ -43,7 +43,7 @@ pub fn invoke_remove_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApi
     // Get Current entry's latest version
     let get_args = GetEntryArgs {
         address: deleted_entry_address,
-        options: GetEntryOptions::default(),
+        options: Default::default(),
     };
     let maybe_entry_result = block_on(get_entry_result_workflow(&runtime.context, &get_args));
     if let Err(_err) = maybe_entry_result {

--- a/core/src/nucleus/ribosome/api/send.rs
+++ b/core/src/nucleus/ribosome/api/send.rs
@@ -27,8 +27,8 @@ pub fn invoke_send(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
     let result = block_on(custom_send(
         args.to_agent,
         message,
-        &args.options.0,
-        &runtime.context,
+        args.options.0,
+        runtime.context.clone(),
     ));
 
     runtime.store_result(result)

--- a/core/src/nucleus/ribosome/api/send.rs
+++ b/core/src/nucleus/ribosome/api/send.rs
@@ -24,7 +24,12 @@ pub fn invoke_send(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
         zome: runtime.zome_call.zome_name.clone(),
     };
 
-    let result = block_on(custom_send(args.to_agent, message, &runtime.context));
+    let result = block_on(custom_send(
+        args.to_agent,
+        message,
+        &args.options.0,
+        &runtime.context,
+    ));
 
     runtime.store_result(result)
 }

--- a/core/src/nucleus/ribosome/api/update_entry.rs
+++ b/core/src/nucleus/ribosome/api/update_entry.rs
@@ -43,7 +43,7 @@ pub fn invoke_update_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApi
     // Get Current entry's latest version
     let get_args = GetEntryArgs {
         address: entry_args.address,
-        options: GetEntryOptions::default(),
+        options: Default::default(),
     };
     let maybe_entry_result = block_on(get_entry_result_workflow(&runtime.context, &get_args));
     if let Err(_err) = maybe_entry_result {

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -17,7 +17,7 @@ pub fn get_link_entries(
     let target_address = link.target();
     let entry_args = &GetEntryArgs {
         address: base_address.clone(),
-        options: GetEntryOptions::default(),
+        options: Default::default(),
     };
     let base_entry_get_result = block_on(get_entry_result_workflow(&context, entry_args))?;
     if !base_entry_get_result.found() {
@@ -28,7 +28,7 @@ pub fn get_link_entries(
     let base_entry = base_entry_get_result.latest().unwrap();
     let entry_args = &GetEntryArgs {
         address: target_address.clone(),
-        options: GetEntryOptions::default(),
+        options: Default::default(),
     };
     let target_entry_get_result = block_on(get_entry_result_workflow(&context, entry_args))?;
     if !target_entry_get_result.found() {

--- a/core/src/workflows/get_entry_result.rs
+++ b/core/src/workflows/get_entry_result.rs
@@ -1,4 +1,5 @@
 use crate::{context::Context, network, nucleus};
+use holochain_core_types::time::Timeout;
 
 use holochain_core_types::{
     cas::content::Address, crud_status::CrudStatus, entry::EntryWithMeta, error::HolochainError,
@@ -12,6 +13,7 @@ use std::sync::Arc;
 pub async fn get_entry_with_meta_workflow<'a>(
     context: &'a Arc<Context>,
     address: &'a Address,
+    timeout: &'a Timeout,
 ) -> Result<Option<EntryWithMeta>, HolochainError> {
     // 1. Try to get the entry locally (i.e. local DHT shard)
     let maybe_entry_with_meta =
@@ -20,7 +22,9 @@ pub async fn get_entry_with_meta_workflow<'a>(
         return Ok(maybe_entry_with_meta);
     }
     // 2. No result, so try on the network
-    await!(network::actions::get_entry::get_entry(context, &address))
+    await!(network::actions::get_entry::get_entry(
+        context, &address, timeout
+    ))
 }
 
 /// Get GetEntryResult workflow
@@ -42,7 +46,11 @@ pub async fn get_entry_result_workflow<'a>(
         let address = maybe_address.unwrap();
         maybe_address = None;
         // Try to get entry
-        let maybe_entry_with_meta = await!(get_entry_with_meta_workflow(context, &address))?;
+        let maybe_entry_with_meta = await!(get_entry_with_meta_workflow(
+            context,
+            &address,
+            &args.options.timeout
+        ))?;
         // Entry found
         if let Some(entry_with_meta) = maybe_entry_with_meta {
             // Erase history if request is for latest

--- a/core/src/workflows/get_entry_result.rs
+++ b/core/src/workflows/get_entry_result.rs
@@ -23,7 +23,9 @@ pub async fn get_entry_with_meta_workflow<'a>(
     }
     // 2. No result, so try on the network
     await!(network::actions::get_entry::get_entry(
-        context, &address, timeout
+        context.clone(),
+        address.clone(),
+        timeout.clone(),
     ))
 }
 

--- a/core_types/src/time.rs
+++ b/core_types/src/time.rs
@@ -38,6 +38,12 @@ impl Default for Timeout {
     }
 }
 
+impl From<Timeout> for Duration {
+    fn from(Timeout(millis): Timeout) -> Duration {
+        Duration::from_millis(millis as u64)
+    }
+}
+
 impl From<&Timeout> for Duration {
     fn from(Timeout(millis): &Timeout) -> Duration {
         Duration::from_millis(*millis as u64)

--- a/core_types/src/time.rs
+++ b/core_types/src/time.rs
@@ -2,6 +2,10 @@
 //! within ChainHeader to enforce that their timestamps
 //! are defined in a useful and consistent way.
 
+use error::error::HolochainError;
+use json::JsonString;
+use std::time::Duration;
+
 /// This struct represents datetime data stored as a string
 /// in the ISO 8601 format.
 /// More info on the relevant [wikipedia article](https://en.wikipedia.org/wiki/ISO_8601).
@@ -16,4 +20,26 @@ impl From<&'static str> for Iso8601 {
 
 pub fn test_iso_8601() -> Iso8601 {
     Iso8601::from("2018-10-11T03:23:38+00:00")
+}
+
+/// Represents a timeout for an HDK function
+#[derive(Clone, Deserialize, Debug, Eq, PartialEq, Hash, Serialize, DefaultJson)]
+pub struct Timeout(usize);
+
+impl Timeout {
+    pub fn new(timeout_ms: usize) -> Self {
+        Self(timeout_ms)
+    }
+}
+
+impl Default for Timeout {
+    fn default() -> Timeout {
+        Timeout(60000)
+    }
+}
+
+impl From<&Timeout> for Duration {
+    fn from(Timeout(millis): &Timeout) -> Duration {
+        Duration::from_millis(*millis as u64)
+    }
 }

--- a/core_types/src/time.rs
+++ b/core_types/src/time.rs
@@ -43,3 +43,9 @@ impl From<&Timeout> for Duration {
         Duration::from_millis(*millis as u64)
     }
 }
+
+impl From<usize> for Timeout {
+    fn from(millis: usize) -> Timeout {
+        Timeout::new(millis)
+    }
+}

--- a/doc/holochain_101/src/zome/zome_functions.md
+++ b/doc/holochain_101/src/zome/zome_functions.md
@@ -224,7 +224,7 @@ Here is an example of a simplistic function, for illustration purposes. It cente
 
 ```rust
 fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String>  {
-    hdk::send(to_agent, message)
+    hdk::send(to_agent, message, 60000.into())
 }
 ```
 
@@ -243,7 +243,7 @@ Here are the above two steps combined:
 ...
 
 fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String>  {
-    hdk::send(to_agent, message)
+    hdk::send(to_agent, message, 60000.into())
 }
 
 define_zome! {

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -638,7 +638,7 @@ pub fn get_entry_result(
 ///
 ///     if let Some(in_reply_to_address) = in_reply_to {
 ///         // return with Err if in_reply_to_address points to missing entry
-///         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions { status_request: StatusRequestKind::All, entry: false, header: false, sources: false })?;
+///         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions { status_request: StatusRequestKind::All, entry: false, header: false, sources: false, timeout: Default::default() })?;
 ///         hdk::link_entries(&in_reply_to_address, &address, "comments")?;
 ///     }
 ///
@@ -1075,7 +1075,7 @@ pub fn query(
 /// fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String> {
 ///     // because the function signature of hdk::send is the same as the
 ///     // signature of handle_send_message we can just directly return its' result
-///     hdk::send(to_agent, message)
+///     hdk::send(to_agent, message, 60000.into())
 /// }
 ///
 /// define_zome! {

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -1100,10 +1100,10 @@ pub fn query(
 ///}
 /// # }
 /// ```
-pub fn send(to_agent: Address, payload: String, timeout_ms: usize) -> ZomeApiResult<String> {
+pub fn send(to_agent: Address, payload: String, timeout: Timeout) -> ZomeApiResult<String> {
     let mut mem_stack: SinglePageStack = unsafe { G_MEM_STACK.unwrap() };
 
-    let options = SendOptions(Timeout::new(timeout_ms));
+    let options = SendOptions(timeout);
     // Put args in struct and serialize into memory
     let allocation_of_input = store_as_json(
         &mut mem_stack,

--- a/hdk-rust/wasm-test/src/handle_crud.rs
+++ b/hdk-rust/wasm-test/src/handle_crud.rs
@@ -157,7 +157,13 @@ pub(crate) fn handle_update_entry_ok() -> JsonString {
     hdk::debug("**** get result from initial, history").ok();
     let res = hdk::get_entry_result(
         &addr_v1,
-        GetEntryOptions::new(StatusRequestKind::All, true, false, false),
+        GetEntryOptions::new(
+            StatusRequestKind::All,
+            true,
+            false,
+            false,
+            Default::default(),
+        ),
     );
     assert_eq!(res.unwrap().latest().unwrap(), entry_v4.clone());
 
@@ -195,7 +201,13 @@ pub fn handle_remove_entry_ok() -> JsonString {
     // Get entry_result
     let res = hdk::get_entry_result(
         &addr_v1,
-        GetEntryOptions::new(StatusRequestKind::All, false, false, false),
+        GetEntryOptions::new(
+            StatusRequestKind::All,
+            false,
+            false,
+            false,
+            Default::default(),
+        ),
     );
     hdk::debug(format!("**** get_entry_result: {:?}", res)).ok();
     match res {

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -168,7 +168,9 @@ fn handle_links_roundtrip_get(address: Address) -> ZomeApiResult<GetLinksResult>
     hdk::get_links(&address, "test-tag")
 }
 
-fn handle_links_roundtrip_get_and_load(address: Address) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
+fn handle_links_roundtrip_get_and_load(
+    address: Address,
+) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
     hdk::get_links_and_load(&address, "test-tag")
 }
 
@@ -186,7 +188,12 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     }
 
     // Query AgentId entry
-    let addresses = hdk::query(QueryArgsNames::QueryList(vec![EntryType::AgentId.to_string()]), 0, 0).unwrap();
+    let addresses = hdk::query(
+        QueryArgsNames::QueryList(vec![EntryType::AgentId.to_string()]),
+        0,
+        0,
+    )
+    .unwrap();
 
     if !addresses.len() == 1 {
         return err("AgentId Addresses not length 1");
@@ -208,7 +215,8 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
         .into(),
     ))
     .unwrap();
-    let addresses = hdk::query(QueryArgsNames::QueryName("testEntryType".to_string()), 0, 1).unwrap();
+    let addresses =
+        hdk::query(QueryArgsNames::QueryName("testEntryType".to_string()), 0, 1).unwrap();
 
     if !addresses.len() == 1 {
         return err("testEntryType Addresses not length 1");
@@ -243,7 +251,7 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     if !addresses.len() == 2 {
         return err("System Addresses not length 3");
     }
-    let addresses = hdk::query(vec!["[%]*","testEntryType"].into(), 0, 0).unwrap();
+    let addresses = hdk::query(vec!["[%]*", "testEntryType"].into(), 0, 0).unwrap();
     if !addresses.len() == 5 {
         return err("System Addresses not length 3");
     }
@@ -368,8 +376,8 @@ fn hdk_test_entry() -> Entry {
     Entry::App(hdk_test_app_entry_type(), hdk_test_entry_value())
 }
 
-fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String>  {
-    hdk::send(to_agent, message)
+fn handle_send_message(to_agent: Address, message: String) -> ZomeApiResult<String> {
+    hdk::send(to_agent, message, 60000.into())
 }
 
 define_zome! {

--- a/wasm_utils/src/api_serialization/get_entry.rs
+++ b/wasm_utils/src/api_serialization/get_entry.rs
@@ -4,6 +4,7 @@ use holochain_core_types::{
     entry::{entry_type::EntryType, Entry, EntryWithMeta},
     error::HolochainError,
     json::*,
+    time::Timeout,
 };
 use std::collections::HashMap;
 
@@ -27,6 +28,7 @@ pub struct GetEntryOptions {
     pub entry: bool,
     pub header: bool,
     pub sources: bool,
+    pub timeout: Timeout,
 }
 
 impl Default for GetEntryOptions {
@@ -36,6 +38,7 @@ impl Default for GetEntryOptions {
             entry: true,
             header: false,
             sources: false,
+            timeout: Default::default(),
         }
     }
 }
@@ -46,12 +49,14 @@ impl GetEntryOptions {
         entry: bool,
         header: bool,
         sources: bool,
+        timeout: Timeout,
     ) -> Self {
         GetEntryOptions {
             status_request,
             entry,
             header,
             sources,
+            timeout,
         }
     }
 }

--- a/wasm_utils/src/api_serialization/get_links.rs
+++ b/wasm_utils/src/api_serialization/get_links.rs
@@ -1,4 +1,4 @@
-use holochain_core_types::{cas::content::Address, error::HolochainError, json::*};
+use holochain_core_types::{cas::content::Address, error::HolochainError, json::*, time::Timeout};
 
 #[derive(Deserialize, Default, Debug, Serialize, Clone, PartialEq, Eq, Hash, DefaultJson)]
 pub struct GetLinksArgs {
@@ -23,12 +23,14 @@ impl Default for LinksStatusRequestKind {
 pub struct GetLinksOptions {
     pub status_request: LinksStatusRequestKind,
     pub sources: bool,
+    pub timeout: Timeout,
 }
 impl Default for GetLinksOptions {
     fn default() -> Self {
         GetLinksOptions {
             status_request: LinksStatusRequestKind::default(),
             sources: false,
+            timeout: Default::default(),
         }
     }
 }

--- a/wasm_utils/src/api_serialization/send.rs
+++ b/wasm_utils/src/api_serialization/send.rs
@@ -1,8 +1,12 @@
-use holochain_core_types::{cas::content::Address, error::HolochainError, json::*};
+use holochain_core_types::{cas::content::Address, error::HolochainError, json::*, time::Timeout};
 
 /// Struct for input data received when Zome API function send() is invoked
 #[derive(Deserialize, Clone, PartialEq, Debug, Serialize, DefaultJson)]
 pub struct SendArgs {
     pub to_agent: Address,
     pub payload: String,
+    pub options: SendOptions,
 }
+
+#[derive(Deserialize, Clone, PartialEq, Debug, Serialize, DefaultJson)]
+pub struct SendOptions(pub Timeout);


### PR DESCRIPTION
Not sure if we want the timeout for all 3 calls, I just noticed that they all had similar hard-coded timeouts.

Also not sure how to effectively test this timeout. Tried adding a zome function in app_spec that used a timeout of 0 but it still succeeded. @thedavidmeister ideas on unit testing this? Or even integration testing this?