### PR TITLE
0.0.6 merge: Compare hashes before installing DNA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - get_as_type - Similar but for a single entry
   - link_entries_bidir - Same as link_entries but creates link in both directions
   - commit_and_link - Save a line and commit and link in a single function
+- The `admin/dna/install_from_file` RPC method now takes an optional `expected_hash`, which performs an integrity check of the DNA file before installing it in the conductor [PR#1093](https://github.com/holochain/holochain-rust/pull/1093).
 
 ### Fixed
 - Validation of link entries gets retried now if base or target of the link were not yet accessible on the validating node. This fixes a bug where links have been invalid due to network timing issues [PR#1054](https://github.com/holochain/holochain-rust/pull/1054).

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -6,7 +6,9 @@ use crate::{
     },
     error::HolochainInstanceError,
 };
-use holochain_core_types::{cas::content::AddressableContent, error::HolochainError};
+use holochain_core_types::{
+    cas::content::AddressableContent, error::HolochainError, hash::HashString,
+};
 use json_patch;
 use std::{fs, path::PathBuf, sync::Arc};
 
@@ -16,6 +18,7 @@ pub trait ConductorAdmin {
         path: PathBuf,
         id: String,
         copy: bool,
+        expected_hash: Option<HashString>,
         properties: Option<&serde_json::Value>,
     ) -> Result<(), HolochainError>;
     fn uninstall_dna(&mut self, id: &String) -> Result<(), HolochainError>;
@@ -65,6 +68,7 @@ impl ConductorAdmin for Conductor {
         path: PathBuf,
         id: String,
         copy: bool,
+        expected_hash: Option<HashString>,
         properties: Option<&serde_json::Value>,
     ) -> Result<(), HolochainError> {
         let path_string = path
@@ -78,6 +82,12 @@ impl ConductorAdmin for Conductor {
                     e.to_string()
                 ))
             })?;
+
+        if let Some(hash) = expected_hash {
+            if dna.address() != hash {
+                return Err(HolochainError::DnaHashMismatch(dna.address(), hash));
+            }
+        }
 
         if let Some(props) = properties {
             if !copy {
@@ -673,6 +683,7 @@ pattern = '.*'"#
                 new_dna_path.clone(),
                 String::from("new-dna"),
                 false,
+                None,
                 None
             ),
             Ok(()),
@@ -741,6 +752,7 @@ id = 'new-dna'"#,
                 new_dna_path.clone(),
                 String::from("new-dna"),
                 true,
+                None,
                 None
             ),
             Ok(()),
@@ -780,6 +792,40 @@ id = 'new-dna'"#,
     }
 
     #[test]
