### PR TITLE
use SecBuf clone in keypair

### DIFF
--- a/dpki/src/keypair.rs
+++ b/dpki/src/keypair.rs
@@ -87,11 +87,7 @@ impl KeyPair for SigningKeyPair {
     }
 
     fn new_from_self(&mut self) -> HcResult<Self> {
-        let mut buf = SecBuf::with_secure(self.private.len());
-        let pub_key = self.public();
-        let lock = self.private().read_lock();
-        buf.write(0, &**lock)?;
-        Ok(SigningKeyPair::new(pub_key, buf))
+        Ok(SigningKeyPair::new(self.public(), self.private.clone()))
     }
 }
 
@@ -162,11 +158,7 @@ impl KeyPair for EncryptingKeyPair {
     }
 
     fn new_from_self(&mut self) -> HcResult<Self> {
-        let mut buf = SecBuf::with_secure(self.private.len());
-        let pub_key = self.public();
-        let lock = self.private().read_lock();
-        buf.write(0, &**lock)?;
-        Ok(EncryptingKeyPair::new(pub_key, buf))
+        Ok(EncryptingKeyPair::new(self.public(), self.private.clone()))
     }
 }
 


### PR DESCRIPTION
This is a simple PR that refactors keypair to use the recently merge code for SecBuf cloning.


Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [ ] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] my changes to the code do not affect any exposed aspect of the developer experience
