### PR TITLE
Expose holo_remote_key to admin interface method

### DIFF
--- a/cli/src/cli/run.rs
+++ b/cli/src/cli/run.rs
@@ -104,7 +104,7 @@ fn agent_configuration() -> AgentConfiguration {
         name: agent_id.nick,
         public_address: agent_id.pub_sign_key,
         key_file: agent_name,
-        holo_remote_key: None,
+        holo_remote_key: false,
     }
 }
 
@@ -275,7 +275,7 @@ mod tests {
                 public_address: "HcScjN8wBwrn3tuyg89aab3a69xsIgdzmX5P9537BqQZ5A7TEZu7qCY4Xzzjhma"
                     .to_string(),
                 key_file: "testAgent".to_string(),
-                holo_remote_key: None,
+                holo_remote_key: false,
             },
         );
     }

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -1285,7 +1285,7 @@ type = 'websocket'"#,
             name: String::from("Mr. New"),
             public_address: AgentId::generate_fake("new").address().to_string(),
             key_file: String::from("new-test-path"),
-            holo_remote_key: None,
+            holo_remote_key: false,
         };
 
         assert_eq!(conductor.add_agent(agent_config), Ok(()),);

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -405,7 +405,7 @@ impl Conductor {
 
                 // Agent:
                 let agent_config = config.agent_by_id(&instance_config.agent).unwrap();
-                let agent_id = if Some(true) == agent_config.holo_remote_key {
+                let agent_id = if agent_config.holo_remote_key {
                     // !!!!!!!!!!!!!!!!!!!!!!!
                     // Holo closed-alpha hack:
                     // !!!!!!!!!!!!!!!!!!!!!!!
@@ -441,7 +441,7 @@ impl Conductor {
                 // Conductor API
                 let mut api_builder = ConductorApiBuilder::new();
                 // Signing callback:
-                if Some(true) == agent_config.holo_remote_key {
+                if agent_config.holo_remote_key {
                     // !!!!!!!!!!!!!!!!!!!!!!!
                     // Holo closed-alpha hack:
                     // !!!!!!!!!!!!!!!!!!!!!!!
@@ -505,12 +505,7 @@ impl Conductor {
     /// passphrase prompts) before bootstrapping the whole config and have prompts appear
     /// in between other initialization output.
     pub fn check_load_key_for_agent(&mut self, agent_id: &String) -> Result<(), String> {
-        if Some(true)
-            == self
-                .config
-                .agent_by_id(agent_id)
-                .and_then(|a| a.holo_remote_key)
-        {
+        if Some(true) == self.config.agent_by_id(agent_id).map(|a| a.holo_remote_key) {
             // !!!!!!!!!!!!!!!!!!!!!!!
             // Holo closed-alpha hack:
             // !!!!!!!!!!!!!!!!!!!!!!!

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -312,7 +312,8 @@ pub struct AgentConfiguration {
     pub key_file: String,
     /// If set to true conductor will ignore key_file and instead use the remote signer
     /// accessible through signing_service_uri to request signatures.
-    pub holo_remote_key: Option<bool>,
+    #[serde(default)]
+    pub holo_remote_key: bool,
 }
 
 impl From<AgentConfiguration> for AgentId {

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -552,13 +552,14 @@ impl ConductorApiBuilder {
             let name = Self::get_as_string("name", &params_map)?;
             let public_address = Self::get_as_string("public_address", &params_map)?;
             let key_file = Self::get_as_string("key_file", &params_map)?;
+            let holo_remote_key = Self::get_as_bool("key_file", &params_map).unwrap_or_default();
 
             let agent = AgentConfiguration {
                 id,
                 name,
                 public_address,
                 key_file,
-                holo_remote_key: None,
+                holo_remote_key,
             };
             conductor_call!(|c| c.add_agent(agent))?;
             Ok(json!({"success": true}))


### PR DESCRIPTION
Needed for Holo Interceptr.

Also takes `holo_remote_key` out of the Option