### PR TITLE
Rename silent to nullpass and add quiet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds hdk access to keystore [#1148](https://github.com/holochain/holochain-rust/pull/1148)
 - Adds a `--path` option to `hc keygen` to specify the location of the generated keybundle. [#1194](https://github.com/holochain/holochain-rust/pull/1194)
+- Adds a `--quiet` option to `hc keygen` for machine-readable output, intended for use in scripts. [#1197](https://github.com/holochain/holochain-rust/pull/1197)
 
 ### Changed
 - Performance optimization: don't recalculate DNA hash during handling of every network message but instead cache the DNA hash. [PR#1163](https://github.com/holochain/holochain-rust/pull/1163)

--- a/cli/src/cli/keygen.rs
+++ b/cli/src/cli/keygen.rs
@@ -12,20 +12,27 @@ use std::{
     path::PathBuf,
 };
 
-pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>) -> DefaultResult<()> {
+pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>, quiet: bool) -> DefaultResult<()> {
     let passphrase = passphrase.unwrap_or_else(|| {
-        println!("This will create a new agent keystore and populate it with an agent keybundle,");
-        println!("containing a public and a private key, for signing and encryption by the agent.");
-        println!("This keybundle will be stored encrypted by passphrase within the keystore file.");
-        println!("The passphrase is securing the keys and will be needed, together with the file,");
-        println!("in order to use the key.");
-        println!("Please enter a secret passphrase below. You will have to enter it again");
-        println!("when unlocking the keybundle to use within a Holochain conductor.");
-        print!("Passphrase: ");
-        io::stdout().flush().expect("Could not flush stdout");
+        if !quiet {
+            println!(
+                "
+This will create a new agent keystore and populate it with an agent keybundle
+containing a public and a private key, for signing and encryption by the agent.
+This keybundle will be stored encrypted by passphrase within the keystore file.
+The passphrase is securing the keys and will be needed, together with the file,
+in order to use the key.
+Please enter a secret passphrase below. You will have to enter it again
+when unlocking the keybundle to use within a Holochain conductor."
+            );
+            print!("Passphrase: ");
+            io::stdout().flush().expect("Could not flush stdout");
+        }
         let passphrase1 = rpassword::read_password().unwrap();
-        print!("Re-enter passphrase: ");
-        io::stdout().flush().expect("Could not flush stdout");
+        if !quiet {
+            print!("Re-enter passphrase: ");
+            io::stdout().flush().expect("Could not flush stdout");
+        }
         let passphrase2 = rpassword::read_password().unwrap();
         if passphrase1 != passphrase2 {
             println!("Passphrases do not match. Please retry...");
@@ -34,7 +41,9 @@ pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>) -> DefaultResul
         passphrase1
     });
 
-    println!("Generating keystore (this will take a few moments)...");
+    if !quiet {
+        println!("Generating keystore (this will take a few moments)...");
+    }
 
     let mut keystore = Keystore::new(mock_passphrase_manager(passphrase), None)?;
     keystore.add_random_seed("root_seed", SEED_SIZE)?;
@@ -50,14 +59,20 @@ pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>) -> DefaultResul
     };
 
     keystore.save(path.clone())?;
+    let path_str = path.to_str().unwrap();
 
-    println!("");
-    println!("Succesfully created new agent keystore.");
-    println!("");
-    println!("Public address: {}", pub_key);
-    println!("Keystore written to: {}", path.to_str().unwrap());
-    println!("");
-    println!("You can set this file in a conductor config as keystore_file for an agent.");
+    if quiet {
+        println!("{}", pub_key);
+        println!("{}", path_str);
+    } else {
+        println!("");
+        println!("Succesfully created new agent keystore.");
+        println!("");
+        println!("Public address: {}", pub_key);
+        println!("Keystore written to: {}", path_str);
+        println!("");
+        println!("You can set this file in a conductor config as keystore_file for an agent.");
+    }
     Ok(())
 }
 
@@ -72,7 +87,7 @@ pub mod test {
         let path = PathBuf::new().join("test.key");
         let passphrase = String::from("secret");
 
-        keygen(Some(path.clone()), Some(passphrase.clone())).expect("Keygen should work");
+        keygen(Some(path.clone()), Some(passphrase.clone()), true).expect("Keygen should work");
 
         let mut keystore =
             Keystore::new_from_file(path.clone(), mock_passphrase_manager(passphrase), None)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -143,10 +143,16 @@ enum Cli {
         about = "Creates a new agent key pair, asks for a passphrase and writes an encrypted key bundle to disk in the XDG compliant config directory of Holochain, which is dependent on the OS platform (/home/alice/.config/holochain/keys or C:\\Users\\Alice\\AppData\\Roaming\\holochain\\holochain\\keys or /Users/Alice/Library/Preferences/com.holochain.holochain/keys)"
     )]
     KeyGen {
-        #[structopt(long, short, help = "Don't ask for passphrase")]
-        silent: bool,
         #[structopt(long, short, help = "Specify path of file")]
         path: Option<PathBuf>,
+        #[structopt(
+            long,
+            short,
+            help = "Only print machine-readable output; intended for use by programs and scripts"
+        )]
+        quiet: bool,
+        #[structopt(long, short, help = "Don't ask for passphrase")]
+        nullpass: bool,
     },
     #[structopt(name = "chain", about = "View the contents of a source chain")]
     ChainLog {
@@ -226,13 +232,17 @@ fn run() -> HolochainResult<()> {
         }
         .map_err(HolochainError::Default)?,
 
-        Cli::KeyGen { silent, path } => {
-            let passphrase = if silent {
+        Cli::KeyGen {
+            path,
+            quiet,
+            nullpass,
+        } => {
+            let passphrase = if nullpass {
                 Some(String::from(holochain_common::DEFAULT_PASSPHRASE))
             } else {
                 None
             };
-            cli::keygen(path, passphrase)
+            cli::keygen(path, passphrase, quiet)
                 .map_err(|e| HolochainError::Default(format_err!("{}", e)))?
         }
 


### PR DESCRIPTION
- [ ] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`


Using this may look roughly like the following
```
const hc = spawn('hc keygen --quiet')
  console.info("auto-entering passphrase twice...")
  hc.stdin.write(passphrase + '\n')
  hc.stdin.write(passphrase + '\n')
  hc.stdin.end()
  // read answers from hc.stdout
```