### PR TITLE
remove n3h debug code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,6 @@ jobs:
    - checkout
    - run: nix-shell --run hc-test
 
- n3h_debug:
-  docker:
-   - image: holochain/holochain-rust:latest
-  steps:
-   - checkout
-   - run: nix-shell --run 'cargo test -p holochain_net can_dl_n3h'
-
  fmt:
   docker:
    - image: holochain/holochain-rust:latest
@@ -246,7 +239,6 @@ workflows:
  tests:
   jobs:
    - build
-   - n3h_debug
    - fmt
    - app-spec-tests
    - cli-tests

--- a/net/src/ipc/n3h.rs
+++ b/net/src/ipc/n3h.rs
@@ -344,14 +344,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "broken-tests")]
     fn it_downloads() {
         let dir = tempfile::tempdir().unwrap();
         download(dir.path().join("n3h").as_os_str(), "https://github.com/holochain/node-static-build/releases/download/deps-2019-03-12/node-v8.15.1-linux-aarch64-alpha6.sha256", "b3f5a2f88ddbdcb642caa272afed7bbfbb283189cfa719a401ac8685b890e553").unwrap();
     }
 
     #[test]
-    #[cfg(feature = "broken-tests")]
     fn it_downloads_bad_hash() {
         let dir = tempfile::tempdir().unwrap();
         download(dir.path().join("n3h").as_os_str(), "https://github.com/holochain/node-static-build/releases/download/deps-2019-03-12/node-v8.15.1-linux-aarch64-alpha6.sha256", "baaaad").unwrap_err();
@@ -359,21 +357,18 @@ mod tests {
 
     #[test]
     #[cfg(windows)]
-    #[cfg(feature = "broken-tests")]
     fn it_checks_path_true() {
         exec_output("cmd", vec!["/C", "echo"], ".", false).unwrap();
     }
 
     #[test]
     #[cfg(not(windows))]
-    #[cfg(feature = "broken-tests")]
     fn it_checks_path_true() {
         exec_output("sh", vec!["-c", "exit"], ".", false).unwrap();
     }
 
     #[test]
     #[cfg(windows)]
-    #[cfg(feature = "broken-tests")]
     fn it_checks_path_false() {
         let args: Vec<&str> = Vec::new();
         exec_output("badcommand", args, ".", false).unwrap_err();
@@ -381,7 +376,6 @@ mod tests {
 
     #[test]
     #[cfg(not(windows))]
-    #[cfg(feature = "broken-tests")]
     fn it_checks_path_false() {
         let args: Vec<&str> = Vec::new();
         exec_output("badcommand", args, ".", false).unwrap_err();


### PR DESCRIPTION
rolls back some debug code that i accidentally merged with n3h dl

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [ ] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] my changes to the code do not affect any exposed aspect of the developer experience
