### PR TITLE
Add agent with auto keygen

### DIFF
--- a/conductor/example-config/empty-container.toml
+++ b/conductor/example-config/empty-container.toml
@@ -1,8 +1,4 @@
-[[agents]]
-id = "test agent 1"
-name = "Holo Tester 1"
-public_address = "HoloTester1-----------------------------------------------------------------------AAACZp4xHB"
-keystore_file = "holo_tester.key"
+agents = []
 
 dnas = []
 

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -656,8 +656,8 @@ impl ConductorApiBuilder {
                 }) // Option<Result<_, _>>
                 .transpose()?; // Result<Option<_>, _>
 
-            conductor_call!(|c| c.add_agent(id, name, holo_remote_key))?;
-            Ok(json!({"success": true}))
+            let agent_id = conductor_call!(|c| c.add_agent(id, name, holo_remote_key))?;
+            Ok(json!({"agentId": agent_id}))
         });
 
         self.io.add_method("admin/agent/remove", move |params| {

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -426,6 +426,9 @@ impl ConductorApiBuilder {
     ///     * `holo_remote_key`: [Option<String>] Create this agent from an existing keypair generated externally. Public key is passed as param.
     ///         All signing calls will be redirected externally via the wormhole websocket.
     ///         If this param is not provided the key generation will be handled by the conductor and signing done internally.
+    ///     * `passphrase`: [Option<String>] A clear text passphrase with which to encrypt the key_store.
+    ///         This prevents the running conductor from prompting for a password.
+    ///         For test agents only. NOT SECURE!
     ///     Returns the agent public key
     ///
     ///  * `admin/agent/remove`
@@ -656,8 +659,10 @@ impl ConductorApiBuilder {
                 }) // Option<Result<_, _>>
                 .transpose()?; // Result<Option<_>, _>
 
-            let agent_id = conductor_call!(|c| c.add_agent(id, name, holo_remote_key))?;
-            Ok(json!({"agentId": agent_id}))
+            let passphrase = Self::get_as_string("passphrase", &params_map).ok();
+
+            let agent_id = conductor_call!(|c| c.add_agent(id, name, holo_remote_key, passphrase))?;
+            Ok(json!({ "agentId": agent_id }))
         });
 
         self.io.add_method("admin/agent/remove", move |params| {

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -423,9 +423,10 @@ impl ConductorApiBuilder {
     ///     Params:
     ///     * `id`: Handle of this agent configuration as used in the config / other function calls
     ///     * `name`: Nickname of this agent configuration
-    ///     * `public_address`: Public part of this agents key. Has to match the private key in the
-    ///         given key file.
-    ///     * `keystore_file`: Local path to the file that holds this agent configuration's private key
+    ///     * `holo_remote_key`: [Option<String>] Create this agent from an existing keypair generated externally. Public key is passed as param.
+    ///         All signing calls will be redirected externally via the wormhole websocket.
+    ///         If this param is not provided the key generation will be handled by the conductor and signing done internally.
+    ///     Returns the agent public key
     ///
     ///  * `admin/agent/remove`
     ///     Remove an agent from the conductor config.


### PR DESCRIPTION
## PR summary

Allows a "passphrase" field to be passed to RPC calls to admin/agent/add. This prevents the conductor from requesting a passphrase from the command line. It is also totally insecure since the passphrase is sent in plain text. This is for the purpose of creating test agents via the scenario-test.js

Also updates the rustdoc for admin/agent/add which was previously not in sync with the code.

## followups

This should enable the scenario-test.js create test agents in the rust conductor. It is slow to generate keypairs though taking ~13 seconds per agent. This is not ideal overhead for every test run so it might need to be changed.

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x ] this is not a code change, or doesn't effect anyone outside holochain core development
