### PR TITLE
Usability: put scaffold lib.rs imports on new lines

### DIFF
--- a/cli/src/cli/scaffold/rust/lib.rs
+++ b/cli/src/cli/scaffold/rust/lib.rs
@@ -13,7 +13,11 @@ use hdk::{
     error::ZomeApiResult,
 };
 use hdk::holochain_core_types::{
-    cas::content::Address, entry::Entry, dna::entry_types::Sharing, error::HolochainError, json::JsonString,
+    cas::content::Address,
+    entry::Entry,
+    dna::entry_types::Sharing,
+    error::HolochainError,
+    json::JsonString,
     validation::EntryValidationData
 };
 


### PR DESCRIPTION
## PR summary
Jamison gave some reasons why its nicer to have these imports be on new lines...
- easier to delete, when one of them is being flagged as "unused" by the compiler
- easier to see differences in `git diff`s

I would assert that this does not merit a changelog item

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
