### PR TITLE
2019 04 21 binary derivations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `nix-shell` includes latest `hc` and `holochain` binaries [#1306](https://github.com/holochain/holochain-rust/pull/1306)
+
 ### Changed
 
 ### Deprecated

--- a/holonix/build.nix
+++ b/holonix/build.nix
@@ -5,27 +5,6 @@ let
   test = import ./src/test.nix;
 
   release = import ./release/config.nix;
-
-  holochain = pkgs.stdenv.mkDerivation {
-   name = "holochain-conductor";
-
-   src = pkgs.fetchurl {
-    url = "https://github.com/holochain/holochain-rust/releases/download/v0.0.12-alpha1/conductor-v0.0.12-alpha1-x86_64-generic-linux-gnu.tar.gz";
-    sha256 = "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq";
-   };
-
-   unpackPhase = ":";
-
-   installPhase = ''
-     mkdir -p $out/{bin,share}
-     cp $src $out/share/holochain
-   '';
-
-  };
-
-
-  # import (builtins.fetchTarball holochain-src);
-  # cli = import (builtins.fetchTarball https://github.com/holochain/holochain-rust/releases/download/v0.0.12-alpha1/cli-v0.0.12-alpha1-x86_64-generic-linux-gnu.tar.gz);
 in
 [
   # I forgot what these are for!
@@ -35,8 +14,6 @@ in
   flush
   test
 
-  holochain
-  # cli
 ]
 
 ++ import ./app-spec/build.nix

--- a/holonix/build.nix
+++ b/holonix/build.nix
@@ -1,6 +1,31 @@
 let
+  pkgs = import ./nixpkgs/nixpkgs.nix;
+
   flush = import ./src/flush.nix;
   test = import ./src/test.nix;
+
+  release = import ./release/config.nix;
+
+  holochain = pkgs.stdenv.mkDerivation {
+   name = "holochain-conductor";
+
+   src = pkgs.fetchurl {
+    url = "https://github.com/holochain/holochain-rust/releases/download/v0.0.12-alpha1/conductor-v0.0.12-alpha1-x86_64-generic-linux-gnu.tar.gz";
+    sha256 = "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq";
+   };
+
+   unpackPhase = ":";
+
+   installPhase = ''
+     mkdir -p $out/{bin,share}
+     cp $src $out/share/holochain
+   '';
+
+  };
+
+
+  # import (builtins.fetchTarball holochain-src);
+  # cli = import (builtins.fetchTarball https://github.com/holochain/holochain-rust/releases/download/v0.0.12-alpha1/cli-v0.0.12-alpha1-x86_64-generic-linux-gnu.tar.gz);
 in
 [
   # I forgot what these are for!
@@ -9,6 +34,9 @@ in
 
   flush
   test
+
+  holochain
+  # cli
 ]
 
 ++ import ./app-spec/build.nix

--- a/holonix/darwin/config.nix
+++ b/holonix/darwin/config.nix
@@ -1,8 +1,9 @@
 let
   pkgs = import ../nixpkgs/nixpkgs.nix;
+  frameworks = if pkgs.stdenv.isDarwin then pkgs.darwin.apple_sdk.frameworks else {};
 in
 {
 
- ld-flags = if pkgs.stdenv.isDarwin then "-F${pkgs.frameworks.CoreFoundation}/Library/Frameworks -framework CoreFoundation " else "";
+ ld-flags = if pkgs.stdenv.isDarwin then "-F${frameworks.CoreFoundation}/Library/Frameworks -framework CoreFoundation " else "";
 
 }

--- a/holonix/dist/build.nix
+++ b/holonix/dist/build.nix
@@ -1,8 +1,14 @@
 let
   dist = import ./src/dist.nix;
   flush = import ./src/flush.nix;
+
+  holochain = import ./src/holochain.nix;
+  hc = import ./src/hc.nix;
 in
 [
   dist
   flush
+
+  holochain
+  hc
 ]

--- a/holonix/dist/config.nix
+++ b/holonix/dist/config.nix
@@ -1,3 +1,20 @@
+let
+ pkgs = import ../nixpkgs/nixpkgs.nix;
+ rust = import ../rust/config.nix;
+in
 {
+
  path = "dist";
+
+ version = "0.0.12-alpha1";
+
+ artifact-target = if pkgs.stdenv.isDarwin
+  then
+   rust.generic-mac-target
+  else
+   builtins.replaceStrings
+    [ "unknown" ]
+    [ "generic" ]
+    rust.generic-linux-target;
+
 }

--- a/holonix/dist/rust/lib.nix
+++ b/holonix/dist/rust/lib.nix
@@ -6,16 +6,18 @@ in
 {
 
  build-rust-artifact = params:
+ let
+  artifact-name = "${params.path}-${release.core.version.current}-${dist.artifact-target}";
+ in
  ''
-  export artifact_name=`sed "s/unknown/generic/g" <<< "${params.path}-${release.core.version.current}-${rust.generic-linux-target}"`
   echo
-  echo "building $artifact_name..."
+  echo "building ${artifact-name}..."
   echo
 
   CARGO_INCREMENTAL=0 cargo rustc --manifest-path ${params.path}/Cargo.toml --target ${rust.generic-linux-target} --release -- -C lto
-  mkdir -p ${dist.path}/$artifact_name
-  cp target/${rust.generic-linux-target}/release/${params.name} ${params.path}/LICENSE ${params.path}/README.md ${dist.path}/$artifact_name
-  tar -C ${dist.path}/$artifact_name -czf ${dist.path}/$artifact_name.tar.gz . && rm -rf ${dist.path}/$artifact_name
+  mkdir -p ${dist.path}/${artifact-name}
+  cp target/${rust.generic-linux-target}/release/${params.name} ${params.path}/LICENSE ${params.path}/README.md ${dist.path}/${artifact-name}
+  tar -C ${dist.path}/${artifact-name} -czf ${dist.path}/${artifact-name}.tar.gz . && rm -rf ${dist.path}/${artifact-name}
  '';
 
 }

--- a/holonix/dist/src/hc.nix
+++ b/holonix/dist/src/hc.nix
@@ -6,8 +6,7 @@ lib.binary-derivation {
  name = "cli";
  sha256 = if pkgs.stdenv.isDarwin
  then
-  # TODO - this hash will be wrong on mac!
-  "15frnjn3q4mfsg53dy59mwnkhzwkf6iwm0d5jix2d575i8cyn5xi"
+  "0n0cq0b9x0jblbydjrpfql7qminkrnxnq8hcb6kb57q08i71pwza"
  else
   "15frnjn3q4mfsg53dy59mwnkhzwkf6iwm0d5jix2d575i8cyn5xi"
  ;

--- a/holonix/dist/src/hc.nix
+++ b/holonix/dist/src/hc.nix
@@ -1,0 +1,8 @@
+let
+ lib = import ./lib.nix;
+in
+lib.binary-derivation {
+ name = "cli";
+ sha256 = "15frnjn3q4mfsg53dy59mwnkhzwkf6iwm0d5jix2d575i8cyn5xi";
+ binary = "hc";
+}

--- a/holonix/dist/src/hc.nix
+++ b/holonix/dist/src/hc.nix
@@ -1,8 +1,15 @@
 let
+ pkgs = import ../../nixpkgs/nixpkgs.nix;
  lib = import ./lib.nix;
 in
 lib.binary-derivation {
  name = "cli";
- sha256 = "15frnjn3q4mfsg53dy59mwnkhzwkf6iwm0d5jix2d575i8cyn5xi";
+ sha256 = if pkgs.stdenv.isDarwin
+ then
+  # TODO - this hash will be wrong on mac!
+  "15frnjn3q4mfsg53dy59mwnkhzwkf6iwm0d5jix2d575i8cyn5xi"
+ else
+  "15frnjn3q4mfsg53dy59mwnkhzwkf6iwm0d5jix2d575i8cyn5xi"
+ ;
  binary = "hc";
 }

--- a/holonix/dist/src/holochain.nix
+++ b/holonix/dist/src/holochain.nix
@@ -1,0 +1,8 @@
+let
+ lib = import ./lib.nix;
+in
+lib.binary-derivation {
+ name = "conductor";
+ sha256 = "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq";
+ binary = "holochain";
+}

--- a/holonix/dist/src/holochain.nix
+++ b/holonix/dist/src/holochain.nix
@@ -1,8 +1,15 @@
 let
+ pkgs = import ../../nixpkgs/nixpkgs.nix;
  lib = import ./lib.nix;
 in
 lib.binary-derivation {
  name = "conductor";
- sha256 = "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq";
+ sha256 = if pkgs.stdenv.isDarwin
+ then
+  # TODO - this hash will be wrong on mac!
+  "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq"
+ else
+  "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq"
+ ;
  binary = "holochain";
 }

--- a/holonix/dist/src/holochain.nix
+++ b/holonix/dist/src/holochain.nix
@@ -6,8 +6,7 @@ lib.binary-derivation {
  name = "conductor";
  sha256 = if pkgs.stdenv.isDarwin
  then
-  # TODO - this hash will be wrong on mac!
-  "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq"
+  "012kga02mnci4vj92jxm1jp5w5z8x0phh4s7hbg0vihk56png43n"
  else
   "0wdlv85vwwp9cwnmnsp20aafrxljsxlc6m00h0905q0cydsf86kq"
  ;

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -24,9 +24,18 @@ in
   ''
     mkdir -p $out/bin
     mv ${args.binary} $out/bin/${args.binary}
-    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/${args.binary}
-    patchelf --shrink-rpath $out/bin/${args.binary}
   '';
+
+  postFixup =
+    if
+      pkgs.stdenv.isDarwin
+    then
+      ""
+    else
+      ''
+        patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/${args.binary}
+        patchelf --shrink-rpath $out/bin/${args.binary}
+      '';
 
   };
 

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -22,11 +22,9 @@ in
 
    installPhase = ''
      mkdir -p $out/bin
-     cp $src $out/bin/${args.binary}.tar.gz
-     tar --strip-components=1 -C $out/bin -zxvf $out/bin/${args.binary}.tar.gz
-     rm $out/bin/${args.binary}.tar.gz
-     chmod +x $out/bin/${args.binary}
+     cp $src $out/bin/${args.binary}
    '';
+
   };
 
 }

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -18,12 +18,26 @@ in
     sha256 = args.sha256;
    };
 
