### PR TITLE
Ensure build of libsodium/rust_sodium-sys is documented in Makefile and works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ clean: ${C_BINDING_CLEAN}
 	@$(RM) -rf app_spec/dist
 	@for cargo in $$( find . -name 'Cargo.toml' ); do \
 	    echo -e "\033[0;93m## 'cargo clean' in $${cargo%/*} ##\033[0m"; \
-	    ( cd $${cargo%/*} && cargo clean ); \
+	    ( cd $${cargo%/*} && $(CARGO) clean ); \
 	done
 
 # clean up the extraneous "C" binding test files

--- a/Makefile
+++ b/Makefile
@@ -221,13 +221,13 @@ wasm_build: ensure_wasm_target
 
 .PHONY: build_holochain libsodium_version
 libsodium_version:
-	@[ ! -z "$$RUST_SODIUM_LIB_DIR" ] \
-	    && echo -e "\033[0;93m## Building rust_sodium-sys -- with system libsodium: $(RUST_SODIUM_LIB) ##\033[0m" \
-	    || ( [ ! -z "$$RUST_SODIUM_USE_PKG_CONFIG" ] \
+	@[ ! -z "$${RUST_SODIUM_LIB_DIR+defined}" ] \
+	    && echo -e "\033[0;93m## Building rust_sodium-sys -- with system libsodium \"$(RUST_SODIUM_LIB)\" in: $${RUST_SODIUM_LIB_DIR:-(unknown)}) ##\033[0m" \
+	    || ( [ ! -z "$${RUST_SODIUM_USE_PKG_CONFIG+defined}" ] \
 		&& echo -e "\033[0;93m## Building rust_sodium-sys -- with pkg_config libsodium ##\033[0m" \
 		|| ( echo -e "\033[0;93m## Building rust_sodium-sys -- with download/build libsodium ##\033[0m" ))
 	@$(CARGO) build --manifest-path rust_sodium-sys/Cargo.toml \
-	    || echo -e "\031[0;93m##  *** Building rust_sodium-sys failed: Ensure libsodium version 1.0.12+ is installed ##\031[0m" \
+	    || echo -e "\033[0;91m##  *** Building rust_sodium-sys failed: Ensure libsodium version 1.0.12+ is installed ##\033[0m" \
 
 build_holochain: core_toolchain wasm_build libsodium_version
 	@echo -e "\033[0;93m## Building holochain... ##\033[0m"

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,12 @@ export RUST_BACKTRACE=1
 # There are 3 methods to obtain the libsodium encryption library required by holochain-rust,
 # selectable by setting/clearing various RUST_SODIUM_...  environment variables (see:
 # https://github.com/maidsafe/rust_sodium).  These selections are implemented and enforced in
-# rust_sodium-sys/build.rs
+# rust_sodium-sys/build.rs.  The default is to download/compile libsodium 1.0.17 (06-Jan-2019).
+
+# 0) DEFAULT: Downloaded/compiled by holochain-rust build: select by clearing RUST_SODIUM_LIB_DIR
+# and RUST_SODIUM_USE_PKG_CONFIG.  Some systems require libsodium to be configured and built with
+# `--disable-pie`; select this here by setting RUST_SODIUM_DISABLE_PIE.
+#export RUST_SODIUM_DISABLE_PIE=1
 
 # 1) System installed: select by setting RUST_SODIUM_LIB_DIR. We need to find the location of the
 # system's libsodium dynamic library: at least version 1.0.12 is required.  On Mac, `brew install
@@ -46,17 +51,12 @@ export RUST_BACKTRACE=1
 # add `buster` to /etc/apt/sources...), or Debian Buster (testing, libsodium 1.0.17): `apt-get -t
 # buster -u install libsodium-dev`.  On other Linux distros, ensure at least libsodium 1.0.12+ is
 # installed.
-RUST_SODIUM_LIB=$(shell find /usr/local/lib /usr/lib /lib -name 'libsodium.so' -o -name 'libsodium.dylib' | head -1)
-export RUST_SODIUM_LIB_DIR=$(dir $(RUST_SODIUM_LIB))
-export RUST_SODIUM_SHARED=1
+#RUST_SODIUM_LIB=$(shell find /usr/local/lib /usr/lib /lib -name 'libsodium.so' -o -name 'libsodium.dylib' | head -1)
+#export RUST_SODIUM_LIB_DIR=$(dir $(RUST_SODIUM_LIB))
+#export RUST_SODIUM_SHARED=1
 
 # 2) Rust `pkg_config::probe_library`-detected: select by setting RUST_SODIUM_USE_PKG_CONFIG.
 #export RUST_SODIUM_USE_PKG_CONFIG=1
-
-# 3) Downloaded/compiled by holochain-rust build: select by clearing RUST_SODIUM_LIB_DIR and
-# RUST_SODIUM_USE_PKG_CONFIG.  Some systems require libsodium to be configured and built with
-# `--disable-pie`; select this here by setting RUST_SODIUM_DISABLE_PIE.
-#export RUST_SODIUM_DISABLE_PIE=1
 
 # list all the "C" binding tests that have been written
 C_BINDING_DIRS = $(sort $(dir $(wildcard c_binding_tests/*/)))

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,43 @@ help:
 	@echo "run 'make install_cli' to build and install the command line tool builds"
 	@echo "run 'make test-something' to run cargo tests matching 'something'"
 
