### PR TITLE
remove flaky test

### DIFF
--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -151,8 +151,8 @@ pub mod tests {
     }
 
     #[test]
-    // flaky thest
-    //  this test failed on macos cold builds blocking on the get_entry
+    // flaky test
+    //  this test failed on macOSx cold builds blocking on the get_entry
     //  adding a sleep after the publish would make it work, but that's flaky!
     #[cfg(feature = "broken-tests")]
     fn get_entry_when_alone() {

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -151,6 +151,10 @@ pub mod tests {
     }
 
     #[test]
+    // flaky thest
+    //  this test failed on macos cold builds blocking on the get_entry
+    //  adding a sleep after the publish would make it work, but that's flaky!
+    #[cfg(feature = "broken-tests")]
     fn get_entry_when_alone() {
         let netname = Some("get_when_alone");
         let mut dna = create_test_dna_with_wat("test_zome", None);


### PR DESCRIPTION
## PR summary

Removed yet another flaky test in core/src/network/mod.rs  This one was causing macos cold-build to fail blocking on the get_entry call.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
