### PR TITLE
Fix mismatched zome fn name / public trait in example

### DIFF
--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -541,7 +541,7 @@ pub enum BundleOnClose {
 ///     ]
 ///
 ///     traits: {
-///         hc_public [sum]
+///         hc_public [check_sum]
 ///     }
 /// }
 ///


### PR DESCRIPTION
Follow-up to [my comment on #1321](https://github.com/holochain/holochain-rust/pull/1321#pullrequestreview-230179705). I can't figure out any other way to make suggestions on code that isn't part of a diff; let me know if there's a better way!

## PR summary

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
