### PR TITLE
added mute env var for simple logger to decrease CI log size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * futures to `0.3.0-alpha.12`
 - Adjusted so that all chain headers are sent in the validation package, not just those for public entry types
 ### Added
+- Adds an environment variable HC_SIMPLE_LOGGER_MUTE for use in testing which silences logging output so CI logs won't be too big.
 - Added Zome API function `hdk::sleep(std::time::Duration)` which works the same as `std::thread::sleep`.
 - All structs/values to all HDK functions must implement `Into<JsonString>` and `TryFrom<JsonString>` (derive `DefaultJson` to do this automatically)
 - HDK globals `AGENT_ADDRESS`, `AGENT_ID_STR`, `DNA_NAME` and `DNA_ADDRESS` are now set to real, correct values.
@@ -47,13 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `admin/bridge/add`
   * `admin/bridge/remove`
   * `admin/bridge/list`
-  
+
 - Hosting of static files over HTTP to allow for container hosted web UIs
 - UI bundle admin RPC functions
-   Adds a further set of functions to the container RPC for managing 
+   Adds a further set of functions to the container RPC for managing
    static UI bundles and HTTP interfaces to these.
    This adds the following RPC endpoints:
-   
+
    * `admin/ui/install`
    * `admin/ui/uninstall`
    * `admin/ui/list`

--- a/core/src/logger.rs
+++ b/core/src/logger.rs
@@ -21,8 +21,14 @@ pub struct SimpleLogger {
 #[cfg_attr(tarpaulin, skip)]
 impl Logger for SimpleLogger {
     fn log(&mut self, msg: String) {
-        let date = Local::now();
-        println!("{}:{}", date.format("%Y-%m-%d %H:%M:%S"), msg);
+        match std::env::var("HC_SIMPLE_LOGGER_MUTE") {
+            Ok(_) => (),
+            Err(_) => {
+                let date = Local::now();
+                println!("{}:{}", date.format("%Y-%m-%d %H:%M:%S"), msg);
+
+            }
+        }
     }
 }
 

--- a/core/src/logger.rs
+++ b/core/src/logger.rs
@@ -21,13 +21,9 @@ pub struct SimpleLogger {
 #[cfg_attr(tarpaulin, skip)]
 impl Logger for SimpleLogger {
     fn log(&mut self, msg: String) {
-        match std::env::var("HC_SIMPLE_LOGGER_MUTE") {
-            Ok(_) => (),
-            Err(_) => {
-                let date = Local::now();
-                println!("{}:{}", date.format("%Y-%m-%d %H:%M:%S"), msg);
-
-            }
+        if std::env::var("HC_SIMPLE_LOGGER_MUTE").is_err() {
+            let date = Local::now();
+            println!("{}:{}", date.format("%Y-%m-%d %H:%M:%S"), msg);
         }
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -81,7 +81,7 @@ let
   hc-test = nixpkgs.writeShellScriptBin "hc-test"
   ''
    hc-build-wasm
-   cargo test --all --release --target-dir "$HC_TARGET_PREFIX"target;
+   HC_SIMPLE_LOGGER_MUTE=1 cargo test --all --release --target-dir "$HC_TARGET_PREFIX"target;
   '';
 
 in


### PR DESCRIPTION
- [x] I have added a summary of my changes to the changelog

Loogging output during CI has made it so you can't see all the test results without downloading a file.  This PR adds an environment variable that mutes that can mute that output and the nix CI is set to use it.