### PR TITLE
Missing hc_dpki serde_drive crate and macros prevents compilation

### DIFF
--- a/hc_dpki/src/lib.rs
+++ b/hc_dpki/src/lib.rs
@@ -7,8 +7,9 @@ extern crate base64;
 extern crate bip39;
 extern crate boolinator;
 extern crate rustc_serialize;
-#[macro_use]
 extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 
 pub mod bundle;
 pub mod error;


### PR DESCRIPTION
Without crate serde_derive and its macros, hc_dpki doesn't compile.  I'm not certain why everyone isn't having this problem, but it seems to be a requirement for clean compilation...