-   unpackPhase = ":";
+  unpackPhase =
+    if pkgs.stdenv.isDarwin
+    then
+      "tar --strip-components=1 -zxvf $src"
+    else
+      ":";
 
-   installPhase = ''
-     mkdir -p $out/bin
-     cp $src $out/bin/${args.binary}
-   '';
+  installPhase =
+    if pkgs.stdenv.isDarwin
+    then
+      ''
+        mkdir -p $out/bin
+        mv ${args.binary} $out/bin/${args.binary}
+      ''
+    else
+      ''
+        mkdir -p $out/bin
+        cp $src $out/bin/${args.binary}
+      '';
+
 
   };
 

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -6,11 +6,15 @@ let
 in
 {
  binary-derivation = args:
+  let
+   artifact-name = "${args.name}-v${dist.version}-${dist.artifact-target}";
+  in
   pkgs.stdenv.mkDerivation {
    name = "holochain-${args.name}";
 
+
    src = pkgs.fetchurl {
-    url = "https://github.com/${git.github.repo}/releases/download/v${dist.version}/${args.name}-v${dist.version}-${dist.artifact-target}.tar.gz";
+    url = "https://github.com/${git.github.repo}/releases/download/v${dist.version}/${artifact-name}.tar.gz";
     sha256 = args.sha256;
    };
 
@@ -18,11 +22,10 @@ in
 
    installPhase = ''
      mkdir -p $out/bin
-     cp $src $out/bin/${args.binary}
-     # chmod +x $out/share/${args.binary}
-     # ln -s $out/share/${args.binary} $out/bin/${args.binary}
-     ls -la $out/bin/${args.binary}
-     # cp $src $out/bin/${args.binary}
+     cp $src $out/bin/${args.binary}.tar.gz
+     tar --strip-components=1 -C $out/bin -zxvf $out/bin/${args.binary}.tar.gz
+     rm $out/bin/${args.binary}.tar.gz
+     chmod +x $out/bin/${args.binary}
    '';
   };
 

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -17,8 +17,12 @@ in
    unpackPhase = ":";
 
    installPhase = ''
-     mkdir -p $out/{bin,share}
-     cp $src $out/share/${args.binary}
+     mkdir -p $out/bin
+     cp $src $out/bin/${args.binary}
+     # chmod +x $out/share/${args.binary}
+     # ln -s $out/share/${args.binary} $out/bin/${args.binary}
+     ls -la $out/bin/${args.binary}
+     # cp $src $out/bin/${args.binary}
    '';
   };
 

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -1,0 +1,25 @@
+let
+ pkgs = import ../../nixpkgs/nixpkgs.nix;
+ rust = import ../../rust/config.nix;
+ dist = import ../config.nix;
+ git = import ../../git/config.nix;
+in
+{
+ binary-derivation = args:
+  pkgs.stdenv.mkDerivation {
+   name = "holochain-${args.name}";
+
+   src = pkgs.fetchurl {
+    url = "https://github.com/${git.github.repo}/releases/download/v${dist.version}/${args.name}-v${dist.version}-${dist.artifact-target}.tar.gz";
+    sha256 = args.sha256;
+   };
+
+   unpackPhase = ":";
+
+   installPhase = ''
+     mkdir -p $out/{bin,share}
+     cp $src $out/share/${args.binary}
+   '';
+  };
+
+}

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -18,26 +18,15 @@ in
     sha256 = args.sha256;
    };
 
