### PR TITLE
hooks up `hc keygen --path` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds hdk access to keystore [#1148](https://github.com/holochain/holochain-rust/pull/1148)
+- Adds a `--path` option to `hc keygen` to specify the location of the generated keybundle. [#1194](https://github.com/holochain/holochain-rust/pull/1194)
 
 ### Changed
 - Performance optimization: don't recalculate DNA hash during handling of every network message but instead cache the DNA hash. [PR#1163](https://github.com/holochain/holochain-rust/pull/1163)

--- a/cli/src/cli/keygen.rs
+++ b/cli/src/cli/keygen.rs
@@ -13,13 +13,14 @@ use std::{
 };
 
 pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>) -> DefaultResult<()> {
-    println!("This will create a new agent keystore and populate it with an agent keybundle");
-    println!("(=all keys needed to represent an agent: public/private keys for signing/encryption");
-    println!("This keybundle will be stored encrypted by passphrase within the keystore file.");
-    println!("The passphrase is securing the keys and will be needed, together with the file, in order to use the key.");
-    println!("Please enter a secret passphrase below, you will have to enter it again when unlocking these keys to use within a Holochain conductor.");
-
     let passphrase = passphrase.unwrap_or_else(|| {
+        println!("This will create a new agent keystore and populate it with an agent keybundle,");
+        println!("containing a public and a private key, for signing and encryption by the agent.");
+        println!("This keybundle will be stored encrypted by passphrase within the keystore file.");
+        println!("The passphrase is securing the keys and will be needed, together with the file,");
+        println!("in order to use the key.");
+        println!("Please enter a secret passphrase below. You will have to enter it again");
+        println!("when unlocking the keybundle to use within a Holochain conductor.");
         print!("Passphrase: ");
         io::stdout().flush().expect("Could not flush stdout");
         let passphrase1 = rpassword::read_password().unwrap();
@@ -32,6 +33,8 @@ pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>) -> DefaultResul
         }
         passphrase1
     });
+
+    println!("Generating keystore (this will take a few moments)...");
 
     let mut keystore = Keystore::new(mock_passphrase_manager(passphrase), None)?;
     keystore.add_random_seed("root_seed", SEED_SIZE)?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -145,6 +145,8 @@ enum Cli {
     KeyGen {
         #[structopt(long, short, help = "Don't ask for passphrase")]
         silent: bool,
+        #[structopt(long, short, help = "Specify path of file")]
+        path: Option<PathBuf>,
     },
     #[structopt(name = "chain", about = "View the contents of a source chain")]
     ChainLog {
@@ -224,13 +226,13 @@ fn run() -> HolochainResult<()> {
         }
         .map_err(HolochainError::Default)?,
 
-        Cli::KeyGen { silent } => {
+        Cli::KeyGen { silent, path } => {
             let passphrase = if silent {
                 Some(String::from(holochain_common::DEFAULT_PASSPHRASE))
             } else {
                 None
             };
-            cli::keygen(None, passphrase)
+            cli::keygen(path, passphrase)
                 .map_err(|e| HolochainError::Default(format_err!("{}", e)))?
         }
 


### PR DESCRIPTION
The keygen accepts an optional path arg but we aren't using it, so I hooked it up. This will be useful for intrceptr to automatically generate a keyfile on startup if one doesn't exist. 

The other option is to still have keys generated in a default location but to have a mode where `hc keygen` outputs in machine-readable format so the caller knows where the file actual got created. Using an explicit path is the easier method.

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [X] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
