### PR TITLE
pass opaque network configuration via stdin on child process spawn

### DIFF
--- a/container_api/src/container/base.rs
+++ b/container_api/src/container/base.rs
@@ -235,6 +235,8 @@ impl Container {
                 "attempt to spawn network when not configured".to_string(),
             ))?;
 
+        let opaque_net_config = String::from("{}");
+
         println!(
             "Spawning network with working directory: {}",
             network_config.n3h_persistence_path
@@ -250,6 +252,7 @@ impl Container {
                 network_config.n3h_path.clone()
             )],
             network_config.n3h_persistence_path.clone(),
+            opaque_net_config,
             hashmap! {
                 String::from("N3H_MODE") => network_config.n3h_mode.clone(),
                 String::from("N3H_WORK_DIR") => network_config.n3h_persistence_path.clone(),

--- a/net/src/ipc_net_worker.rs
+++ b/net/src/ipc_net_worker.rs
@@ -41,6 +41,8 @@ pub struct IpcNetWorker {
 impl IpcNetWorker {
     // Constructor with config as a json string
     pub fn new(handler: NetHandler, config: &JsonString) -> NetResult<Self> {
+        let opaque_net_config = String::from("{}");
+
         // Load config
         let config: serde_json::Value = serde_json::from_str(config.into())?;
         // Only zmq protocol is handled for now
@@ -85,6 +87,7 @@ impl IpcNetWorker {
                     .map(|i| i.as_str().unwrap_or_default().to_string())
                     .collect(),
                 spawn_config["workDir"].as_str().unwrap().to_string(),
+                opaque_net_config,
                 env,
                 block_connect,
                 bootstrap_nodes,
@@ -133,12 +136,13 @@ impl IpcNetWorker {
         cmd: String,
         args: Vec<String>,
         work_dir: String,
+        config: String,
         env: HashMap<String, String>,
         block_connect: bool,
         bootstrap_nodes: Vec<String>,
     ) -> NetResult<Self> {
         // Spawn a process with given `cmd` that we will have an IPC connection with
-        let spawn_result = spawn::ipc_spawn(cmd, args, work_dir, env, block_connect)?;
+        let spawn_result = spawn::ipc_spawn(cmd, args, work_dir, config, env, block_connect)?;
         // Get spawn result info
         let ipc_binding = spawn_result.ipc_binding;
         let kill = spawn_result.kill;


### PR DESCRIPTION
- [ ] I have added a summary of my changes to the changelog

this is related to n3h proxy / relay - https://github.com/holochain/n3h/pull/35

We need to pass end-user configured configuration to the networking module (all of which should be opaque to rust core... i.e. it doesn't need to parse / alter / read / write / anything the data).

This is the first step, ended up passing it to the child process over stdin rather than creating a file as I had originally thought, since it was much simpler this way.

Hopefully @ddd-mtl or someone else with more knowledge of how the composer loads config files can take it from here. (right now there are just `let opaque_net_config = String::from("{}");` stubs in the locations that need this data for subprocess spawning).