-  unpackPhase =
-    if pkgs.stdenv.isDarwin
-    then
-      "tar --strip-components=1 -zxvf $src"
-    else
-      ":";
+  unpackPhase = "tar --strip-components=1 -zxvf $src";
 
   installPhase =
-    if pkgs.stdenv.isDarwin
-    then
-      ''
-        mkdir -p $out/bin
-        mv ${args.binary} $out/bin/${args.binary}
-      ''
-    else
-      ''
-        mkdir -p $out/bin
-        cp $src $out/bin/${args.binary}
-      '';
-
+  ''
+    mkdir -p $out/bin
+    mv ${args.binary} $out/bin/${args.binary}
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/${args.binary}
+    patchelf --shrink-rpath $out/bin/${args.binary}
+  '';
 
   };
 

--- a/holonix/git/config.nix
+++ b/holonix/git/config.nix
@@ -1,8 +1,21 @@
-{
+let
+ base = {
 
- github = {
-   repo = "holochain/holochain-rust";
-   upstream = "origin";
+  github = {
+    user = "holochain";
+    repo-name = "holochain-rust";
+    upstream = "origin";
+  };
+
  };
 
-}
+ derived = {
+
+  github = base.github // {
+   repo = "${base.github.user}/${base.github.repo-name}";
+  };
+
+ };
+
+in
+base // derived

