### PR TITLE
Fix tests hanging when runTape function throws exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fixes tests hanging when function passed to `runTape` threw an exception. [#1225](https://github.com/holochain/holochain-rust/pull/1225)
 
 ### Security
 

--- a/nodejs_conductor/index.js
+++ b/nodejs_conductor/index.js
@@ -183,10 +183,11 @@ class Scenario {
         }
         Scenario._tape(description, t => {
             this.run((stop, instances) => {
-                return fn(t, instances).then(() => stop())
-            })
-                .catch(e => t.fail(e))
-                .then(t.end)
+                return fn(t, instances).then(stop).catch(e => {
+                    t.fail(e)
+                    stop()
+                })
+            }).then(t.end)
         })
     }
 }

--- a/nodejs_conductor/index.js
+++ b/nodejs_conductor/index.js
@@ -183,10 +183,7 @@ class Scenario {
         }
         Scenario._tape(description, t => {
             this.run((stop, instances) => {
-                return fn(t, instances).then(stop).catch(e => {
-                    t.fail(e)
-                    stop()
-                })
+                return fn(t, instances).catch(t.fail).finally(stop)
             }).then(t.end)
         })
     }


### PR DESCRIPTION
- [x] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`

I think this was just a small thing that went unnoticed when changing the function to `async`.