### PR TITLE
Remove an extraneous trailing `.`, which is included in copy/paste path

### DIFF
--- a/cli/src/cli/keygen.rs
+++ b/cli/src/cli/keygen.rs
@@ -44,7 +44,7 @@ pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>) -> DefaultResul
     println!("Succesfully created new agent keystore.");
     println!("");
     println!("Public address: {}", pub_key);
-    println!("Bundle written to: {}.", path.to_str().unwrap());
+    println!("Bundle written to: {}", path.to_str().unwrap());
     println!("");
     println!("You can set this file in a conductor config as keystore_file for an agent.");
     Ok(())


### PR DESCRIPTION
Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [ ] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] my changes to the code do not affect any exposed aspect of the developer experience