--- a/holonix/rust/config.nix
+++ b/holonix/rust/config.nix
@@ -12,6 +12,9 @@ let
     # the target used by all linux when we don't have a specific target
     generic-linux-target = "x86_64-unknown-linux-gnu";
 
+    # the target used by all mac
+    generic-mac-target = "x86_64-apple-darwin";
+
     # set this to "info" to debug compiler cache misses due to fingerprinting
     # @see https://github.com/rust-lang/cargo/issues/4961#issuecomment-359189913
     log = "warnings";


### PR DESCRIPTION
## PR summary

downloads "current" binaries into `nix-shell`

something like the `hcup` idea but for nixos

sits on top of https://github.com/holochain/holochain-rust/pull/1292 (land that first)

part of the release process will be to bump the version and hashes once artifacts are deployed, this will need to be iterated a few times to make it smooth

at some point (soon) we will want to make it easy for consumers to pin binaries as well as roll forward with each weekly cycle

supports mac and linux (although i don't have a debian/ubuntu to test on)

## questions

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

`holochain` and `hc` should be available in `nix-shell`

```shell
# should error
holochain -V
# should error
hc -V
# drop into nix-shell
nix-shell
# should report holochain 0.0.12-alpha1
holochain -V
# should report hc 0.0.12-alpha1
hc -V
```

### nixos

```
[thedavidmeister@nixos:~/holochain-rust]$ holochain
holochain: command not found

[thedavidmeister@nixos:~/holochain-rust]$ hc
hc: command not found

[thedavidmeister@nixos:~/holochain-rust]$ nix-shell

[nix-shell:~/holochain-rust]$ holochain -V
holochain 0.0.12-alpha1

[nix-shell:~/holochain-rust]$ hc -V
hc 0.0.12-alpha1

[nix-shell:~/holochain-rust]$ 
```

### mac 

```
davidmeister@Davids-MacBook-Pro:~/holochain-rust$ holochain
-bash: holochain: command not found
davidmeister@Davids-MacBook-Pro:~/holochain-rust$ hc
-bash: hc: command not found
davidmeister@Davids-MacBook-Pro:~/holochain-rust$ nix-shell

[nix-shell:~/holochain-rust]$ holochain -V
holochain 0.0.12-alpha1

[nix-shell:~/holochain-rust]$ hc -V
hc 0.0.12-alpha1

[nix-shell:~/holochain-rust]$ 
```

### alpine docker

```
bash-4.4# holochain -V
bash: holochain: command not found
bash-4.4# hc -V
bash: hc: command not found
bash-4.4# nix-shell

[nix-shell:/holochain-rust/build]# holochain -V
holochain 0.0.12-alpha1

[nix-shell:/holochain-rust/build]# hc -V
hc 0.0.12-alpha1

[nix-shell:/holochain-rust/build]# 
```

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

- what is a good workflow for getting linux and mac hashes at release time?
- what is the best way to expose pinning for consumers?

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
