### PR TITLE
one_time_sign now handles multiple payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Performance optimization: don't recalculate DNA hash during handling of every network message but instead cache the DNA hash. [PR#1163](https://github.com/holochain/holochain-rust/pull/1163)
+- One-time-signing now takes a vector of payloads, and returns a vector of signatures.
 
 ### Deprecated
 

--- a/core/src/nucleus/ribosome/api/keystore.rs
+++ b/core/src/nucleus/ribosome/api/keystore.rs
@@ -22,10 +22,11 @@ fn conductor_callback<S: Into<String>>(
 
     let handler = conductor_api.write().unwrap();
 
+    let method = method.into();
     let id = ProcessUniqueId::new();
     let request = format!(
         r#"{{"jsonrpc": "2.0", "method": "{}", "params": {}, "id": "{}"}}"#,
-        method.into(),
+        method,
         params.into(),
         id
     );
@@ -43,9 +44,10 @@ fn conductor_callback<S: Into<String>>(
         JsonRpc::Error(_) => Err(HolochainError::ErrorGeneric(
             serde_json::to_string(&response.get_error().unwrap()).unwrap(),
         )),
-        _ => Err(HolochainError::ErrorGeneric(
-            "sign_one_time call failed".to_string(),
-        )),
+        _ => Err(HolochainError::ErrorGeneric(format!(
+            "{} call failed",
+            method
+        ))),
     }
 }
 

--- a/core/src/nucleus/ribosome/api/sign.rs
+++ b/core/src/nucleus/ribosome/api/sign.rs
@@ -2,7 +2,7 @@ use crate::nucleus::ribosome::{api::ZomeApiResult, Runtime};
 use holochain_core_types::{error::HcResult, signature::Signature};
 use holochain_dpki::keypair::generate_random_sign_keypair;
 use holochain_sodium::secbuf::SecBuf;
-use holochain_wasm_utils::api_serialization::sign::{SignArgs, SignOneTimeResult};
+use holochain_wasm_utils::api_serialization::sign::{OneTimeSignArgs, SignArgs, SignOneTimeResult};
 use std::convert::TryFrom;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
