### PR TITLE
fix nodejs_conductor config bug: couldn't set to not-debug logging

### DIFF
--- a/nodejs_conductor/native/src/config.rs
+++ b/nodejs_conductor/native/src/config.rs
@@ -43,7 +43,7 @@ pub fn js_make_config(mut cx: FunctionContext) -> JsResult<JsValue> {
         Default::default()
     } else {
         LoggerConfiguration {
-            logger_type: "debug".into(),
+            logger_type: "simple".into(),
             rules: LogRules::new(),
         }
     };


### PR DESCRIPTION
- [ ] I have added a summary of my changes to the changelog

since `Default::default` for LoggerConfiguration picks "debug", and the other picks "debug", there's no way to pick simple

This then allows muting the log output of the tests, which is a firehose