### PR TITLE
Fix guidebook describing `hc run --networked`

### DIFF
--- a/doc/holochain_101/src/hc_configuring_networking.md
+++ b/doc/holochain_101/src/hc_configuring_networking.md
@@ -2,9 +2,9 @@
 
 `hc run` uses mock networking by default and therefore doesn't talk to any other nodes.
 
-Start the server by running:
+In order to have `hc run` spawn a real network instance, start it with the `--networked` option:
 ```shell
-hc run
+hc run --networked
 ```
 
 You should see something like this:


### PR DESCRIPTION
## PR summary

`hc run` will not start n3h. We need the option `--networked` for that. The guide book was asserting we would get networking without that option which does not match the current behavior.
