### PR TITLE
[WIP] Use dummy keystore_file value if remote key

### DIFF
--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -620,11 +620,18 @@ impl ConductorApiBuilder {
             let id = Self::get_as_string("id", &params_map)?;
             let name = Self::get_as_string("name", &params_map)?;
             let public_address = Self::get_as_string("public_address", &params_map)?;
-            let keystore_file = Self::get_as_string("keystore_file", &params_map)?;
             let holo_remote_key = params_map
                 .get("holo_remote_key")
                 .map(|k| k.as_bool())
                 .unwrap_or_default();
+            let keystore_file = {
+                let result = Self::get_as_string("keystore_file", &params_map);
+                if holo_remote_key.unwrap_or_default() {
+                    result.unwrap_or("[IGNORED]".to_string())
+                } else {
+                    result?
+                }
+            };
 
             let agent = AgentConfiguration {
                 id,


### PR DESCRIPTION
I discovered a "regression" of sorts that will affect Holo. I started this PR just to get the ball rolling, but this is nowhere near a fix.

The problem is the Holo remote_key hack fell through the cracks, and it seems that the agent creation process expects there to be a valid `keystore_file` when creating an agent. However, the correct behavior for now is to ignore the `keystore_file` field when `holo_remote_key` is true. Not sure where to draw the line to bifurcate this into the two different cases, because currently it seems like the process expects a valid key file from end to end.

Hoping @zippy or @lucksus whoever has coherence on the new keybundle stuff can work on this. If it's easier to just give me some input on the best way to do this, I'd be happy to. But I don't want to spend a bunch of time figuring out how it's all put together, and then maybe miss something important.

- [X] my changes to the code do not affect any exposed aspect of the developer experience
