### PR TITLE
Fix n3h version check

### DIFF
--- a/net/src/ipc/n3h.rs
+++ b/net/src/ipc/n3h.rs
@@ -150,11 +150,10 @@ fn check_n3h_version(path: &std::path::PathBuf) -> NetResult<Vec<String>> {
 }
 
 fn sub_check_n3h_version(path: &std::path::PathBuf, out_args: &[&str]) -> NetResult<bool> {
-    let res = exec_output(path, out_args, ".", false)
-        .map_err(|err| {
-            println!("response: {:?}", err);
-            format_err!("n3h not found in path: {:?}", &path)
-        })?;
+    let res = exec_output(path, out_args, ".", false).map_err(|err| {
+        println!("response: {:?}", err);
+        format_err!("n3h not found in path: {:?}", &path)
+    })?;
 
     // `n3h --version` returns only the version number, for example "v0.0.11-alpha"
     if res == N3H_INFO.version {

--- a/net/src/ipc/n3h.rs
+++ b/net/src/ipc/n3h.rs
@@ -167,14 +167,15 @@ fn sub_check_n3h_version(path: &std::path::PathBuf, out_args: &[&str]) -> NetRes
             version = Some(m[1].to_string());
         }
 
-        if version.is_none() || version.as_ref().unwrap() != &N3H_INFO.version {
+        if version.is_some() && version.as_ref().unwrap() == &N3H_INFO.version {
+            Ok(true)
+        } else {
             bail!(
                 "n3h version mismatch, expected: {}, got: {:?}",
                 &N3H_INFO.version,
                 version
-            );
+            )
         }
-        Ok(true)
     }
 }
 


### PR DESCRIPTION
## PR summary

Although I made the pinned n3h version match the version in the n3h branch I'm working on, I couldn't get the conductor to use my local n3h from $PATH. Found out that the version check fails if the string returned from the spawned command does not match the regex, although in my case the string was exactly the version that was pinned.

This adds a plain `res == &N3H.version` test and refactors that function so the flow easier to understand.

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
