### PR TITLE
Network test: fetchMeta without base nor meta present

### DIFF
--- a/test_bin/src/basic_workflows.rs
+++ b/test_bin/src/basic_workflows.rs
@@ -602,3 +602,29 @@ pub fn no_entry_meta_test(
     // Done
     Ok(())
 }
+
+// this is all debug code, no need to track code test coverage
+#[cfg_attr(tarpaulin, skip)]
+pub fn no_entry_no_meta_test(alex: &mut P2pNode, billy: &mut P2pNode, can_connect: bool) -> NetResult<()> {
+    // Setup
+    setup_two_nodes(alex, billy, can_connect)?;
+
+    // Billy asks for missing metadata on the network.
+    let fetch_meta = billy.request_meta(ENTRY_ADDRESS_1.clone(), META_LINK_ATTRIBUTE.to_string());
+
+    // Alex sends that data back to the network
+    alex.reply_to_HandleFetchMeta(&fetch_meta)?;
+
+    // Billy should receive an empty list
+    let result = billy
+        .wait(Box::new(one_is!(JsonProtocol::FetchMetaResult(_))))
+        .unwrap();
+
+    log_i!("got GetMetaResult: {:?}", result);
+    let meta_data = unwrap_to!(result => JsonProtocol::FetchMetaResult);
+    assert_eq!(meta_data.entry_address, ENTRY_ADDRESS_1.clone());
+    assert_eq!(meta_data.attribute, META_LINK_ATTRIBUTE.clone());
+    assert_eq!(meta_data.content_list.len(), 0);
+    // Done
+    Ok(())
+}

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -55,6 +55,7 @@ lazy_static! {
         basic_workflows::meta_test,
         basic_workflows::no_meta_test,
         basic_workflows::no_entry_meta_test,
+        basic_workflows::no_entry_no_meta_test,
     ];
     pub static ref TWO_NODES_LIST_TEST_FNS: Vec<TwoNodesTestFn> = vec![
         publish_hold_workflows::empty_publish_entry_list_test,


### PR DESCRIPTION
This is set to merge into @ddd-mtl's #1323.

# Add another test where we fetch meta for non-existent base & entry

The tests added before either have the base entry or the meta that's requested present. In a real-world use case I saw a link request for an anchor that sometimes wasn't even there.
