### PR TITLE
Release blocker unblock: better nodejs logging default

### DIFF
--- a/app_spec/test/regressions.js
+++ b/app_spec/test/regressions.js
@@ -10,7 +10,7 @@ const agentTash = Config.agent("tash")
 const instanceAlice = Config.instance(agentAlice, dna)
 const instanceTash = Config.instance(agentTash, dna)
 
-const scenario = new Scenario([instanceAlice, instanceTash])
+const scenario = new Scenario([instanceAlice, instanceTash], { debugLog: true })
 
 scenario.runTape('calling get_links before link_entries makes no difference', async (t, {alice}) => {
 

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -12,9 +12,9 @@ const instanceAlice = Config.instance(agentAlice, dna)
 const instanceBob = Config.instance(agentBob, dna)
 const instanceCarol = Config.instance(agentCarol, dna)
 
-const scenario1 = new Scenario([instanceAlice])
-const scenario2 = new Scenario([instanceAlice, instanceBob])
-const scenario3 = new Scenario([instanceAlice, instanceBob, instanceCarol])
+const scenario1 = new Scenario([instanceAlice], { debugLog: true })
+const scenario2 = new Scenario([instanceAlice, instanceBob], { debugLog: true })
+const scenario3 = new Scenario([instanceAlice, instanceBob, instanceCarol], { debugLog: true })
 
 scenario2.runTape('agentId', async (t, { alice, bob }) => {
   t.ok(alice.agentId)

--- a/doc/holochain_101/src/scenario_testing_setup.md
+++ b/doc/holochain_101/src/scenario_testing_setup.md
@@ -17,9 +17,7 @@ ___
 
 **Type** `object`
 
-**Description** *conductorOptions.debugLog* `boolean` Which logging to use. There are two options:
-- debugLog = true: Use the "debug" logger. This one has full debug logging and nice, colorful output.
-- debugLog = false: Doesn't output any logs.
+**Description** *conductorOptions.debugLog* `boolean` Enables debug logging. The logger produces nice, colorful output of the internal workings of Holochain.
 
 **Default** `{ debugLog: false }`
 ___

--- a/doc/holochain_101/src/scenario_testing_setup.md
+++ b/doc/holochain_101/src/scenario_testing_setup.md
@@ -17,11 +17,11 @@ ___
 
 **Type** `object`
 
-**Description** *conductorOptions.debugLog* `boolean` Which logger type to use. There are two options:
-- debugLog = true: Use the "debug" logger. This one has nicer, colorful output.
-- debugLog = false: Use the "simple" logger. This one has less interesting output, but can be silenced with the env variable `HC_SIMPLE_LOGGER_MUTE=1`
+**Description** *conductorOptions.debugLog* `boolean` Which logging to use. There are two options:
+- debugLog = true: Use the "debug" logger. This one has full debug logging and nice, colorful output.
+- debugLog = false: Doesn't output any logs.
 
-**Default** `{ debugLog: true }`
+**Default** `{ debugLog: false }`
 ___
 
 #### Example
@@ -32,12 +32,12 @@ const instanceBob = Config.instance(Config.agent("bob"), dna)
 const scenario = new Scenario([instanceAlice])
 ```
 
-#### With Config Example
+#### With conductorOptions Example
 ```javascript
 const dna = Config.dna("path/to/happ.hcpkg")
 const instanceAlice = Config.instance(Config.agent("alice"), dna)
 const instanceBob = Config.instance(Config.agent("bob"), dna)
-const scenario = new Scenario([instanceAlice], { debugLog: false })
+const scenario = new Scenario([instanceAlice], { debugLog: true })
 ```
 
 ## Inject Tape Version

--- a/doc/holochain_101/src/testing_configuration.md
+++ b/doc/holochain_101/src/testing_configuration.md
@@ -132,9 +132,7 @@ ___
 
 **Type** `object`
 
-**Description** *conductorOptions.debugLog* `boolean` Which logging to use. There are two options:
-- debugLog = true: Use the "debug" logger. This one has full debug logging and nice, colorful output.
-- debugLog = false: Doesn't output any logs.
+**Description** *conductorOptions.debugLog* `boolean` Enables debug logging. The logger produces nice, colorful output of the internal workings of Holochain.
 
 **Default** `{ debugLog: false }`
 ___

--- a/doc/holochain_101/src/testing_configuration.md
+++ b/doc/holochain_101/src/testing_configuration.md
@@ -132,11 +132,11 @@ ___
 
 **Type** `object`
 
-**Description** *conductorOptions.debugLog* `boolean` Which logger type to use. There are two options:
-- debugLog = true: Use the "debug" logger. This one has nicer, colorful output.
-- debugLog = false: Use the "simple" logger. This one has less interesting output, but can be silenced with the env variable `HC_SIMPLE_LOGGER_MUTE=1`
+**Description** *conductorOptions.debugLog* `boolean` Which logging to use. There are two options:
+- debugLog = true: Use the "debug" logger. This one has full debug logging and nice, colorful output.
+- debugLog = false: Doesn't output any logs.
 
-**Default** `{ debugLog: true }`
+**Default** `{ debugLog: false }`
 ___
 
 #### Example
@@ -152,7 +152,7 @@ const conductorConfig = Config.conductor([instanceConfig])
 const agentConfig = Config.agent('alice')
 const dnaConfig = Config.dna('path/to/bundle.json')
 const instanceConfig = Config.instance(agentConfig, dnaConfig)
-const conductorConfig = Config.conductor([instanceConfig], { debugLog: false })
+const conductorConfig = Config.conductor([instanceConfig], { debugLog: true })
 ```
 
 

--- a/nodejs_conductor/index.js
+++ b/nodejs_conductor/index.js
@@ -19,7 +19,7 @@ const callbackFromPromise = (fulfill, reject) => (err, val) => {
 /////////////////////////////////////////////////////////////
 
 const defaultOpts = {
-    debugLog: true
+    debugLog: false
 }
 
 const Config = {

--- a/nodejs_conductor/native/src/config.rs
+++ b/nodejs_conductor/native/src/config.rs
@@ -42,9 +42,14 @@ pub fn js_make_config(mut cx: FunctionContext) -> JsResult<JsValue> {
     let logger = if opts.debug_log {
         Default::default()
     } else {
+        // creates a logger which just mutes all
+        let mut rules = LogRules::new();
+        rules
+            .add_rule("^*", true, None)
+            .expect("rule is valid");
         LoggerConfiguration {
-            logger_type: "simple".into(),
-            rules: LogRules::new(),
+            logger_type: "debug".into(),
+            rules,
         }
     };
     let config = make_config(instances, logger);


### PR DESCRIPTION
This has another nice upside which is that it removes all the crazy amounts of extra logging in app_spec tests, which might actually also help speed it up and maybe eliminate the memory challenge too