### PR TITLE
Fix Pending Validations and thereby HoloFuel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
  app-spec-tests:
   docker:
    - image: holochain/holochain-rust:circle.zz.end
-  resource_class: large
+  resource_class: xlarge
   steps:
    - checkout
 

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -10,7 +10,7 @@ use crate::{
         validation::ValidationResult,
         ZomeFnCall,
     },
-    scheduled_jobs::pending_validations::PendingValidation,
+    scheduled_jobs::pending_validations::{PendingValidation, ValidatingWorkflow},
 };
 use holochain_core_types::{
     cas::content::Address,
@@ -212,7 +212,7 @@ pub enum Action {
     AddPendingValidation(PendingValidation),
 
     /// Clear an entry from the pending validation list
-    RemovePendingValidation(Address),
+    RemovePendingValidation((Address, ValidatingWorkflow)),
 }
 
 /// function signature for action handler functions

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -238,16 +238,18 @@ impl Context {
     }
 
     /// Custom future executor that enables nested futures and nested calls of `block_on`.
-    /// This makes use of the redux action loop and the observers.
-    /// The given future gets polled everytime the instance's state got changed.
+    /// This used to make use of the redux action loop and the observers to have the given
+    /// future be polled everytime the instance's state got changed.
+    /// Because handling a large number of sync channels can fail, this is now just sleeps
+    /// 10 milliseconds and then polls again.
     pub fn block_on<F: Future>(&self, future: F) -> <F as Future>::Output {
-        let tick_rx = self.create_observer();
         pin_utils::pin_mut!(future);
 
         loop {
+            print!(".");
             let _ = match future.as_mut().poll(noop_local_waker_ref()) {
                 Poll::Ready(result) => return result,
-                _ => tick_rx.recv_timeout(Duration::from_millis(10)),
+                _ => sleep(Duration::from_millis(10))
             };
         }
     }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -246,7 +246,6 @@ impl Context {
         pin_utils::pin_mut!(future);
 
         loop {
-            print!(".");
             let _ = match future.as_mut().poll(noop_local_waker_ref()) {
                 Poll::Ready(result) => return result,
                 _ => sleep(Duration::from_millis(10)),

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -249,7 +249,7 @@ impl Context {
             print!(".");
             let _ = match future.as_mut().poll(noop_local_waker_ref()) {
                 Poll::Ready(result) => return result,
-                _ => sleep(Duration::from_millis(10))
+                _ => sleep(Duration::from_millis(10)),
             };
         }
     }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -213,7 +213,9 @@ impl Instance {
             *state = new_state;
         }
 
-        self.save();
+        if let Err(e) = self.save() {
+            context.log(format!("err/instance/process_action: could not save state: {:?}", e));
+        }
         self.maybe_emit_action_signal(context, action_wrapper.clone());
 
         // Add new observers

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -263,15 +263,13 @@ impl Instance {
             .expect("owners of the state RwLock shouldn't panic")
     }
 
-    pub fn save(&self) {
-        if let Some(ref persister) = self.persister {
-            let _ = persister
-                .lock()
-                .unwrap()
-                .save(&self.state())
-                .map_err(|err| println!("Could not save instance! Error: {:?}", err));
-        } else {
-            println!("Instance::save() called without persister set.");
+    pub fn save(&self) -> HcResult<()> {
+        self.persister
+            .as_ref()
+            .ok_or(HolochainError::new("Instance::save() called without persister set."))?
+            .try_lock()
+            .map_err(|_|HolochainError::new("Could not get lock on persister"))?
+            .save(&self.state())
         }
     }
 }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -19,6 +19,7 @@ use std::{
     thread,
     time::Duration,
 };
+use holochain_core_types::error::error::HolochainError;
 
 pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
 
@@ -270,7 +271,6 @@ impl Instance {
             .try_lock()
             .map_err(|_|HolochainError::new("Could not get lock on persister"))?
             .save(&self.state())
-        }
     }
 }
 

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -10,7 +10,10 @@ use crate::{
 use clokwerk::{ScheduleHandle, Scheduler, TimeUnits};
 #[cfg(test)]
 use holochain_core_types::cas::content::Address;
-use holochain_core_types::{dna::Dna, error::HcResult};
+use holochain_core_types::{
+    dna::Dna,
+    error::{error::HolochainError, HcResult},
+};
 use std::{
     sync::{
         mpsc::{sync_channel, Receiver, Sender, SyncSender},
@@ -19,7 +22,6 @@ use std::{
     thread,
     time::Duration,
 };
-use holochain_core_types::error::error::HolochainError;
 
 pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
 
@@ -214,7 +216,10 @@ impl Instance {
         }
 
         if let Err(e) = self.save() {
-            context.log(format!("err/instance/process_action: could not save state: {:?}", e));
+            context.log(format!(
+                "err/instance/process_action: could not save state: {:?}",
+                e
+            ));
         }
         self.maybe_emit_action_signal(context, action_wrapper.clone());
 
@@ -269,9 +274,11 @@ impl Instance {
     pub fn save(&self) -> HcResult<()> {
         self.persister
             .as_ref()
-            .ok_or(HolochainError::new("Instance::save() called without persister set."))?
+            .ok_or(HolochainError::new(
+                "Instance::save() called without persister set.",
+            ))?
             .try_lock()
-            .map_err(|_|HolochainError::new("Could not get lock on persister"))?
+            .map_err(|_| HolochainError::new("Could not get lock on persister"))?
             .save(&self.state())
     }
 }

--- a/core/src/nucleus/actions/add_pending_validation.rs
+++ b/core/src/nucleus/actions/add_pending_validation.rs
@@ -3,7 +3,7 @@ use crate::{
     context::Context,
     instance::dispatch_action,
     network::entry_with_header::EntryWithHeader,
-    scheduled_jobs::pending_validations::PendingValidationStruct,
+    scheduled_jobs::pending_validations::{PendingValidationStruct, ValidatingWorkflow},
 };
 use holochain_core_types::cas::content::Address;
 use std::sync::Arc;
@@ -11,6 +11,7 @@ use std::sync::Arc;
 pub fn add_pending_validation(
     entry_with_header: EntryWithHeader,
     dependencies: Vec<Address>,
+    workflow: ValidatingWorkflow,
     context: &Arc<Context>,
 ) {
     dispatch_action(
@@ -19,6 +20,7 @@ pub fn add_pending_validation(
             PendingValidationStruct {
                 entry_with_header,
                 dependencies,
+                workflow,
             },
         ))),
     );

--- a/core/src/nucleus/actions/remove_pending_validation.rs
+++ b/core/src/nucleus/actions/remove_pending_validation.rs
@@ -2,13 +2,18 @@ use crate::{
     action::{Action, ActionWrapper},
     context::Context,
     instance::dispatch_action,
+    scheduled_jobs::pending_validations::ValidatingWorkflow,
 };
 use holochain_core_types::cas::content::Address;
 use std::sync::Arc;
 
-pub fn remove_pending_validation(address: Address, context: &Arc<Context>) {
+pub fn remove_pending_validation(
+    address: Address,
+    workflow: ValidatingWorkflow,
+    context: &Arc<Context>,
+) {
     dispatch_action(
         context.action_channel(),
-        ActionWrapper::new(Action::RemovePendingValidation(address)),
+        ActionWrapper::new(Action::RemovePendingValidation((address, workflow))),
     );
 }

--- a/core/src/nucleus/reducers/add_pending_validation.rs
+++ b/core/src/nucleus/reducers/add_pending_validation.rs
@@ -1,7 +1,7 @@
 use crate::{
     action::{Action, ActionWrapper},
     context::Context,
-    nucleus::state::NucleusState,
+    nucleus::state::{NucleusState, PendingValidationKey},
 };
 use holochain_core_types::cas::content::AddressableContent;
 use std::sync::Arc;
@@ -22,7 +22,7 @@ pub fn reduce_add_pending_validation(
     let workflow = pending.workflow.clone();
     state
         .pending_validations
-        .insert((address, workflow), pending.clone());
+        .insert(PendingValidationKey::new(address, workflow), pending.clone());
 }
 
 #[cfg(test)]

--- a/core/src/nucleus/reducers/add_pending_validation.rs
+++ b/core/src/nucleus/reducers/add_pending_validation.rs
@@ -32,7 +32,7 @@ pub mod tests {
     use crate::{
         instance::tests::test_context,
         network::entry_with_header::EntryWithHeader,
-        nucleus::state::tests::test_nucleus_state,
+        nucleus::state::{PendingValidationKey, tests::test_nucleus_state},
         scheduled_jobs::pending_validations::{PendingValidationStruct, ValidatingWorkflow},
     };
     use holochain_core_types::{chain_header::test_chain_header, entry::Entry, json::RawString};
@@ -60,6 +60,6 @@ pub mod tests {
 
         assert!(state
             .pending_validations
-            .contains_key(&(entry.address(), ValidatingWorkflow::HoldEntry)));
+            .contains_key(&PendingValidationKey::new(entry.address(), ValidatingWorkflow::HoldEntry)));
     }
 }

--- a/core/src/nucleus/reducers/add_pending_validation.rs
+++ b/core/src/nucleus/reducers/add_pending_validation.rs
@@ -32,7 +32,7 @@ pub mod tests {
     use crate::{
         instance::tests::test_context,
         network::entry_with_header::EntryWithHeader,
-        nucleus::state::{PendingValidationKey, tests::test_nucleus_state},
+        nucleus::state::{tests::test_nucleus_state, PendingValidationKey},
         scheduled_jobs::pending_validations::{PendingValidationStruct, ValidatingWorkflow},
     };
     use holochain_core_types::{chain_header::test_chain_header, entry::Entry, json::RawString};
@@ -60,6 +60,9 @@ pub mod tests {
 
         assert!(state
             .pending_validations
-            .contains_key(&PendingValidationKey::new(entry.address(), ValidatingWorkflow::HoldEntry)));
+            .contains_key(&PendingValidationKey::new(
+                entry.address(),
+                ValidatingWorkflow::HoldEntry
+            )));
     }
 }

--- a/core/src/nucleus/reducers/add_pending_validation.rs
+++ b/core/src/nucleus/reducers/add_pending_validation.rs
@@ -20,9 +20,10 @@ pub fn reduce_add_pending_validation(
     let pending = unwrap_to!(action => Action::AddPendingValidation);
     let address = pending.entry_with_header.entry.address();
     let workflow = pending.workflow.clone();
-    state
-        .pending_validations
-        .insert(PendingValidationKey::new(address, workflow), pending.clone());
+    state.pending_validations.insert(
+        PendingValidationKey::new(address, workflow),
+        pending.clone(),
+    );
 }
 
 #[cfg(test)]

--- a/core/src/nucleus/reducers/remove_pending_validation.rs
+++ b/core/src/nucleus/reducers/remove_pending_validation.rs
@@ -4,6 +4,7 @@ use crate::{
     nucleus::state::NucleusState,
 };
 use std::sync::Arc;
+use crate::nucleus::state::PendingValidationKey;
 
 /// Reduce RemovePendingValidation Action.
 /// Removes boxed EntryWithHeader and dependencies from state, referenced with
@@ -17,8 +18,8 @@ pub fn reduce_remove_pending_validation(
     action_wrapper: &ActionWrapper,
 ) {
     let action = action_wrapper.action();
-    let address = unwrap_to!(action => Action::RemovePendingValidation);
-    state.pending_validations.remove(address);
+    let (address, workflow) = unwrap_to!(action => Action::RemovePendingValidation).clone();
+    state.pending_validations.remove(&PendingValidationKey::new(address, workflow));
 }
 
 #[cfg(test)]

--- a/core/src/nucleus/reducers/remove_pending_validation.rs
+++ b/core/src/nucleus/reducers/remove_pending_validation.rs
@@ -31,7 +31,7 @@ pub mod tests {
             reducers::add_pending_validation::reduce_add_pending_validation,
             state::tests::test_nucleus_state,
         },
-        scheduled_jobs::pending_validations::PendingValidationStruct,
+        scheduled_jobs::pending_validations::{PendingValidationStruct, ValidatingWorkflow},
     };
     use holochain_core_types::{
         cas::content::AddressableContent, chain_header::test_chain_header, entry::Entry,
@@ -53,17 +53,25 @@ pub mod tests {
             PendingValidationStruct {
                 entry_with_header,
                 dependencies: Vec::new(),
+                workflow: ValidatingWorkflow::HoldEntry,
             },
         )));
 
         reduce_add_pending_validation(context.clone(), &mut state, &action_wrapper);
 