+# We use bash features in some of our Makefile shell scripting
 SHELL = /bin/bash
+
+# The Rust versions required for Holochain development, and the required cargo options are configured here:
 CORE_RUST_VERSION ?= nightly-2019-01-24
 TOOLS_RUST_VERSION ?= nightly-2019-01-24
-CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(CORE_RUST_VERSION) cargo $(CARGO_ARGS)
-CARGO_TOOLS = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(TOOLS_RUST_VERSION) cargo $(CARGO_ARGS)
-CARGO_TARPULIN_INSTALL = RUSTFLAGS="--cfg procmacro2_semver_exempt -D warnings" RUST_BACKTRACE=1 cargo $(CARGO_ARGS) +$(CORE_RUST_VERSION)
+CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" rustup run $(CORE_RUST_VERSION) cargo -Z config-profile $(CARGO_ARGS)
+CARGO_TOOLS = RUSTFLAGS="-Z external-macro-backtrace -D warnings" rustup run $(TOOLS_RUST_VERSION) cargo -Z config-profile $(CARGO_ARGS)
+CARGO_TARPULIN_INSTALL = RUSTFLAGS="--cfg procmacro2_semver_exempt -D warnings" cargo -Z config-profile $(CARGO_ARGS) +$(CORE_RUST_VERSION)
+
+# All rustup and cargo invocations executed (directly in this Makefile, or indirectly eg. via npm)
+# must include these environment variables.  If we'd like to see Rust back-traces:
+export RUST_BACKTRACE=1
+
+# There are 3 methods to obtain the libsodium encryption library required by holochain-rust,
+# selectable by setting/clearing various RUST_SODIUM_...  environment variables (see:
+# https://github.com/maidsafe/rust_sodium).  These selections are implemented and enforced in
+# rust_sodium-sys/build.rs
+
+# 1) System installed: select by setting RUST_SODIUM_LIB_DIR. We need to find the location of the
+# system's libsodium dynamic library: at least version 1.0.12 is required.  On Mac, `brew install
+# libsodium`.  On Ubuntu Bionic (libsodium 1.0.16), Consmic (libsodium 1.0.16) and Disco (libsodium
+# 1.0.17): `apt-get install libsodium-dev`.  On Debian Stretch (stable, libsodium 1.0.11 *to old*,
+# add `buster` to /etc/apt/sources...), or Debian Buster (testing, libsodium 1.0.17): `apt-get -t
+# buster -u install libsodium-dev`.  On other Linux distros, ensure at least libsodium 1.0.12+ is
+# installed.
+RUST_SODIUM_LIB=$(shell find /usr/local/lib /usr/lib /lib -name 'libsodium.so' -o -name 'libsodium.dylib' | head -1)
+export RUST_SODIUM_LIB_DIR=$(dir $(RUST_SODIUM_LIB))
+export RUST_SODIUM_SHARED=1
+
+# 2) Rust `pkg_config::probe_library`-detected: select by setting RUST_SODIUM_USE_PKG_CONFIG.
+#export RUST_SODIUM_USE_PKG_CONFIG=1
+
+# 3) Downloaded/compiled by holochain-rust build: select by clearing RUST_SODIUM_LIB_DIR and
+# RUST_SODIUM_USE_PKG_CONFIG.  Some systems require libsodium to be configured and built with
+# `--disable-pie`; select this here by setting RUST_SODIUM_DISABLE_PIE.
+#export RUST_SODIUM_DISABLE_PIE=1
 
 # list all the "C" binding tests that have been written
 C_BINDING_DIRS = $(sort $(dir $(wildcard c_binding_tests/*/)))
@@ -187,8 +218,18 @@ wasm_build: ensure_wasm_target
 	cd hdk-rust/wasm-test && $(CARGO) build --release --target wasm32-unknown-unknown
 	cd wasm_utils/wasm-test/integration-test && $(CARGO) build --release --target wasm32-unknown-unknown
 
-.PHONY: build_holochain
-build_holochain: core_toolchain wasm_build
+
+.PHONY: build_holochain libsodium_version
+libsodium_version:
+	@[ ! -z "$$RUST_SODIUM_LIB_DIR" ] \
+	    && echo -e "\033[0;93m## Building rust_sodium-sys -- with system libsodium: $(RUST_SODIUM_LIB) ##\033[0m" \
+	    || ( [ ! -z "$$RUST_SODIUM_USE_PKG_CONFIG" ] \
+		&& echo -e "\033[0;93m## Building rust_sodium-sys -- with pkg_config libsodium ##\033[0m" \
+		|| ( echo -e "\033[0;93m## Building rust_sodium-sys -- with download/build libsodium ##\033[0m" ))
+	@$(CARGO) build --manifest-path rust_sodium-sys/Cargo.toml \
+	    || echo -e "\031[0;93m##  *** Building rust_sodium-sys failed: Ensure libsodium version 1.0.12+ is installed ##\031[0m" \
+
+build_holochain: core_toolchain wasm_build libsodium_version
 	@echo -e "\033[0;93m## Building holochain... ##\033[0m"
 	$(CARGO) build --all --exclude hc
 

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -64,6 +64,10 @@ fn main() {
             );
         }
     } else {
+        println!(
+            "cargo:warning=Downloading/building libsodium version {} from {}.",
+            VERSION, DOWNLOAD_BASE_URL
+        );
         get_libsodium();
     }
 }
@@ -350,7 +354,7 @@ fn get_libsodium() {
     if !cflags.is_empty() {
         configure_cmd.env("CFLAGS", &cflags);
     }
-    println!("cargo:warning=libsodium CFLAGS used: {}", cflags);
+    //println!("cargo:warning=libsodium CFLAGS used: {}", cflags);
     println!("cargo:rerun-if-env-changed=RUST_SODIUM_DISABLE_PIE");
     if env::var("RUST_SODIUM_DISABLE_PIE").is_ok() {
         configure_cmd.arg("--disable-pie");

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -21,16 +21,16 @@ use sha2::{Digest, Sha256};
 use std::{env, fs, io::Cursor, path::Path};
 
 const DOWNLOAD_BASE_URL: &'static str = "https://download.libsodium.org/libsodium/releases/";
-const VERSION: &'static str = "1.0.16";
-
+const VERSION: &'static str = "1.0.17";
+    
 #[cfg(target_env = "msvc")] // libsodium-<VERSION>-msvc.zip
-const SHA256: &'static str = "0580d54f57594a7cb493607cec6e7045369fb67d43623491523781e901589948";
+const SHA256: &'static str = "d0ccc129253d0d51f09f8d030129041eb56fc3f488a0206babff2ef0b1752368";
 
 #[cfg(all(windows, not(target_env = "msvc")))] // libsodium-<VERSION>-mingw.tar.gz
-const SHA256: &'static str = "5b81a4fc5d0de36dbda7efeaf355c133d4f6cc0b4dbf69bbe46ef7f5a6baa639";
+const SHA256: &'static str = "3c76ab4a5033b03503331314b2f289361171d7fbbfd98886751dd7f8a8a6496f";
 
 #[cfg(not(windows))] // libsodium-<VERSION>.tar.gz
-const SHA256: &'static str = "eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533";
+const SHA256: &'static str = "0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1";
 
 fn main() {
     println!("cargo:rerun-if-env-changed=RUST_SODIUM_LIB_DIR");
@@ -357,6 +357,7 @@ fn get_libsodium() {
     //println!("cargo:warning=libsodium CFLAGS used: {}", cflags);
     println!("cargo:rerun-if-env-changed=RUST_SODIUM_DISABLE_PIE");
     if env::var("RUST_SODIUM_DISABLE_PIE").is_ok() {
+        println!("cargo:warning=libsodium --disable-pie used");
         configure_cmd.arg("--disable-pie");
     }
     let configure_output = configure_cmd

--- a/rust_sodium-sys/build.rs
+++ b/rust_sodium-sys/build.rs
@@ -354,7 +354,7 @@ fn get_libsodium() {
     if !cflags.is_empty() {
         configure_cmd.env("CFLAGS", &cflags);
     }
-    //println!("cargo:warning=libsodium CFLAGS used: {}", cflags);
+    println!("cargo:warning=libsodium CFLAGS used: {}", cflags);
     println!("cargo:rerun-if-env-changed=RUST_SODIUM_DISABLE_PIE");
     if env::var("RUST_SODIUM_DISABLE_PIE").is_ok() {
         println!("cargo:warning=libsodium --disable-pie used");

--- a/shell.nix
+++ b/shell.nix
@@ -83,13 +83,13 @@ let
 
 in
 with nixpkgs;
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   name = "holochain-rust-environment";
 
   buildInputs = [
 
     # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md
-    binutils gcc gnumake openssl pkgconfig coreutils
+    binutils gcc8 gnumake openssl pkgconfig coreutils
 
     cmake
     python


### PR DESCRIPTION
Presently, building libsodium and linking against the result fails on important linux platforms (eg. Debian), and it is not clear in the Makefile or elsewhere how to fix the issues.  I've added some documentation to the Makefile to assist the developer in overcoming this obstacle.

* Detail how to select system/pkg_config/download build approach for libsodium in the Makefile
* Logs the selected libsodium version and/or build approach and builds rust_sodium-sys
  as a separate target, to isolate failures.
* Remove an unnecessary logging of CFLAGS used to build libsodium, but add
  logging of selected libsodium build choice.

By default, we'll download/build our pinned libsodium version, and try to log alternatives for the user if it fails (but this failure is not always detectable, because it builds fine but fails in the later linking stage).

- [ ] I have added a summary of my changes to the changelog
