### PR TITLE
WIP: Improve error message when json arguments are malformed

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -146,6 +146,19 @@ scenario1.runTape('create_post', async (t, { alice }) => {
   t.equal(result.Ok, "QmY6MfiuhHnQ1kg7RwNZJNUQhwDxTFL45AAPnpJMNPEoxk")
 })
 
+scenario1.runTape('create_post_malformed_args', async (t, { alice }) => {
+
+  const content = "Holo world"
+  const malformed_arg = content
+  const params = { malformed_arg }
+  const result = alice.call("blog", "create_post", params)
+
+  t.notOk(result.Ok)
+  // TODO The result should have a deserialization error but this assertion instead fails!
+  t.ok(result.Err)
+})
+
+
 scenario1.runTape('create_memo', async (t, { alice }) => {
 
   const content = "Reminder: Buy some HOT."


### PR DESCRIPTION
## PR summary
This writes an app spec test to ensure a user friendly error is returned back when failing to deserialize the json arguments of zome functions.

The fix itself is still unimplemented.

## testing/benchmarking notes

See the _currently failing_ [create_posted_malformed](https://github.com/holochain/holochain-rust/blob/malformed_json_argument_test/app_spec/test/test.js#L149) app spec test.

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