-        assert!(state.pending_validations.contains_key(&entry.address()));
+        assert!(state
+            .pending_validations
+            .contains_key(&(entry.address(), ValidatingWorkflow::HoldEntry)));
 
-        let action_wrapper = ActionWrapper::new(Action::RemovePendingValidation(entry.address()));
+        let action_wrapper = ActionWrapper::new(Action::RemovePendingValidation((
+            entry.address(),
+            ValidatingWorkflow::HoldEntry,
+        )));
 
         reduce_remove_pending_validation(context, &mut state, &action_wrapper);
 
-        assert!(!state.pending_validations.contains_key(&entry.address()));
+        assert!(!state
+            .pending_validations
+            .contains_key(&(entry.address(), ValidatingWorkflow::HoldEntry)));
     }
 }

--- a/core/src/nucleus/reducers/remove_pending_validation.rs
+++ b/core/src/nucleus/reducers/remove_pending_validation.rs
@@ -63,7 +63,7 @@ pub mod tests {
 
         assert!(state
             .pending_validations
-            .contains_key(&(entry.address(), ValidatingWorkflow::HoldEntry)));
+            .contains_key(&PendingValidationKey::new(entry.address(), ValidatingWorkflow::HoldEntry)));
 
         let action_wrapper = ActionWrapper::new(Action::RemovePendingValidation((
             entry.address(),
@@ -74,6 +74,6 @@ pub mod tests {
 
         assert!(!state
             .pending_validations
-            .contains_key(&(entry.address(), ValidatingWorkflow::HoldEntry)));
+            .contains_key(&PendingValidationKey::new(entry.address(), ValidatingWorkflow::HoldEntry)));
     }
 }

--- a/core/src/nucleus/reducers/remove_pending_validation.rs
+++ b/core/src/nucleus/reducers/remove_pending_validation.rs
@@ -63,7 +63,10 @@ pub mod tests {
 
         assert!(state
             .pending_validations
-            .contains_key(&PendingValidationKey::new(entry.address(), ValidatingWorkflow::HoldEntry)));
+            .contains_key(&PendingValidationKey::new(
+                entry.address(),
+                ValidatingWorkflow::HoldEntry
+            )));
 
         let action_wrapper = ActionWrapper::new(Action::RemovePendingValidation((
             entry.address(),
@@ -74,6 +77,9 @@ pub mod tests {
 
         assert!(!state
             .pending_validations
-            .contains_key(&PendingValidationKey::new(entry.address(), ValidatingWorkflow::HoldEntry)));
+            .contains_key(&PendingValidationKey::new(
+                entry.address(),
+                ValidatingWorkflow::HoldEntry
+            )));
     }
 }

--- a/core/src/nucleus/reducers/remove_pending_validation.rs
+++ b/core/src/nucleus/reducers/remove_pending_validation.rs
@@ -1,10 +1,9 @@
 use crate::{
     action::{Action, ActionWrapper},
     context::Context,
-    nucleus::state::NucleusState,
+    nucleus::state::{NucleusState, PendingValidationKey},
 };
 use std::sync::Arc;
-use crate::nucleus::state::PendingValidationKey;
 
 /// Reduce RemovePendingValidation Action.
 /// Removes boxed EntryWithHeader and dependencies from state, referenced with
@@ -19,7 +18,9 @@ pub fn reduce_remove_pending_validation(
 ) {
     let action = action_wrapper.action();
     let (address, workflow) = unwrap_to!(action => Action::RemovePendingValidation).clone();
-    state.pending_validations.remove(&PendingValidationKey::new(address, workflow));
+    state
+        .pending_validations
+        .remove(&PendingValidationKey::new(address, workflow));
 }
 
 #[cfg(test)]

--- a/core/src/nucleus/reducers/return_validation_result.rs
+++ b/core/src/nucleus/reducers/return_validation_result.rs
@@ -15,5 +15,4 @@ pub fn reduce_return_validation_result(
     state
         .validation_results
         .insert((id.clone(), hash.clone()), validation_result.clone());
-    state.pending_validations.remove(hash);
 }

--- a/core/src/nucleus/state.rs
+++ b/core/src/nucleus/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     nucleus::{actions::initialize::Initialization, validation::ValidationResult, ZomeFnCall},
-    scheduled_jobs::pending_validations::PendingValidation,
+    scheduled_jobs::pending_validations::{PendingValidation, ValidatingWorkflow},
     state::State,
 };
 use holochain_core_types::{
@@ -33,7 +33,7 @@ impl Default for NucleusStatus {
 pub struct NucleusState {
     // Persisted fields:
     pub status: NucleusStatus,
-    pub pending_validations: HashMap<Address, PendingValidation>,
+    pub pending_validations: HashMap<(Address, ValidatingWorkflow), PendingValidation>,
 
     // Transient fields:
     pub dna: Option<Dna>, //DNA is transient here because it is stored in the chain and gets
@@ -103,7 +103,7 @@ impl NucleusState {
 #[derive(Clone, Debug, Deserialize, Serialize, DefaultJson)]
 pub struct NucleusStateSnapshot {
     pub status: NucleusStatus,
-    pub pending_validations: HashMap<Address, PendingValidation>,
+    pub pending_validations: HashMap<(Address, ValidatingWorkflow), PendingValidation>,
 }
 
 impl From<&State> for NucleusStateSnapshot {

--- a/core/src/nucleus/state.rs
+++ b/core/src/nucleus/state.rs
@@ -27,13 +27,21 @@ impl Default for NucleusStatus {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PendingValidationKey(String);
+impl PendingValidationKey {
+    pub fn new(address: Address, workflow: ValidatingWorkflow) -> Self {
+        PendingValidationKey(format!("{}:{}", workflow, address))
+    }
+}
+
 /// The state-slice for the Nucleus.
 /// Holds the dynamic parts of the DNA, i.e. zome calls and validation requests.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct NucleusState {
     // Persisted fields:
     pub status: NucleusStatus,
-    pub pending_validations: HashMap<(Address, ValidatingWorkflow), PendingValidation>,
+    pub pending_validations: HashMap<PendingValidationKey, PendingValidation>,
 
     // Transient fields:
     pub dna: Option<Dna>, //DNA is transient here because it is stored in the chain and gets
@@ -103,7 +111,7 @@ impl NucleusState {
 #[derive(Clone, Debug, Deserialize, Serialize, DefaultJson)]
 pub struct NucleusStateSnapshot {
     pub status: NucleusStatus,
-    pub pending_validations: HashMap<(Address, ValidatingWorkflow), PendingValidation>,
+    pub pending_validations: HashMap<PendingValidationKey, PendingValidation>,
 }
 
 impl From<&State> for NucleusStateSnapshot {

--- a/core/src/persister.rs
+++ b/core/src/persister.rs
@@ -40,7 +40,9 @@ impl PartialEq for SimplePersister {
 impl Persister for SimplePersister {
     fn save(&mut self, state: &State) -> Result<(), HolochainError> {
         let lock = &*self.storage.clone();
-        let mut store = lock.write().unwrap();
+        let mut store = lock
+            .try_write()
+            .map_err(|_| HolochainError::new("Could not get write lock on storage"))?;
         let agent_snapshot = AgentStateSnapshot::try_from(state)?;
         let nucleus_snapshot = NucleusStateSnapshot::from(state);
         store.add(&agent_snapshot)?;

--- a/core/src/scheduled_jobs/pending_validations.rs
+++ b/core/src/scheduled_jobs/pending_validations.rs
@@ -32,12 +32,10 @@ fn retry_validation(pending: PendingValidation, context: Arc<Context>) {
             ValidatingWorkflow::HoldLink => {
                 context.block_on(hold_link_workflow(&pending.entry_with_header, &context))
             }
-            ValidatingWorkflow::HoldEntry => {
-                context.block_on(hold_entry_workflow(
-                    &pending.entry_with_header,
-                    context.clone(),
-                ))
-            },
+            ValidatingWorkflow::HoldEntry => context.block_on(hold_entry_workflow(
+                &pending.entry_with_header,
+                context.clone(),
+            )),
         };
 
         if Err(HolochainError::ValidationPending) != result {

--- a/core/src/scheduled_jobs/pending_validations.rs
+++ b/core/src/scheduled_jobs/pending_validations.rs
@@ -9,7 +9,7 @@ use holochain_core_types::{
     error::error::HolochainError,
     json::JsonString,
 };
-use std::{sync::Arc, thread};
+use std::{fmt, sync::Arc, thread};
 
 pub type PendingValidation = Arc<PendingValidationStruct>;
 
@@ -17,6 +17,15 @@ pub type PendingValidation = Arc<PendingValidationStruct>;
 pub enum ValidatingWorkflow {
     HoldEntry,
     HoldLink,
+}
+
+impl fmt::Display for ValidatingWorkflow {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ValidatingWorkflow::HoldEntry => write!(f, "HoldEntryWorkflow"),
+            ValidatingWorkflow::HoldLink => write!(f, "HoldLinkWorkflow"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, DefaultJson)]

--- a/core/src/scheduled_jobs/pending_validations.rs
+++ b/core/src/scheduled_jobs/pending_validations.rs
@@ -66,11 +66,11 @@ pub fn run_pending_validations(context: Arc<Context>) {
         .clone();
 
     pending_validations.iter().for_each(|(_, pending)| {
-        context.log(dbg!(format!(
+        context.log(format!(
             "debug/scheduled_jobs/run_pending_validations: found pending validation for {}: {}",
             pending.entry_with_header.entry.entry_type(),
             pending.entry_with_header.entry.address()
-        )));
+        ));
         retry_validation(pending.clone(), context.clone());
     });
 }

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -36,7 +36,7 @@ pub async fn hold_entry_workflow<'a>(
             );
             HolochainError::ValidationPending
         })?;
-    let validation_package = maybe_validation_package.ok_or_else(|| {
+    let validation_package = maybe_validation_package.ok_or({
         let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_entry: {}", message));
         add_pending_validation(

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -9,6 +9,7 @@ use crate::{
     },
 };
 
+use crate::scheduled_jobs::pending_validations::ValidatingWorkflow;
 use holochain_core_types::{
     error::HolochainError,
     validation::{EntryAction, EntryLifecycle, ValidationData},
@@ -27,7 +28,12 @@ pub async fn hold_entry_workflow<'a>(
             let message = "Could not get validation package from source! -> Add to pending...";
             context.log(format!("debug/workflow/hold_entry: {}", message));
             context.log(format!("debug/workflow/hold_entry: Error was: {:?}", err));
-            add_pending_validation(entry_with_header.to_owned(), Vec::new(), &context);
+            add_pending_validation(
+                entry_with_header.to_owned(),
+                Vec::new(),
+                ValidatingWorkflow::HoldEntry,
+                &context,
+            );
             HolochainError::ValidationPending
         })?;
     let validation_package = maybe_validation_package.ok_or({

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -37,9 +37,15 @@ pub async fn hold_entry_workflow<'a>(
             HolochainError::ValidationPending
         })?;
     let validation_package = maybe_validation_package.ok_or({
-        let message = "Source did respond to request but did not deliver validation package! This is weird! Entry is not valid!";
+        let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_entry: {}", message));
-        HolochainError::ValidationFailed("Entry not backed by source".to_string())
+        add_pending_validation(
+            entry_with_header.to_owned(),
+            Vec::new(),
+            ValidatingWorkflow::HoldEntry,
+            &context,
+        );
+        HolochainError::ValidationPending
     })?;
     context.log(format!("debug/workflow/hold_entry: got validation package"));
 

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -36,7 +36,7 @@ pub async fn hold_entry_workflow<'a>(
             );
             HolochainError::ValidationPending
         })?;
-    let validation_package = maybe_validation_package.ok_or({
+    let validation_package = maybe_validation_package.ok_or_else(|| {
         let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_entry: {}", message));
         add_pending_validation(

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -26,7 +26,6 @@ pub async fn hold_link_workflow<'a>(
 ) -> Result<(), HolochainError> {
     let EntryWithHeader { entry, header } = &entry_with_header;
 
-    println!("HOLD LINK 1");
     let link_add = match entry {
         Entry::LinkAdd(link_add) => link_add,
         _ => Err(HolochainError::ErrorGeneric(
@@ -35,7 +34,6 @@ pub async fn hold_link_workflow<'a>(
     };
     let link = link_add.link().clone();
 
-    println!("HOLD LINK 2");
     context.log(format!("debug/workflow/hold_link: {:?}", link));
     // 1. Get validation package from source
     context.log(format!(
@@ -54,7 +52,6 @@ pub async fn hold_link_workflow<'a>(
             );
             HolochainError::ValidationPending
         })?;
-    println!("HOLD LINK 3");
     let validation_package = maybe_validation_package.ok_or({
         let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_link: {}", message));
@@ -68,15 +65,12 @@ pub async fn hold_link_workflow<'a>(
     })?;
     context.log(format!("debug/workflow/hold_link: got validation package"));
 
-    println!("HOLD LINK 4");
     // 2. Create validation data struct
     let validation_data = ValidationData {
         package: validation_package,
         lifecycle: EntryLifecycle::Meta,
         action: EntryAction::Create,
     };
-
-    println!("HOLD LINK 5");
 
     // 3. Validate the entry
     context.log(format!("debug/workflow/hold_link: validate..."));
@@ -94,7 +88,6 @@ pub async fn hold_link_workflow<'a>(
     })?;
     context.log(format!("debug/workflow/hold_link: is valid!"));
 
-    println!("HOLD LINK 6");
     // 3. If valid store the entry in the local DHT shard
     await!(add_link(&link, &context))?;
     context.log(format!("debug/workflow/hold_link: added! {:?}", link));

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -26,6 +26,7 @@ pub async fn hold_link_workflow<'a>(
 ) -> Result<(), HolochainError> {
     let EntryWithHeader { entry, header } = &entry_with_header;
 
+    println!("HOLD LINK 1");
     let link_add = match entry {
         Entry::LinkAdd(link_add) => link_add,
         _ => Err(HolochainError::ErrorGeneric(
@@ -34,6 +35,7 @@ pub async fn hold_link_workflow<'a>(
     };
     let link = link_add.link().clone();
 
+    println!("HOLD LINK 2");
     context.log(format!("debug/workflow/hold_link: {:?}", link));
     // 1. Get validation package from source
     context.log(format!(
@@ -52,6 +54,7 @@ pub async fn hold_link_workflow<'a>(
             );
             HolochainError::ValidationPending
         })?;
+    println!("HOLD LINK 3");
     let validation_package = maybe_validation_package.ok_or({
         let message = "Source did respond to request but did not deliver validation package! This is weird! Entry is not valid!";
         context.log(format!("debug/workflow/hold_link: {}", message));
@@ -59,12 +62,15 @@ pub async fn hold_link_workflow<'a>(
     })?;
     context.log(format!("debug/workflow/hold_link: got validation package"));
 
+    println!("HOLD LINK 4");
     // 2. Create validation data struct
     let validation_data = ValidationData {
         package: validation_package,
         lifecycle: EntryLifecycle::Meta,
         action: EntryAction::Create,
     };
+
+    println!("HOLD LINK 5");
 
     // 3. Validate the entry
     context.log(format!("debug/workflow/hold_link: validate..."));
@@ -82,6 +88,7 @@ pub async fn hold_link_workflow<'a>(
     })?;
     context.log(format!("debug/workflow/hold_link: is valid!"));
 
+    println!("HOLD LINK 6");
     // 3. If valid store the entry in the local DHT shard
     await!(add_link(&link, &context))?;
     context.log(format!("debug/workflow/hold_link: added! {:?}", link));

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -52,7 +52,7 @@ pub async fn hold_link_workflow<'a>(
             );
             HolochainError::ValidationPending
         })?;
-    let validation_package = maybe_validation_package.ok_or_else(|| {
+    let validation_package = maybe_validation_package.ok_or({
         let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_link: {}", message));
         add_pending_validation(

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -56,9 +56,15 @@ pub async fn hold_link_workflow<'a>(
         })?;
     println!("HOLD LINK 3");
     let validation_package = maybe_validation_package.ok_or({
-        let message = "Source did respond to request but did not deliver validation package! This is weird! Entry is not valid!";
+        let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_link: {}", message));
-        HolochainError::ValidationFailed("Entry not backed by source".to_string())
+        add_pending_validation(
+            entry_with_header.to_owned(),
+            Vec::new(),
+            ValidatingWorkflow::HoldLink,
+            &context,
+        );
+        HolochainError::ValidationPending
     })?;
     context.log(format!("debug/workflow/hold_link: got validation package"));
 

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -52,7 +52,7 @@ pub async fn hold_link_workflow<'a>(
             );
             HolochainError::ValidationPending
         })?;
-    let validation_package = maybe_validation_package.ok_or({
+    let validation_package = maybe_validation_package.ok_or_else(|| {
         let message = "Source did respond to request but did not deliver validation package! (Empty response) This is weird! Let's try this again later -> Add to pending";
         context.log(format!("debug/workflow/hold_link: {}", message));
         add_pending_validation(

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -7,8 +7,11 @@ use crate::{
     nucleus::validation::validate_entry,
 };
 
-use crate::nucleus::{
-    actions::add_pending_validation::add_pending_validation, validation::ValidationError,
+use crate::{
+    nucleus::{
+        actions::add_pending_validation::add_pending_validation, validation::ValidationError,
+    },
+    scheduled_jobs::pending_validations::ValidatingWorkflow,
 };
 use holochain_core_types::{
     entry::Entry,
@@ -41,7 +44,12 @@ pub async fn hold_link_workflow<'a>(
             let message = "Could not get validation package from source! -> Add to pending...";
             context.log(format!("debug/workflow/hold_link: {}", message));
             context.log(format!("debug/workflow/hold_link: Error was: {:?}", err));
-            add_pending_validation(entry_with_header.to_owned(), Vec::new(), context);
+            add_pending_validation(
+                entry_with_header.to_owned(),
+                Vec::new(),
+                ValidatingWorkflow::HoldLink,
+                context,
+            );
             HolochainError::ValidationPending
         })?;
     let validation_package = maybe_validation_package.ok_or({
@@ -63,7 +71,12 @@ pub async fn hold_link_workflow<'a>(
     await!(validate_entry(entry.clone(), validation_data, &context)).map_err(|err| {
         context.log(format!("debug/workflow/hold_link: invalid! {:?}", err));
         if let ValidationError::UnresolvedDependencies(dependencies) = &err {
-            add_pending_validation(entry_with_header.to_owned(), dependencies.clone(), &context);
+            add_pending_validation(
+                entry_with_header.to_owned(),
+                dependencies.clone(),
+                ValidatingWorkflow::HoldLink,
+                &context,
+            );
         }
         HolochainError::ValidationPending
     })?;

--- a/core_types_derive/src/lib.rs
+++ b/core_types_derive/src/lib.rs
@@ -17,7 +17,10 @@ fn impl_default_json_macro(ast: &syn::DeriveInput) -> TokenStream {
             fn from(v: &#name) -> JsonString {
                 match ::serde_json::to_string(v) {
                     Ok(s) => Ok(JsonString::from(s)),
-                    Err(e) => Err(HolochainError::SerializationError(e.to_string())),
+                    Err(e) => {
+                        println!("Error serializing to JSON: {:?}", e);
+                        Err(HolochainError::SerializationError(e.to_string()))
+                    },
                 }.expect(&format!("could not Jsonify {}: {:?}", stringify!(#name), v))
             }
         }

--- a/core_types_derive/src/lib.rs
+++ b/core_types_derive/src/lib.rs
@@ -18,7 +18,7 @@ fn impl_default_json_macro(ast: &syn::DeriveInput) -> TokenStream {
                 match ::serde_json::to_string(v) {
                     Ok(s) => Ok(JsonString::from(s)),
                     Err(e) => {
-                        println!("Error serializing to JSON: {:?}", e);
+                        eprintln!("Error serializing to JSON: {:?}", e);
                         Err(HolochainError::SerializationError(e.to_string()))
                     },
                 }.expect(&format!("could not Jsonify {}: {:?}", stringify!(#name), v))

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -231,8 +231,9 @@ impl Waiter {
 
                     (Some(checker), Action::AddPendingValidation(pending)) => {
                         let address = pending.entry_with_header.entry.address();
+                        let workflow = pending.workflow.clone();
                         checker.add(1, move |aw| {
-                            *aw.action() == Action::RemovePendingValidation(address.clone())
+                            *aw.action() == Action::RemovePendingValidation((address.clone(), workflow.clone()))
                         });
                     }
 

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -183,17 +183,21 @@ impl Waiter {
                         // TODO: is there a possiblity that this can get messed up if the same
                         // entry is committed multiple times?
                         let committed_entry_clone = committed_entry.clone();
-                        checker.add(num_instances, move |aw| match aw.action() {
-                            Action::Hold(EntryWithHeader { entry, header: _ }) => {
-                                *entry == committed_entry_clone
+                        checker.add(num_instances, move |aw| {
+                            println!("WAITER: Action::Commit -> Action::Hold");
+                            match aw.action() {
+                                Action::Hold(EntryWithHeader { entry, header: _ }) => {
+                                    *entry == committed_entry_clone
+                                }
+                                _ => false,
                             }
-                            _ => false,
                         });
 
                         match committed_entry.clone() {
                             Entry::App(_, _) => {
                                 if link_update_delete.is_some() {
                                     checker.add(num_instances, move |aw| {
+                                        println!("WAITER: Entry::LinkRemove -> Action::RemoveLink");
                                         *aw.action()
                                             == Action::UpdateEntry((
                                                 link_update_delete.clone().expect(
@@ -206,6 +210,7 @@ impl Waiter {
                             }
                             Entry::Deletion(deletion_entry) => {
                                 checker.add(num_instances, move |aw| {
+                                    println!("WAITER: Entry::Deletion -> Action::RemoveEntry");
                                     *aw.action()
                                         == Action::RemoveEntry((
                                             deletion_entry.clone().deleted_entry_address(),
@@ -216,11 +221,13 @@ impl Waiter {
 
                             Entry::LinkAdd(link_add) => {
                                 checker.add(num_instances, move |aw| {
+                                    println!("WAITER: Entry::LinkAdd -> Action::AddLink");
                                     *aw.action() == Action::AddLink(link_add.clone().link().clone())
                                 });
                             }
                             Entry::LinkRemove(link_remove) => {
                                 checker.add(num_instances, move |aw| {
+                                    println!("WAITER: Entry::LinkRemove -> Action::RemoveLink");
                                     *aw.action()
                                         == Action::RemoveLink(link_remove.clone().link().clone())
                                 });
@@ -233,6 +240,7 @@ impl Waiter {
                         let address = pending.entry_with_header.entry.address();
                         let workflow = pending.workflow.clone();
                         checker.add(1, move |aw| {
+                            println!("WAITER: Action::AddPendingValidation -> Action::RemovePendingValidation");
                             *aw.action()
                                 == Action::RemovePendingValidation((
                                     address.clone(),

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -233,7 +233,11 @@ impl Waiter {
                         let address = pending.entry_with_header.entry.address();
                         let workflow = pending.workflow.clone();
                         checker.add(1, move |aw| {
-                            *aw.action() == Action::RemovePendingValidation((address.clone(), workflow.clone()))
+                            *aw.action()
+                                == Action::RemovePendingValidation((
+                                    address.clone(),
+                                    workflow.clone(),
+                                ))
                         });
                     }
 


### PR DESCRIPTION
- [ ] I have added a summary of my changes to the changelog
 *-> No, fix for feature that is introduced in next version.*

# Fix for blocking dead-locks in HoloFuel integration tests
The reason the tests were blocking was that the Pending Validations feature was not working correctly in all cases, but the waiter correctly waits for all nodes in the test scenario to have received and validated all entries. 

## Problem in Detail
There was no differentiation between:
* storing an `Entry::LinkAdd` as an entry itself in the DHT, and
* updating the meta information of the link's base entry.

Both cases resulted in calling `hold_link` which only works in the second case.

## Solution
With these changes the pending validation `HashMap` includes the workflow that added the entry so the worker thread now knows which kind of workflow to run when retrying validation.

----

Furthermore, receiving an empty response when requesting the validation package from source was treated as validation failure. This lead to another reason for blocking. Now, receiving an empty response also adds the entry to the pending list which fixes the last remaining waiter dead-locks.