### PR TITLE
Handle signing errors

### DIFF
--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -167,7 +167,7 @@ pub fn create_new_chain_header(
     entry: &Entry,
     context: Arc<Context>,
     crud_link: &Option<Address>,
-) -> ChainHeader {
+) -> Result<ChainHeader, HolochainError> {
     let agent_state = context
         .state()
         .expect("create_new_chain_header called without state")
@@ -177,13 +177,15 @@ pub fn create_new_chain_header(
         .unwrap_or(context.agent_id.address());
     let signature = Signature::from(
         context
-            .sign(entry.address().to_string())
-            .expect("Must be able to create signatures!"),
+            .sign(entry.address().to_string())?,
+            // Temporarily replaced by error handling for Holo hack signing.
+            // TODO: pull in the expect below after removing the Holo signing hack again
+            //.expect("Must be able to create signatures!"),
     );
     let duration_since_epoch = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("System time must not be before UNIX EPOCH");
-    ChainHeader::new(
+    Ok(ChainHeader::new(
         &entry.entry_type(),
         &entry.address(),
         &vec![(agent_address, signature)],
@@ -198,7 +200,7 @@ pub fn create_new_chain_header(
             .and_then(|chain_header| Some(chain_header.address())),
         crud_link,
         &Iso8601::from(duration_since_epoch.as_secs()),
-    )
+    ))
 }
 
 /// Do a Commit Action against an agent state.
@@ -216,32 +218,29 @@ fn reduce_commit_entry(
 ) {
     let action = action_wrapper.action();
     let (entry, maybe_crud_link) = unwrap_to!(action => Action::Commit);
-    let chain_header = create_new_chain_header(&entry, context.clone(), &maybe_crud_link);
 
-    fn response(
-        state: &mut AgentState,
-        entry: &Entry,
-        chain_header: &ChainHeader,
-    ) -> Result<Address, HolochainError> {
-        let storage = &state.chain_store.content_storage().clone();
-        storage.write().unwrap().add(entry)?;
-        storage.write().unwrap().add(chain_header)?;
-        Ok(entry.address())
-    }
-    let result = response(state, &entry, &chain_header);
-    state.top_chain_header = Some(chain_header);
-    let con = context.clone();
-
-    #[allow(unused_must_use)]
-    con.state().map(|global_state_lock| {
-        let persis_lock = context.clone().persister.clone();
-        let persister = &mut *persis_lock.lock().unwrap();
-        persister.save(global_state_lock.clone());
-    });
+    let result = create_new_chain_header(&entry, context.clone(), &maybe_crud_link)
+        .and_then(|chain_header| {
+            let storage = &state.chain_store.content_storage().clone();
+            storage.write().unwrap().add(entry)?;
+            storage.write().unwrap().add(&chain_header)?;
+            Ok((chain_header, entry.address()))
+        })
+        .and_then(|(chain_header, address)| {
+            state.top_chain_header = Some(chain_header);
+            Ok(address)
+        });
 
     state
         .actions
         .insert(action_wrapper.clone(), ActionResponse::Commit(result));
+
+    #[allow(unused_must_use)]
+    context.state().map(|global_state_lock| {
+        let persis_lock = context.clone().persister.clone();
+        let persister = &mut *persis_lock.lock().unwrap();
+        persister.save(global_state_lock.clone());
+    });
 }
 
 /// maps incoming action to the correct handler
@@ -421,7 +420,7 @@ pub mod tests {
             .unwrap()
             .set_state(Arc::new(RwLock::new(state)));
 
-        let header = create_new_chain_header(&test_entry(), context.clone(), &None);
+        let header = create_new_chain_header(&test_entry(), context.clone(), &None).unwrap();
         println!("{:?}", header);
         assert_eq!(
             header,

--- a/core/src/agent/state.rs
+++ b/core/src/agent/state.rs
@@ -176,11 +176,10 @@ pub fn create_new_chain_header(
         .get_agent_address()
         .unwrap_or(context.agent_id.address());
     let signature = Signature::from(
-        context
-            .sign(entry.address().to_string())?,
-            // Temporarily replaced by error handling for Holo hack signing.
-            // TODO: pull in the expect below after removing the Holo signing hack again
-            //.expect("Must be able to create signatures!"),
+        context.sign(entry.address().to_string())?,
+        // Temporarily replaced by error handling for Holo hack signing.
+        // TODO: pull in the expect below after removing the Holo signing hack again
+        //.expect("Must be able to create signatures!"),
     );
     let duration_since_epoch = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -94,8 +94,8 @@ pub mod tests {
 
         // Create Entry & crud-status metadata, and store it.
         let entry = test_entry();
-        let header1 = create_new_chain_header(&entry, context1.clone(), &None);
-        let header2 = create_new_chain_header(&entry, context2.clone(), &None);
+        let header1 = create_new_chain_header(&entry, context1.clone(), &None).unwrap();
+        let header2 = create_new_chain_header(&entry, context2.clone(), &None).unwrap();
         context1
             .block_on(commit_entry(entry.clone(), None, &context1))
             .unwrap();

--- a/core/src/nucleus/actions/build_validation_package.rs
+++ b/core/src/nucleus/actions/build_validation_package.rs
@@ -19,7 +19,10 @@ use holochain_core_types::{
 use snowflake;
 use std::{convert::TryInto, pin::Pin, sync::Arc, thread};
 
-pub async fn build_validation_package(entry: &Entry, context: Arc<Context>) -> Result<ValidationPackage, HolochainError> {
+pub async fn build_validation_package(
+    entry: &Entry,
+    context: Arc<Context>,
+) -> Result<ValidationPackage, HolochainError> {
     let id = snowflake::ProcessUniqueId::new();
 
     match entry.entry_type() {
@@ -59,10 +62,12 @@ pub async fn build_validation_package(entry: &Entry, context: Arc<Context>) -> R
         EntryType::AgentId => {
             // FIXME
         }
-        _ => return Err(HolochainError::ValidationFailed(format!(
+        _ => {
+            return Err(HolochainError::ValidationFailed(format!(
                 "Attempted to validate system entry type {:?}",
                 entry.entry_type(),
-            ))),
+            )));
+        }
     };
 
     {

--- a/core/src/nucleus/actions/build_validation_package.rs
+++ b/core/src/nucleus/actions/build_validation_package.rs
@@ -19,7 +19,7 @@ use holochain_core_types::{
 use snowflake;
 use std::{convert::TryInto, pin::Pin, sync::Arc, thread};
 
-pub fn build_validation_package(entry: &Entry, context: &Arc<Context>) -> ValidationPackageFuture {
+pub async fn build_validation_package(entry: &Entry, context: Arc<Context>) -> Result<ValidationPackage, HolochainError> {
     let id = snowflake::ProcessUniqueId::new();
 
     match entry.entry_type() {
@@ -33,14 +33,10 @@ pub fn build_validation_package(entry: &Entry, context: &Arc<Context>) -> Valida
                 .get_zome_name_for_app_entry_type(&app_entry_type)
                 .is_none()
             {
-                return ValidationPackageFuture {
-                    context: context.clone(),
-                    key: id,
-                    error: Some(HolochainError::ValidationFailed(format!(
-                        "Unknown app entry type '{}'",
-                        String::from(app_entry_type),
-                    ))),
-                };
+                return Err(HolochainError::ValidationFailed(format!(
+                    "Unknown app entry type '{}'",
+                    String::from(app_entry_type),
+                )));
             }
         }
 
@@ -63,16 +59,10 @@ pub fn build_validation_package(entry: &Entry, context: &Arc<Context>) -> Valida
         EntryType::AgentId => {
             // FIXME
         }
-        _ => {
-            return ValidationPackageFuture {
-                context: context.clone(),
-                key: id,
-                error: Some(HolochainError::ValidationFailed(format!(
-                    "Attempted to validate system entry type {:?}",
-                    entry.entry_type(),
-                ))),
-            };
-        }
+        _ => return Err(HolochainError::ValidationFailed(format!(
+                "Attempted to validate system entry type {:?}",
+                entry.entry_type(),
+            ))),
     };
 
     {
@@ -92,7 +82,7 @@ pub fn build_validation_package(entry: &Entry, context: &Arc<Context>) -> Valida
             // and just used for the validation, I don't see why it would be a problem.
             // If it was a problem, we would have to make sure that the whole commit process
             // (including validtion) is atomic.
-            agent::state::create_new_chain_header(&entry, context.clone(), &None),
+            agent::state::create_new_chain_header(&entry, context.clone(), &None)?,
         );
 
         thread::spawn(move || {
@@ -149,11 +139,11 @@ pub fn build_validation_package(entry: &Entry, context: &Arc<Context>) -> Valida
         });
     }
 
-    ValidationPackageFuture {
+    await!(ValidationPackageFuture {
         context: context.clone(),
         key: id,
         error: None,
-    }
+    })
 }
 
 fn all_public_chain_entries(context: &Arc<Context>) -> Vec<Entry> {
@@ -231,7 +221,7 @@ mod tests {
 
         let maybe_validation_package = context.block_on(build_validation_package(
             &test_entry_package_entry(),
-            &context.clone(),
+            context.clone(),
         ));
         println!("{:?}", maybe_validation_package);
         assert!(maybe_validation_package.is_ok());
@@ -259,7 +249,7 @@ mod tests {
 
         let maybe_validation_package = context.block_on(build_validation_package(
             &test_entry_package_chain_entries(),
-            &context.clone(),
+            context.clone(),
         ));
         assert!(maybe_validation_package.is_ok());
 
@@ -286,7 +276,7 @@ mod tests {
 
         let maybe_validation_package = context.block_on(build_validation_package(
             &test_entry_package_chain_headers(),
-            &context.clone(),
+            context.clone(),
         ));
         assert!(maybe_validation_package.is_ok());
 
@@ -313,7 +303,7 @@ mod tests {
 
         let maybe_validation_package = context.block_on(build_validation_package(
             &test_entry_package_chain_full(),
-            &context.clone(),
+            context.clone(),
         ));
         assert!(maybe_validation_package.is_ok());
 

--- a/core/src/nucleus/ribosome/api/remove_entry.rs
+++ b/core/src/nucleus/ribosome/api/remove_entry.rs
@@ -62,7 +62,7 @@ pub fn invoke_remove_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApi
     // Resolve future
     let result: Result<(), HolochainError> = zome_call_data.context.block_on(
         // 1. Build the context needed for validation of the entry
-        build_validation_package(&deletion_entry, &zome_call_data.context)
+        build_validation_package(&deletion_entry, zome_call_data.context.clone())
             .and_then(|validation_package| {
                 future::ready(Ok(ValidationData {
                     package: validation_package,

--- a/core/src/nucleus/ribosome/api/update_entry.rs
+++ b/core/src/nucleus/ribosome/api/update_entry.rs
@@ -70,7 +70,7 @@ pub fn invoke_update_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApi
     // Wait for future to be resolved
     let task_result: Result<Address, HolochainError> = zome_call_data.context.block_on(
         // 1. Build the context needed for validation of the entry
-        build_validation_package(&entry, &zome_call_data.context)
+        build_validation_package(&entry, zome_call_data.context.clone())
             .and_then(|validation_package| {
                 future::ready(Ok(ValidationData {
                     package: validation_package,

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -26,7 +26,7 @@ pub async fn author_entry<'a>(
         address, entry
     ));
     // 1. Build the context needed for validation of the entry
-    let validation_package = await!(build_validation_package(&entry, &context))?;
+    let validation_package = await!(build_validation_package(&entry, context.clone()))?;
     let validation_data = ValidationData {
         package: validation_package,
         lifecycle: EntryLifecycle::Chain,

--- a/core/src/workflows/respond_validation_package_request.rs
+++ b/core/src/workflows/respond_validation_package_request.rs
@@ -33,7 +33,7 @@ pub async fn respond_validation_package_request(
     context: Arc<Context>,
 ) {
     let maybe_validation_package = match get_entry(&requested_entry_address, &context) {
-        Ok(entry) => await!(build_validation_package(&entry, &context)).ok(),
+        Ok(entry) => await!(build_validation_package(&entry, context.clone())).ok(),
         Err(_) => None,
     };
 


### PR DESCRIPTION
- [ ] I have added a summary of my changes to the changelog
*No, not user facing*

# Context
Last change set to complete crypto story for current milestone:
![screenshot 2019-02-21 at 18 24 55](https://user-images.githubusercontent.com/311749/53188604-08fcce00-3606-11e9-906e-67683e60efc4.png)


With the changes in https://github.com/holochain/holochain-rust/pull/1043 signing can fail if the client is offline or the connection times out etc.

Instead of panicking, we now handle this error gracefully which means the commit fails.

Since we also create headers as a fall back in `build_validation_package` I had to refactor to that function `async/await!` syntax to allow for easy error returning.