### PR TITLE
Makefile cleanup: the current Makefile does not work, and needs to be fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Makefile updated with Nix/Native build targets [PR#1255](https://github.com/holochain/holochain-rust/pull/1255)
+
 ### Changed
 
 ### Deprecated

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ wasm_build: ensure_wasm_target
 	  hdk-rust/wasm-test \
 	  wasm_utils/wasm-test/integration-test; do \
 	    echo -e "\033[0;93m## Building $${target}... ##\033[0m"; \
-	    ( cd core/src/nucleus/actions/wasm-test && $(CARGO) build --release --target wasm32-unknown-unknown ); \
+	    ( cd $${target} && $(CARGO) build --release --target wasm32-unknown-unknown ); \
 	done
 
 .PHONY: build_holochain libsodium_version

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,90 @@
 # holochain-rust Makefile
-# currently only supports 'debug' builds
+# - Build Holochain targets, either via Nix Shell (recommended), or using local toolchain/libs
 
+SHELL = /bin/bash
+
+# Native Toolchain {build,install,help}
+# 
+# Using the native toolchain and installed libraries may require system configuration (eg. see
+# RUST_SODIUM..., below)
 .PHONY: all build install help
-
 all: build
 
-build: build_holochain build_cli build_nodejs
+build: build_holochain build_cli build_node_conductor
 
-install: build install_cli
+install: build install_cli install_conductor
 
 help:
-	@echo "run 'make' to build all the libraries and binaries, and the nodejs bin-package"
+	@echo "run 'make all' to build all the libraries and binaries, and the nodejs bin-package"
+	@echo "run 'make nix-all' to build all the libraries and binaries, and the nodejs bin-package using a Nix environment"
 	@echo "run 'make install' to build and install all the libraries and binaries, and the nodejs bin-package"
 	@echo "run 'make test' to execute all the tests"
 	@echo "run 'make test_app_spec' to build and test app_spec API tests"
 	@echo "run 'make clean' to clean up the build environment"
 	@echo "run 'make test_holochain' to test holochain builds"
 	@echo "run 'make test_cli' to build and test the command line tool builds"
-	@echo "run 'make install_cli' to build and install the command line tool builds"
+	@echo "run 'make install_cli' to build and install the `hc` command-line tool"
+	@echo "run 'make install_conductor' to build and install the `holochain` command-line tool"
 	@echo "run 'make test-something' to run cargo tests matching 'something'"
 
-SHELL = /bin/bash
+# NIX Shell nix-{all,build,install,test} targets: Builds hc, holochain, WASM, and NodeJS conductor
+#
+# See `shell.nix` and the Nix environment manager `nix-shell`.  We don't want to contaminate the Nix
+# build environment with the environment variables required to get machine-local builds to work
+# (eg. RUST_SODIUM_...), so use --pure.  To install Nix: https://nixos.org/nix/download.html
+.PHONY: nix-all nix-build nix-install nix-test
+nix-all: nix-build nix-test
+
+nix-build:
+	nix-shell --pure --run hc-build-wasm
+	rm -rf nodejs_conductor/build
+	nix-shell --pure --run hc-install-node-conductor
+
+nix-install: nix-build
+	nix-shell --pure --run hc-install-cli			# hc
+	nix-shell --pure --run hc-install-conductor		# holochain
+
+nix-test: nix-build
+	nix-shell --pure --run hc-test-app-spec
+
+# The Rust versions required for Holochain development, and the required cargo options are configured here:
 CORE_RUST_VERSION ?= nightly-2019-01-24
 TOOLS_RUST_VERSION ?= nightly-2019-01-24
-CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(CORE_RUST_VERSION) cargo $(CARGO_ARGS)
-CARGO_TOOLS = RUSTFLAGS="-Z external-macro-backtrace -D warnings" RUST_BACKTRACE=1 rustup run $(TOOLS_RUST_VERSION) cargo $(CARGO_ARGS)
-CARGO_TARPULIN_INSTALL = RUSTFLAGS="--cfg procmacro2_semver_exempt -D warnings" RUST_BACKTRACE=1 cargo $(CARGO_ARGS) +$(CORE_RUST_VERSION)
+CARGO = RUSTFLAGS="-Z external-macro-backtrace -D warnings" rustup run $(CORE_RUST_VERSION) cargo -Z config-profile $(CARGO_ARGS)
+CARGO_TOOLS = RUSTFLAGS="-Z external-macro-backtrace -D warnings" rustup run $(TOOLS_RUST_VERSION) cargo -Z config-profile $(CARGO_ARGS)
+CARGO_TARPULIN_INSTALL = RUSTFLAGS="--cfg procmacro2_semver_exempt -D warnings" cargo -Z config-profile $(CARGO_ARGS) +$(CORE_RUST_VERSION)
 OPENSSL_STATIC = 1
+
+# All rustup and cargo invocations executed (directly in this Makefile, or indirectly eg. via npm)
+# must include these environment variables.  If we'd like to see Rust back-traces:
+export RUST_BACKTRACE=1
+
+# Select libsodium library linkage
+#
+# There are 3 methods to obtain the libsodium encryption library required by holochain-rust,
+# selectable by setting/clearing various RUST_SODIUM_...  environment variables (see:
+# https://github.com/maidsafe/rust_sodium).  These selections are implemented and enforced in
+# rust_sodium-sys/build.rs.  The default is to download/compile libsodium 1.0.17 (06-Jan-2019).
+
+# 0) DEFAULT: Downloaded/compiled by holochain-rust build: select by *un-setting* the variables
+# RUST_SODIUM_LIB_DIR and RUST_SODIUM_USE_PKG_CONFIG.  Some systems require libsodium to be
+# configured and built with `--disable-pie`; select this here by setting RUST_SODIUM_DISABLE_PIE.
+export RUST_SODIUM_DISABLE_PIE=1
+
+# 1) System installed: select by setting RUST_SODIUM_LIB_DIR. We need to find the location of the
+# system's libsodium dynamic library: at least version 1.0.12 is required.  On Mac, `brew install
+# libsodium`.  On Ubuntu Bionic (libsodium 1.0.16), Consmic (libsodium 1.0.16) and Disco (libsodium
+# 1.0.17): `apt-get install libsodium-dev`.  On Debian Stretch (stable, libsodium 1.0.11 *to old*,
+# add `buster` to /etc/apt/sources...), or Debian Buster (testing, libsodium 1.0.17): `apt-get -t
+# buster -u install libsodium-dev`.  On other Linux distros, ensure at least libsodium 1.0.12+ is
+# installed.
+RUST_SODIUM_LIB=$(shell find /usr/local/lib /usr/lib /lib -name 'libsodium.so' -o -name 'libsodium.dylib' 2>/dev/null | head -1)
+#export RUST_SODIUM_LIB_DIR=$(dir $(RUST_SODIUM_LIB))
+#export RUST_SODIUM_SHARED=1
+
+# 2) Rust `pkg_config::probe_library`-detected: select by setting RUST_SODIUM_USE_PKG_CONFIG.
+#export RUST_SODIUM_USE_PKG_CONFIG=1
+
 
 # list all the "C" binding tests that have been written
 C_BINDING_DIRS = $(sort $(dir $(wildcard c_binding_tests/*/)))
@@ -110,7 +168,7 @@ tools_toolchain: version_rustup install_rustup_tools
 # idempotent addition of wasm target in current (default: CORE_RUST_VERSION) toolchain
 .PHONY: ensure_wasm_target
 ensure_wasm_target: core_toolchain
-	rustup target add wasm32-unknown-unknown
+	@rustup target add wasm32-unknown-unknown
 
 # idempotent installation of development tooling; RUST_VERSION defaults to TOOLS_RUST_VERSION
 # Since the default toolchain has been changed (see: tools_toolchain, version_rustup), we can
@@ -150,6 +208,7 @@ ${C_BINDING_DIRS}:
 	cd $@; $(MAKE)
 
 # execute all tests: holochain, command-line tools, app spec, nodejs conductor, and "C" bindings
+.PHONY: test
 test: test_holochain test_cli test_app_spec c_binding_tests ${C_BINDING_TESTS}
 
 test_holochain: build_holochain
@@ -165,12 +224,14 @@ test_cli: build_cli
 	cd cli && RUSTFLAGS="-D warnings" $(CARGO) test
 
 test_app_spec: RUST_VERSION=$(CORE_RUST_VERSION)
-test_app_spec: version_rustup ensure_wasm_target install_cli build_nodejs_conductor
+test_app_spec: version_rustup ensure_wasm_target install_cli build_node_conductor
 	@echo -e "\033[0;93m## Testing app_spec... ##\033[0m"
 	cd app_spec && ./build_and_test.sh
 
-build_nodejs_conductor: RUST_VERSION=$(CORE_RUST_VERSION)
-build_nodejs_conductor: version_rustup core_toolchain
+# Build the NodeJS conductor for unit tests
+.PHONY: build_node_conductor
+build_node_conductor: RUST_VERSION=$(CORE_RUST_VERSION)
+build_node_conductor: version_rustup core_toolchain
 	@echo -e "\033[0;93m## Building nodejs_conductor... ##\033[0m"
 	./scripts/build_nodejs_conductor.sh
 
@@ -181,32 +242,47 @@ test_c_ci: c_build c_binding_tests ${C_BINDING_TESTS}
 
 .PHONY: wasm_build
 wasm_build: ensure_wasm_target
-	@echo -e "\033[0;93m## Building wasm targets... ##\033[0m"
-	cd core/src/nucleus/actions/wasm-test && $(CARGO) build --release --target wasm32-unknown-unknown
-	cd conductor_api/wasm-test && $(CARGO) build --release --target wasm32-unknown-unknown
-	cd conductor_api/test-bridge-caller && $(CARGO) build --release --target wasm32-unknown-unknown
-	cd hdk-rust/wasm-test && $(CARGO) build --release --target wasm32-unknown-unknown
-	cd wasm_utils/wasm-test/integration-test && $(CARGO) build --release --target wasm32-unknown-unknown
+	@for target in \
+	  core/src/nucleus/actions/wasm-test \
+	  conductor_api/wasm-test \
+	  conductor_api/test-bridge-caller \
+	  hdk-rust/wasm-test \
+	  wasm_utils/wasm-test/integration-test; do \
+	    echo -e "\033[0;93m## Building $${target}... ##\033[0m"; \
+	    ( cd core/src/nucleus/actions/wasm-test && $(CARGO) build --release --target wasm32-unknown-unknown ); \
+	done
 
-.PHONY: build_holochain
-build_holochain: core_toolchain wasm_build
+.PHONY: build_holochain libsodium_version
+libsodium_version:
+	@[ ! -z "$${RUST_SODIUM_LIB_DIR+defined}" ] \
+	    && echo -e "\033[0;93m## Configured rust_sodium-sys -- with system libsodium \"$(RUST_SODIUM_LIB)\" in: $${RUST_SODIUM_LIB_DIR:-(unknown: install libsodium; see Makefile)}) ##\033[0m" \
+	    || ( [ ! -z "$${RUST_SODIUM_USE_PKG_CONFIG+defined}" ] \
+		&& echo -e "\033[0;93m## Configured rust_sodium-sys -- with pkg_config libsodium ##\033[0m" \
+		|| ( echo -e "\033[0;93m## Configured rust_sodium-sys -- with download/build libsodium ##\033[0m" ))
+
+build_holochain: core_toolchain wasm_build libsodium_version
 	@echo -e "\033[0;93m## Building holochain... ##\033[0m"
-	$(CARGO) build --all --exclude hc
+	@$(CARGO) build --all --exclude hc
 
 .PHONY: build_cli
 build_cli: core_toolchain ensure_wasm_target
 	@echo -e "\033[0;93m## Building hc command... ##\033[0m"
-	$(CARGO) build -p hc
+	@$(CARGO) build -p hc --release
 
-.PHONY: build_nodejs
-build_nodejs:
-	@echo -e "\033[0;93m## Building nodejs interface... ##\033[0m"
-	cd nodejs_conductor && npm run compile && mkdir -p bin-package && cp native/index.node bin-package
+.PHONY: build_conductor
+build_conductor: core_toolchain ensure_wasm_target
+	@echo -e "\033[0;93m## Building holochain command... ##\033[0m"
+	@$(CARGO) build -p holochain --release
 
 .PHONY: install_cli
 install_cli: build_cli
 	@echo -e "\033[0;93m## Installing hc command... ##\033[0m"
-	cd cli && $(CARGO) install -f --path .
+	@$(CARGO) install -f --path cli
+
+.PHONY: install_conductor
+install_conductor: build_conductor
+	@echo -e "\033[0;93m## Installing holochain command... ##\033[0m"
+	@$(CARGO) install -f --path conductor
 
 .PHONY: code_coverage
 code_coverage: core_toolchain wasm_build install_ci
@@ -239,7 +315,7 @@ clean: ${C_BINDING_CLEAN}
 	@$(RM) -rf app_spec/dist
 	@for cargo in $$( find . -name 'Cargo.toml' ); do \
 	    echo -e "\033[0;93m## 'cargo clean' in $${cargo%/*} ##\033[0m"; \
-	    ( cd $${cargo%/*} && cargo clean ); \
+	    ( cd $${cargo%/*} && $(CARGO) clean ); \
 	done
 
 # clean up the extraneous "C" binding test files


### PR DESCRIPTION
The current Makefile is not useful (doesn't know how to build 'holochain', incorrectly builds 'nodejs_conductor', fails for non-Nix-Shell Native toolchain/library builds, etc.)  However, many grey-beards still look to Makefile for build advice; I feel that it is important to maintain -- at least, as an interface to document how to invoke the alternative build approaches, eg. Nix Shell.

Adds support for both Nix/Native build. Adds support for building the main hc, holochain, WASM and NodeJS conductor targets via Nix Environment, as well as for selecting the Native libsodium library options to use for native builds (defaults to same build approach as used by shell.nix, with documentation to support other platforms, eg. Debian).

The appropiate Nix Shell targets required to build the Holochain Rust components is included in the Makefile for documentation, selection and execution.  This doesn't replace the direct Nix Shell approach; it just makes it accessible and documented for Makefile users.

Likewise, the selection of system libsodium library is foundational to the success of building/running the NodeJS tests. The options for selecting/building that are detailed here, as well -- again, the shell.nix approach is the "default", and alternatives are clearly laid out for platforms where that default approach does not work.

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [x] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] my changes to the code do not affect any exposed aspect of the developer experience
