### PR TITLE
Fix `call()` function's namespacing

### DIFF
--- a/doc/holochain_101/src/bridging.md
+++ b/doc/holochain_101/src/bridging.md
@@ -33,10 +33,10 @@ callee_id = "target-instance"
 handle = "sample-bridge"
 ```
 
-Then on the caller DNA you have to initiate the bridge call using `hdk::call` like this:
+Then on the caller DNA you have to initiate the bridge call using `hdk::api::call` like this:
 
 ```rust
-    let response = match hdk::call(
+    let response = match hdk::api::call(
         "sample-bridge",
         "sample_zome",
         Address::from(PUBLIC_TOKEN.to_string()), // never mind this for now


### PR DESCRIPTION
`s/hdk::call/hdk::api::call/g`

## PR summary

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
