### PR TITLE
remove capabilities from minimal define_zome! documentation

### DIFF
--- a/doc/holochain_101/src/zome/define_zome.md
+++ b/doc/holochain_101/src/zome/define_zome.md
@@ -44,8 +44,6 @@ define_zome! {
     }
 
     functions: []
-
-    capabilitites: {}
 }
 ```
 


### PR DESCRIPTION
I'm assuming that the text below the code is correct and that `entries`, `genesis`, and `functions` are the three required properties

- [ ] I have added a summary of my changes to the changelog

I have not added anything to the changelog though I'm happy to do so if that's needed
