### PR TITLE
make portable - c_char is u8 on arm

### DIFF
--- a/wasm_utils/src/memory/write.rs
+++ b/wasm_utils/src/memory/write.rs
@@ -15,7 +15,7 @@ impl WasmStack {
         let ptr = MemoryInt::from(self.allocate(next_allocation)?) as *mut c_char;
         let ptr_safe = unsafe { slice::from_raw_parts_mut(ptr, usize::from(length)) };
         for (i, byte) in bytes.iter().enumerate() {
-            ptr_safe[i] = *byte as i8;
+            ptr_safe[i] = *byte as c_char;
         }
 
         WasmAllocation::new((ptr as MemoryInt).into(), length)


### PR DESCRIPTION
## PR summary

This bit breaks when building on an arm processor, apparently c_char is a u8 instead of an i8 on those architectures... so use the c_char type directly.

## testing/benchmarking notes

builds / runs on arm64:

```
$ ./holochain --version
holochain 0.0.11-alpha1
```

```
$ readelf -h ./holochain
ELF Header:
  Class:                             ELF64
  Data:                              2's complement, little endian
  Type:                              DYN (Shared object file)
  Machine:                           AArch64
# ... snip
```

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