+    fn test_install_dna_with_expected_hash() {
+        let test_name = "test_install_dna_with_expected_hash";
+        let mut conductor = create_test_conductor(test_name, 3000);
+        let mut new_dna_path = PathBuf::new();
+        new_dna_path.push("new-dna.dna.json");
+        let dna = Arc::get_mut(&mut conductor.dna_loader).unwrap()(&new_dna_path).unwrap();
+
+        assert_eq!(
+            conductor.install_dna_from_file(
+                new_dna_path.clone(),
+                String::from("new-dna"),
+                false,
+                Some(dna.address()),
+                None
+            ),
+            Ok(()),
+        );
+
+        assert_eq!(
+            conductor.install_dna_from_file(
+                new_dna_path.clone(),
+                String::from("new-dna"),
+                false,
+                Some("wrong-address".into()),
+                None
+            ),
+            Err(HolochainError::DnaHashMismatch(
+                dna.address(),
+                "wrong-address".into()
+            )),
+        );
+    }
+
+    #[test]
     fn test_install_dna_from_file_with_properties() {
         let test_name = "test_install_dna_from_file_with_properties";
         let mut conductor = create_test_conductor(test_name, 3000);
@@ -793,6 +839,7 @@ id = 'new-dna'"#,
                 new_dna_path.clone(),
                 String::from("new-dna-with-props"),
                 false,
+                None,
                 Some(&new_props)
             ),
             Err(HolochainError::ConfigError(
@@ -805,6 +852,7 @@ id = 'new-dna'"#,
                 new_dna_path.clone(),
                 String::from("new-dna-with-props"),
                 true,
+                None,
                 Some(&new_props)
             ),
             Ok(()),
@@ -854,7 +902,13 @@ id = 'new-dna'"#,
         let mut new_dna_path = PathBuf::new();
         new_dna_path.push("new-dna.dna.json");
         conductor
-            .install_dna_from_file(new_dna_path.clone(), String::from("new-dna"), false, None)
+            .install_dna_from_file(
+                new_dna_path.clone(),
+                String::from("new-dna"),
+                false,
+                None,
+                None,
+            )
             .expect("Could not install DNA");
 
         let add_result = conductor.add_instance(

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -397,6 +397,7 @@ impl ConductorApiBuilder {
                     PathBuf::from(path),
                     id.to_string(),
                     copy,
+                    None,
                     properties
                 ))?;
                 Ok(json!({"success": true}))

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -392,12 +392,24 @@ impl ConductorApiBuilder {
                 let id = Self::get_as_string("id", &params_map)?;
                 let path = Self::get_as_string("path", &params_map)?;
                 let copy = Self::get_as_bool("copy", &params_map).unwrap_or(false);
+                let expected_hash = match params_map.get("expected_hash") {
+                    Some(value) => Some(
+                        value
+                            .as_str()
+                            .ok_or(jsonrpc_core::Error::invalid_params(format!(
+                                "`{}` is not a valid json string",
+                                &value
+                            )))?
+                            .into(),
+                    ),
+                    None => None,
+                };
                 let properties = params_map.get("properties");
                 conductor_call!(|c| c.install_dna_from_file(
                     PathBuf::from(path),
                     id.to_string(),
                     copy,
-                    None,
+                    expected_hash,
                     properties
                 ))?;
                 Ok(json!({"success": true}))

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -277,6 +277,7 @@ impl ConductorApiBuilder {
     ///     Params:
     ///     * `id`: [string] internal handle/name of the newly created DNA config
     ///     * `path`: [string] local file path to DNA file
+    ///     * `expected_hash`: [string] (optional) the hash of this DNA. If this does not match the actual hash, installation will fail.
     ///
     ///  * `admin/dna/uninstall`
     ///     Uninstalls a DNA from the conductor config. Recursively also removes (and stops)

--- a/core_types/src/error/error.rs
+++ b/core_types/src/error/error.rs
@@ -4,6 +4,7 @@ use crate::{
     json::*,
 };
 use futures::channel::oneshot::Canceled as FutureCanceled;
+use hash::HashString;
 use serde_json::Error as SerdeError;
 use std::{
     error::Error,
@@ -96,6 +97,7 @@ pub enum HolochainError {
     ConfigError(String),
     Timeout,
     InitializationFailed(String),
+    DnaHashMismatch(HashString, HashString),
 }
 
 pub type HcResult<T> = Result<T, HolochainError>;
@@ -127,6 +129,11 @@ impl fmt::Display for HolochainError {
             ConfigError(err_msg) => write!(f, "{}", err_msg),
             Timeout => write!(f, "timeout"),
             InitializationFailed(err_msg) => write!(f, "{}", err_msg),
+            DnaHashMismatch(hash1, hash2) => write!(
+                f,
+                "DNA hash does not match expected hash!\n{} != {}",
+                hash1, hash2
+            ),
         }
     }
 }

--- a/core_types/src/error/ribosome_error.rs
+++ b/core_types/src/error/ribosome_error.rs
@@ -197,6 +197,7 @@ impl From<HolochainError> for RibosomeErrorCode {
             HolochainError::ConfigError(_) => RibosomeErrorCode::Unspecified,
             HolochainError::Timeout => RibosomeErrorCode::Unspecified,
             HolochainError::InitializationFailed(_) => RibosomeErrorCode::Unspecified,
+            HolochainError::DnaHashMismatch(_, _) => RibosomeErrorCode::Unspecified,
         }
     }
 }


### PR DESCRIPTION
Adds optional `expected_hash` parameter to admin/dna/install_from_file, which will fail installation if the hash of the DNA produced from the file does not match expected hash. If `expected_hash` is not passed, the DNA will be installed with no hash check.

TODO: do the same for UI, although we need to decide how UIs should be reliably hashed first

- I propose this isn't necessary to put in the changelog