### PR TITLE
sets version =0.7.1 for UUID crate

### DIFF
--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -24,7 +24,7 @@ rust-base58 = "0.0.4"
 snowflake = "1.2"
 objekt="0.1.1"
 holochain_core_types_derive = { path = "../core_types_derive" }
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { version = "=0.7.1", features = ["v4"] }
 regex = "^1.1"
 
 


### PR DESCRIPTION
UUID crate seems to have published a broken version 0.7.2 which breaks our build. This pins the version exactly to the previous version.

We need to discuss Cargo.lock file to stop this happening again.
