### PR TITLE
Failures to initialize P2P fail with an information-free panic

### DIFF
--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -399,16 +399,20 @@ impl Conductor {
         if self.config.network.is_none() {
             return P2pConfig::new_with_unique_memory_backend();
         }
-        // if there is a config then either we need to spawn a process and get the
-        // ipc_uri for it and save it for future calls to `load_config`
-        // or we use that uri value that was created from previous calls!
+        // if there is a config then either we need to spawn a process and get
+        // the ipc_uri for it and save it for future calls to `load_config` or
+        // we use a (non-empty) uri value that was created from previous calls!
         let net_config = self.config.network.clone().unwrap();
-        let uri = net_config.n3h_ipc_uri.clone().or_else(|| {
-            self.network_spawn = self.spawn_network().ok();
-            self.network_spawn
-                .as_ref()
-                .map(|spawn| spawn.ipc_binding.clone())
-        });
+        let uri = net_config
+            .n3h_ipc_uri
+            .clone()
+            .and_then(|v| if v == "" { None } else { Some(v) })
+            .or_else(|| {
+                self.network_spawn = self.spawn_network().ok();
+                self.network_spawn
+                    .as_ref()
+                    .map(|spawn| spawn.ipc_binding.clone())
+            });
 
         P2pConfig::new_ipc_uri(
             uri,

--- a/net/src/connection/net_connection_thread.rs
+++ b/net/src/connection/net_connection_thread.rs
@@ -104,10 +104,10 @@ impl NetConnectionThread {
             });
         });
 
-        // Retrieve endpoint from spawned thread
-        let endpoint = recv_endpoint
-            .recv()
-            .expect("Failed to receive endpoint address from net worker");
+        // Retrieve endpoint from spawned thread.
+        let endpoint = recv_endpoint.recv().map_err(|e| {
+            format_err!("Failed to receive endpoint address from net worker: {}", e)
+        })?;
         let endpoint = endpoint
             .expect("Should have an endpoint address")
             .to_string();

--- a/net/src/connection/net_connection_thread.rs
+++ b/net/src/connection/net_connection_thread.rs
@@ -48,7 +48,9 @@ impl NetConnectionThread {
         // Spawn worker thread
         let thread = thread::spawn(move || {
             // Create worker
-            let mut worker = worker_factory(handler).unwrap_or_else(|e| panic!("{:?}", e));
+            let mut worker = worker_factory(handler).unwrap_or_else(|e| {
+                panic!("Failure while attempting to create network worker with provided P2pConfig. Error: {:?}", e)
+            });
             // Get endpoint and send it to owner (NetConnectionThread)
             let endpoint = worker.endpoint();
             send_endpoint

--- a/net/src/p2p_network.rs
+++ b/net/src/p2p_network.rs
@@ -52,8 +52,15 @@ impl P2pNetwork {
                 Ok(Box::new(InMemoryWorker::new(h, &backend_config)?) as Box<NetWorker>)
             }),
         };
-        // Create NetConnectionThread with appropriate worker factory
-        let connection = NetConnectionThread::new(handler, worker_factory, None)?;
+        // Create NetConnectionThread with appropriate worker factory.  Indicate *what*
+        // configuration failed to produce a connection.
+        let connection = NetConnectionThread::new(handler, worker_factory, None).map_err(|e| {
+            format_err!(
+                "Failed to obtain p2p connection w/ config: {}: {}",
+                p2p_config.as_str(),
+                e
+            )
+        })?;
         if let P2pBackendKind::IPC = p2p_config.backend_kind {
             // TODO: this is a hack until Core takes in account the 'P2pReady' message sent by the network module
             // see: https://realtimeboard.com/app/board/o9J_kyiXmFs=/?moveToWidget=3074457346457995629

--- a/net/src/p2p_network.rs
+++ b/net/src/p2p_network.rs
@@ -56,7 +56,7 @@ impl P2pNetwork {
         // configuration failed to produce a connection.
         let connection = NetConnectionThread::new(handler, worker_factory, None).map_err(|e| {
             format_err!(
-                "Failed to obtain p2p connection w/ config: {}: {}",
+                "Failed to obtain a connection to a p2p network module w/ config: {}: {}",
                 p2p_config.as_str(),
                 e
             )


### PR DESCRIPTION
## PR summary

o Provide an Err(failure::Error) instead of a panic when failing
  to produce a connection.
o Allow an empty string or a None to indicate no n3h_ipc_uri, so
  that automated generation of conductor configurations is easier.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

Tested by providing an `n3h_ipc_uri = ""` in a `conductor.toml` configuration file.  Result was an information-free panic.  After changes and testing, was able to see the error that was occurring if a connection could not be created.  Also, confirmed that a `n3h_ipc_uri = ""` is allowed, and was functionally identical to commenting out the line.  This allows automatic scripting to more easily create valid conductor.toml files (ie. with an empty string, if no N3H IPC URI is known, instead of completely eliminating the line)

We may want to document this increased flexibility, but we don't have to -- the functionality is a pure superset of existing functionality; previously this configuration led to an information-free panic.

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x ] this is not a code change, or doesn't effect anyone outside holochain core development