@@ -48,33 +48,37 @@ pub fn invoke_sign_one_time(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeAp
     // deserialize args
     let args_str = runtime.load_json_string_from_args(&args);
 
-    let sign_args = match SignArgs::try_from(args_str.clone()) {
+    let sign_args = match OneTimeSignArgs::try_from(args_str.clone()) {
         Ok(sign_input) => sign_input,
         // Exit on error
         Err(err) => {
             context.log(format!(
-                "err/zome: invoke_sign_one_time failed to deserialize SignArgs: {:?} got err: {:?}",
+                "err/zome: invoke_sign_one_time failed to deserialize OneTimeSignArgs: {:?} got err: {:?}",
                 args_str, err
             ));
             return ribosome_error_code!(ArgumentDeserializationFailed);
         }
     };
 
-    runtime.store_result(sign_one_time(sign_args.payload))
+    runtime.store_result(sign_one_time(sign_args.payloads))
 }
 
 /// creates a one-time private key and sign data returning the signature and the public key
-pub fn sign_one_time(data: String) -> HcResult<SignOneTimeResult> {
-    let mut data_buf = SecBuf::with_insecure_from_string(data);
+pub fn sign_one_time(payloads: Vec<String>) -> HcResult<SignOneTimeResult> {
     let mut sign_keys = generate_random_sign_keypair()?;
+    let mut signatures = Vec::new();
+    for data in payloads {
+        let mut data_buf = SecBuf::with_insecure_from_string(data);
 
-    let mut signature_buf = sign_keys.sign(&mut data_buf)?;
-    let buf = signature_buf.read_lock();
-    // Return as base64 encoded string
-    let signature_str = base64::encode(&**buf);
+        let mut signature_buf = sign_keys.sign(&mut data_buf)?;
+        let buf = signature_buf.read_lock();
+        // Return as base64 encoded string
+        let signature_str = base64::encode(&**buf);
+        signatures.push(Signature::from(signature_str))
+    }
     Ok(SignOneTimeResult {
         pub_key: sign_keys.public,
-        signature: Signature::from(signature_str),
+        signatures,
     })
 }
 
@@ -101,15 +105,26 @@ mod test_super {
     #[test]
     fn test_sign_one_time() {
         let data = base64::encode("the data to sign");
-        let result = sign_one_time(data.clone());
+        let more_data = base64::encode("more data to sign");
+        let result = sign_one_time(vec![data.clone(), more_data.clone()]);
         assert!(!result.is_err());
 
         let result = result.unwrap();
 
-        assert_eq!(String::from(result.signature.clone()).len(), 88); //88 is the size of a base64ized signature buf
+        assert_eq!(result.signatures.len(), 2);
 
-        let result = verify(Address::from(result.pub_key), data, result.signature);
-        assert!(!result.is_err());
-        assert!(result.unwrap());
+        let sig1 = result.signatures[0].clone();
+        let sig2 = result.signatures[1].clone();
+
+        let source = Address::from(result.pub_key);
+        let vresult = verify(source.clone(), data, sig1.clone());
+        assert!(!vresult.is_err());
+        assert!(vresult.unwrap());
+
+        let vresult = verify(source, more_data, sig2.clone());
+        assert!(!vresult.is_err());
+        assert!(vresult.unwrap());
+
+        assert_ne!(sig1, sig2);
     }
 }

--- a/doc/holochain_101/src/zome/crypto.md
+++ b/doc/holochain_101/src/zome/crypto.md
@@ -18,5 +18,5 @@ Here are the available functions:
 - `keystore_derive_key(src_id,dst_id,key_type)`-> derives a key (signing or encrypting) to be identified by `dst_id` from a previously created seed identified by `src_id`.  This function returns the public key of the keypair.
 - `keystore_sign(src_id,payload)` -> returns a signature of the payload as signed by the key identified by `src_id`
 - `sign(payload)` -> signs the payload using the DNA's instance agent ID public key.  This is a convenience function which is equivalent to calling `keystore_sign("primary_keybundle:sign_key",payload)`
-- `sign-one-time(payload)` -> signs the payload with a randomly generated key-pair, returning the signature and the public key of the key-pair after shredding the private-key.
+- `sign_one_time(payload_list)` -> signs the payloads with a randomly generated key-pair, returning the signatures and the public key of the key-pair after shredding the private-key.
 - `verify_signature(provenance, payload)` -> verifies that the `payload` matches the `provenance` which is a public key/signature pair.

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -24,7 +24,7 @@ use holochain_wasm_utils::{
         },
         link_entries::LinkEntriesArgs,
         send::{SendArgs, SendOptions},
-        sign::{SignArgs, SignOneTimeResult},
+        sign::{OneTimeSignArgs, SignArgs, SignOneTimeResult},
         verify_signature::VerifySignatureArgs,
         QueryArgs, QueryArgsNames, QueryArgsOptions, QueryResult, UpdateEntryArgs, ZomeApiGlobals,
         ZomeFnCallArgs,
@@ -833,10 +833,14 @@ pub fn sign<S: Into<String>>(payload: S) -> ZomeApiResult<String> {
     })
 }
 
-/// sign_one_time ( priv_id_str, base64payload ) -> ( base64signature )
-pub fn sign_one_time<S: Into<String>>(payload: S) -> ZomeApiResult<SignOneTimeResult> {
-    Dispatch::SignOneTime.with_input(SignArgs {
-        payload: payload.into(),
+/// sign_one_time ( priv_id_str, base64payloads ) -> ( base64signature )
+pub fn sign_one_time<S: Into<String>>(payloads: Vec<S>) -> ZomeApiResult<SignOneTimeResult> {
+    let mut converted_payloads = Vec::new();
+    for p in payloads {
+        converted_payloads.push(p.into());
+    }
+    Dispatch::SignOneTime.with_input(OneTimeSignArgs {
+        payloads: converted_payloads,
     })
 }
 

--- a/wasm_utils/src/api_serialization/sign.rs
+++ b/wasm_utils/src/api_serialization/sign.rs
@@ -5,8 +5,13 @@ pub struct SignArgs {
     pub payload: String,
 }
 
+#[derive(Deserialize, Default, Clone, PartialEq, Eq, Hash, Debug, Serialize, DefaultJson)]
+pub struct OneTimeSignArgs {
+    pub payloads: Vec<String>,
+}
+
 #[derive(Deserialize, Clone, PartialEq, Eq, Hash, Debug, Serialize, DefaultJson)]
 pub struct SignOneTimeResult {
     pub pub_key: Base32,
-    pub signature: Signature,
+    pub signatures: Vec<Signature>,
 }


### PR DESCRIPTION
Changes the signature of `one_time_sign` to take a vector of payloads, and return a vector of signatures.  This is a necessary change for deepkey to work, and makes sense because since you only have one change to sign stuff, you might as well be able to sign more than one thing...


Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [x] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] my changes to the code do not affect any exposed aspect of the developer experience
