### PR TITLE
only run cold builds against develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,24 +139,32 @@ workflows:
 
  cold.ubuntu:
   jobs:
-   - cold.ubuntu.bionic
-      # filters:
-      #  branches:
-      #   only:
-      #    - develop
-   - cold.ubuntu.xenial
+   - cold.ubuntu.bionic:
+      filters:
+       branches:
+        only:
+         - develop
+   - cold.ubuntu.xenial:
+      filters:
+       branches:
+        only:
+         - develop
 
  cold.debian:
   jobs:
-   - cold.debian.stable
+   - cold.debian.stable:
+      filters:
+       branches:
+        only:
+         - develop
 
  cold.mac:
   jobs:
-   - cold.mac
-      # filters:
-      #  branches:
-      #   only:
-      #    - develop
+   - cold.mac:
+      filters:
+       branches:
+        only:
+         - develop
 
  dockers:
   # https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow


### PR DESCRIPTION
- [x] I have added a summary of my changes to the changelog

## changes

https://github.com/holochain/holochain-rust/pull/1105 disabled the branch filtering for cold builds for debugging

this adds branch filtering back in for cold builds (against develop only)