### PR TITLE
Remove some voluminous logging of NodeJS WAITER actions

### DIFF
--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -184,7 +184,7 @@ impl Waiter {
                         // entry is committed multiple times?
                         let committed_entry_clone = committed_entry.clone();
                         checker.add(num_instances, move |aw| {
-                            println!("WAITER: Action::Commit -> Action::Hold");
+                            //println!("WAITER: Action::Commit -> Action::Hold");
                             match aw.action() {
                                 Action::Hold(EntryWithHeader { entry, header: _ }) => {
                                     *entry == committed_entry_clone
@@ -197,7 +197,7 @@ impl Waiter {
                             Entry::App(_, _) => {
                                 if link_update_delete.is_some() {
                                     checker.add(num_instances, move |aw| {
-                                        println!("WAITER: Entry::LinkRemove -> Action::RemoveLink");
+                                        //println!("WAITER: Entry::LinkRemove -> Action::RemoveLink");
                                         *aw.action()
                                             == Action::UpdateEntry((
                                                 link_update_delete.clone().expect(
@@ -210,7 +210,7 @@ impl Waiter {
                             }
                             Entry::Deletion(deletion_entry) => {
                                 checker.add(num_instances, move |aw| {
-                                    println!("WAITER: Entry::Deletion -> Action::RemoveEntry");
+                                    //println!("WAITER: Entry::Deletion -> Action::RemoveEntry");
                                     *aw.action()
                                         == Action::RemoveEntry((
                                             deletion_entry.clone().deleted_entry_address(),
@@ -221,13 +221,13 @@ impl Waiter {
 
                             Entry::LinkAdd(link_add) => {
                                 checker.add(num_instances, move |aw| {
-                                    println!("WAITER: Entry::LinkAdd -> Action::AddLink");
+                                    //println!("WAITER: Entry::LinkAdd -> Action::AddLink");
                                     *aw.action() == Action::AddLink(link_add.clone().link().clone())
                                 });
                             }
                             Entry::LinkRemove(link_remove) => {
                                 checker.add(num_instances, move |aw| {
-                                    println!("WAITER: Entry::LinkRemove -> Action::RemoveLink");
+                                    //println!("WAITER: Entry::LinkRemove -> Action::RemoveLink");
                                     *aw.action()
                                         == Action::RemoveLink(link_remove.clone().link().clone())
                                 });
@@ -240,7 +240,7 @@ impl Waiter {
                         let address = pending.entry_with_header.entry.address();
                         let workflow = pending.workflow.clone();
                         checker.add(1, move |aw| {
-                            println!("WAITER: Action::AddPendingValidation -> Action::RemovePendingValidation");
+                            //println!("WAITER: Action::AddPendingValidation -> Action::RemovePendingValidation");
                             *aw.action()
                                 == Action::RemovePendingValidation((
                                     address.clone(),


### PR DESCRIPTION
Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [ ] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] my changes to the code do not affect any exposed aspect of the developer experience
