### PR TITLE
bridging article is no longer empty

### DIFF
--- a/doc/holochain_101/src/SUMMARY.md
+++ b/doc/holochain_101/src/SUMMARY.md
@@ -75,7 +75,7 @@
     - [WebSockets](./json_rpc_websockets.md)
   - [Conductor Admin](./conductor_admin.md)
 - [Building Holochain Apps: User Interfaces](./apps_user_interfaces.md)
-- [(E) Building Holochain Apps: Bridging](./bridging.md)
+- [Building Holochain Apps: Bridging](./bridging.md)
 - [(E) Going Live with Holochain Apps](./live_hc_apps.md)
   - [(E) Creating Versioned Releases](./creating_versioned_releases.md)
 - [(E) Building Holochain Apps: Advanced Topics](./apps_advanced_topics.md)


### PR DESCRIPTION
Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md), which should be updated if relevant
- [ ] my changes to the code affect some exposed aspect of the developer experience, and I have added an item to relevant 'Added, Fixed, Changed, Removed, Deprecated, or Security' heading under the 'Unreleased' heading of the CHANGELOG, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] my changes to the code do not affect any exposed aspect of the developer experience
