### PR TITLE
Remove entry link add return hashes

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Changes `LinkAdd` and `RemoveEntry` so that they return a hash instead of a null [#1343](https://github.com/holochain/holochain-rust/pull/1343)
 
 ### Deprecated
 

--- a/app_spec/test/regressions.js
+++ b/app_spec/test/regressions.js
@@ -70,7 +70,7 @@ scenario.runTape('alice create & publish post -> recommend own post to self', as
     agent_address: alice.agentId
   })
   console.log("linked: ", linked)
-  t.equal(linked.Ok, null)
+  t.equal(linked.Ok, "QmQja9SJhYWA5B3myrtnd9bR6dNeaFj6Lr3DRjumfTPWaX")
 
   const recommendedPosts = alice.call('blog', 'my_recommended_posts', {})
   console.log("recommendedPosts", recommendedPosts)
@@ -94,7 +94,7 @@ scenario.runTape('alice create & publish post -> tash recommend to self', async 
     agent_address: tash.agentId
   })
   console.log("linked: ", linked)
-  t.equal(linked.Ok, null)
+  t.equal(linked.Ok, "QmYZKfRGykurtW96zv9ra8D9cof7Ki4Df8XFSgupWP711Y")
 
   const recommendedPosts = tash.call("blog", "my_recommended_posts", {})
   console.log("recommendedPosts", recommendedPosts)
@@ -118,7 +118,7 @@ scenario.runTape('create & publish post -> recommend to other agent', async (t, 
     agent_address: tash.agentId
   })
   console.log("linked: ", linked)
-  t.equal(linked.Ok, null)
+  t.equal(linked.Ok, "QmZg7WfQhyUMzfd68VJZg9ah6WhtpLSZQe9BHaz8pmN3Pz")
 
   const recommendedPosts = tash.call('blog', 'my_recommended_posts', {})
   console.log("recommendedPosts", recommendedPosts)

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -266,7 +266,7 @@ scenario2.runTape('delete_entry_post', async (t, { alice, bob }) => {
   const deletionParams = { post_address: createResult.Ok }
   const deletionResult = await alice.callSync("blog", "delete_entry_post", deletionParams)
 
-  t.notOk(deletionResult.Ok)
+  t.Ok(deletionResult.Ok)
 
 
   //delete should fail
@@ -436,7 +436,7 @@ scenario2.runTape('remove_update_modifed_entry', async (t, { alice, bob }) => {
   //delete
   const removeParamsV2 = { post_address: createResult.Ok }
   const removeResultV2 = await bob.callSync("blog", "delete_entry_post", removeParamsV2)
-  t.notOk(removeResultV2.Ok)
+  t.Ok(removeResultV2.Ok)
 
   //get v2 using initial adders
   const Postv2Initial = alice.call("blog", "get_initial_post", { post_address: createResult.Ok })

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -266,7 +266,7 @@ scenario2.runTape('delete_entry_post', async (t, { alice, bob }) => {
   const deletionParams = { post_address: createResult.Ok }
   const deletionResult = await alice.callSync("blog", "delete_entry_post", deletionParams)
 
-  t.Ok(deletionResult.Ok)
+  t.ok(deletionResult.Ok)
 
 
   //delete should fail

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -436,7 +436,7 @@ scenario2.runTape('remove_update_modifed_entry', async (t, { alice, bob }) => {
   //delete
   const removeParamsV2 = { post_address: createResult.Ok }
   const removeResultV2 = await bob.callSync("blog", "delete_entry_post", removeParamsV2)
-  t.Ok(removeResultV2.Ok)
+  t.ok(removeResultV2.Ok)
 
   //get v2 using initial adders
   const Postv2Initial = alice.call("blog", "get_initial_post", { post_address: createResult.Ok })

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -235,12 +235,10 @@ pub fn handle_get_post(post_address: Address) -> ZomeApiResult<Option<Entry>> {
     hdk::get_entry(&post_address)
 }
 
-pub fn handle_delete_entry_post(post_address: Address) -> ZomeApiResult<()> {
+pub fn handle_delete_entry_post(post_address: Address) -> ZomeApiResult<Address> {
     hdk::get_entry(&post_address)?;
 
-    hdk::remove_entry(&post_address)?;
-
-    Ok(())
+    hdk::remove_entry(&post_address)
 }
 
 pub fn handle_get_initial_post(post_address: Address) -> ZomeApiResult<Option<Entry>> {
@@ -287,7 +285,7 @@ pub fn handle_update_post(post_address: Address, new_content: String) -> ZomeApi
     }
 }
 
-pub fn handle_recommend_post(post_address: Address, agent_address: Address) -> ZomeApiResult<()> {
+pub fn handle_recommend_post(post_address: Address, agent_address: Address) -> ZomeApiResult<Address> {
     hdk::debug(format!("my address:\n{:?}", AGENT_ADDRESS.to_string()))?;
     hdk::debug(format!("other address:\n{:?}", agent_address.to_string()))?;
     hdk::link_entries(&agent_address, &post_address, "recommended_posts")

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -120,7 +120,7 @@ define_zome! {
 
         delete_entry_post: {
             inputs: |post_address: Address|,
-            outputs: |result: ZomeApiResult<()>|,
+            outputs: |result: ZomeApiResult<Address>|,
             handler: blog::handle_delete_entry_post
         }
 
@@ -205,7 +205,7 @@ define_zome! {
 
         recommend_post: {
             inputs: |post_address: Address, agent_address: Address|,
-            outputs: |result: ZomeApiResult<()>|,
+            outputs: |result: ZomeApiResult<Address>|,
             handler: blog::handle_recommend_post
         }
 

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -6,6 +6,7 @@ use holochain_core_types::{
     entry::Entry,
     error::HolochainError,
     link::{link_data::LinkData, LinkActionKind},
+    cas::content::{Address,AddressableContent}
 };
 use holochain_wasm_utils::api_serialization::link_entries::LinkEntriesArgs;
 use std::convert::TryFrom;
@@ -34,9 +35,9 @@ pub fn invoke_link_entries(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApi
     let link_add = LinkData::from_link(&link, LinkActionKind::ADD);
     let entry = Entry::LinkAdd(link_add);
     // Wait for future to be resolved
-    let result: Result<(), HolochainError> = context
+    let result: Result<Address, HolochainError> = context
         .block_on(author_entry(&entry, None, &context))
-        .map(|_| ());
+        .map(|_| entry.address().clone());
 
     runtime.store_result(result)
 }
@@ -55,10 +56,11 @@ pub mod tests {
         },
     };
     use holochain_core_types::{
-        cas::content::AddressableContent,
+        cas::content::{Address,AddressableContent},
         entry::{test_entry, Entry},
         error::{CoreError, ZomeApiInternalResult},
         json::JsonString,
+        hash::HashString
     };
     use holochain_wasm_utils::api_serialization::link_entries::*;
     use serde_json;
@@ -144,7 +146,7 @@ pub mod tests {
             test_link_args_bytes(String::from("test-tag")),
         );
 
-        let no_entry: Option<Entry> = None;
+        let no_entry: Option<Address> = Some(HashString::from("QmWXM2r3iujqGvka8XMKU2wLdz5N14bEhvDp7Rx3R3oaEP"));
         let result = ZomeApiInternalResult::success(no_entry);
         assert_eq!(
             call_result,
@@ -189,7 +191,7 @@ pub mod tests {
             test_link_2_args_bytes(String::from("test-tag")),
         );
 
-        let no_entry: Option<Entry> = None;
+        let no_entry: Option<Address> = Some(HashString::from("QmcmcrbAfoaqJMZun74Xs1TsCUndXAohJNrKu7xZyr68P8"));
         let result = ZomeApiInternalResult::success(no_entry);
 
         assert_eq!(

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -3,10 +3,10 @@ use crate::{
     workflows::author_entry::author_entry,
 };
 use holochain_core_types::{
+    cas::content::{Address, AddressableContent},
     entry::Entry,
     error::HolochainError,
     link::{link_data::LinkData, LinkActionKind},
-    cas::content::{Address,AddressableContent}
 };
 use holochain_wasm_utils::api_serialization::link_entries::LinkEntriesArgs;
 use std::convert::TryFrom;
@@ -56,11 +56,11 @@ pub mod tests {
         },
     };
     use holochain_core_types::{
-        cas::content::{Address,AddressableContent},
+        cas::content::{Address, AddressableContent},
         entry::{test_entry, Entry},
         error::{CoreError, ZomeApiInternalResult},
+        hash::HashString,
         json::JsonString,
-        hash::HashString
     };
     use holochain_wasm_utils::api_serialization::link_entries::*;
     use serde_json;
@@ -146,7 +146,9 @@ pub mod tests {
             test_link_args_bytes(String::from("test-tag")),
         );
 
-        let no_entry: Option<Address> = Some(HashString::from("QmWXM2r3iujqGvka8XMKU2wLdz5N14bEhvDp7Rx3R3oaEP"));
+        let no_entry: Option<Address> = Some(HashString::from(
+            "QmWXM2r3iujqGvka8XMKU2wLdz5N14bEhvDp7Rx3R3oaEP",
+        ));
         let result = ZomeApiInternalResult::success(no_entry);
         assert_eq!(
             call_result,
@@ -191,7 +193,9 @@ pub mod tests {
             test_link_2_args_bytes(String::from("test-tag")),
         );
 
-        let no_entry: Option<Address> = Some(HashString::from("QmcmcrbAfoaqJMZun74Xs1TsCUndXAohJNrKu7xZyr68P8"));
+        let no_entry: Option<Address> = Some(HashString::from(
+            "QmcmcrbAfoaqJMZun74Xs1TsCUndXAohJNrKu7xZyr68P8",
+        ));
         let result = ZomeApiInternalResult::success(no_entry);
 
         assert_eq!(

--- a/core/src/nucleus/ribosome/api/remove_entry.rs
+++ b/core/src/nucleus/ribosome/api/remove_entry.rs
@@ -58,13 +58,13 @@ pub fn invoke_remove_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApi
     // Create deletion entry
     let deletion_entry = Entry::Deletion(DeletionEntry::new(deleted_entry_address.clone()));
 
-    let res: Result<(), HolochainError> = context
+    let res: Result<Address, HolochainError> = context
         .block_on(author_entry(
             &deletion_entry.clone(),
             Some(deleted_entry_address.clone()),
             &context.clone(),
         ))
-        .map(|_| ());
+        .map(|_| deletion_entry.address());
 
     runtime.store_result(res)
 }

--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -118,8 +118,8 @@ Not yet available.
 Canonical name: `remove_entry`
 
 Enables an entry, referred to by its address, to be marked in the chain as 'deleted'. This is done by adding a new entry
-which indicates the deleted status of the old one. This will change which types of results that entry would then show up in,
-according to its new 'deleted' status. It can still be retrieved, but only if specifically asked for.
+which indicates the deleted status of the old one. This will changes which types of results that entry would then show up in,
+according to its new 'deleted' status. It can still be retrieved, but only if specifically asked for. This function also returns the Hash of the deletion entry on completion
 
 [View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.remove_entry.html)
 
@@ -159,7 +159,7 @@ Consumes two values, the first of which is the address of an entry, base, and th
 
 Canonical name: `link_entries`
 
-Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a relationship between them, called a `tag`. Later, lists of entries can be looked up by using `get_links`. Entries can only be looked up in the direction from the `base`, which is the first argument, to the `target`, which is the second.
+Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a relationship between them, called a `tag`. Later, lists of entries can be looked up by using `get_links`. Entries can only be looked up in the direction from the `base`, which is the first argument, to the `target`, which is the second. This function returns a hash for the LinkAdd entry on completion.
 
 [View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.link_entries.html)
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -775,7 +775,7 @@ pub fn link_entries<S: Into<String>>(
     base: &Address,
     target: &Address,
     tag: S,
-) -> Result<(), ZomeApiError> {
+) -> Result<Address, ZomeApiError> {
     Dispatch::LinkEntries.with_input(LinkEntriesArgs {
         base: base.clone(),
         target: target.clone(),
@@ -997,7 +997,7 @@ pub fn update_agent() -> ZomeApiResult<Address> {
 /// Commit a DeletionEntry to your local source chain that marks an entry as 'deleted' by setting
 /// its status metadata to `Deleted` and adding the DeleteEntry's address in the deleted entry's
 /// metadata, which will be used by validation routes.
-pub fn remove_entry(address: &Address) -> ZomeApiResult<()> {
+pub fn remove_entry(address: &Address) -> ZomeApiResult<Address> {
     Dispatch::RemoveEntry.with_input(address.to_owned())
 }
 

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -575,7 +575,10 @@ fn can_link_entries() {
 
     let result = make_test_call(&mut hc, "link_two_entries", r#"{}"#);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(), JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#));
+    assert_eq!(
+        result.unwrap(),
+        JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#)
+    );
 }
 
 #[test]
@@ -584,7 +587,10 @@ fn can_remove_link() {
 
     let result = make_test_call(&mut hc, "link_two_entries", r#"{}"#);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(), JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#));
+    assert_eq!(
+        result.unwrap(),
+        JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#)
+    );
 }
 
 #[test]

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -575,7 +575,7 @@ fn can_link_entries() {
 
     let result = make_test_call(&mut hc, "link_two_entries", r#"{}"#);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(), JsonString::from_json(r#"{"Ok":null}"#));
+    assert_eq!(result.unwrap(), JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#));
 }
 
 #[test]
@@ -584,7 +584,7 @@ fn can_remove_link() {
 
     let result = make_test_call(&mut hc, "link_two_entries", r#"{}"#);
     assert!(result.is_ok(), "\t result = {:?}", result);
-    assert_eq!(result.unwrap(), JsonString::from_json(r#"{"Ok":null}"#));
+    assert_eq!(result.unwrap(), JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#));
 }
 
 #[test]

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -125,7 +125,7 @@ fn handle_commit_validation_package_tester() -> ZomeApiResult<Address> {
     ))
 }
 
-fn handle_link_two_entries() -> ZomeApiResult<()> {
+fn handle_link_two_entries() -> ZomeApiResult<Address> {
     let entry_1 = Entry::App(
         "testEntryType".into(),
         EntryStruct {
@@ -610,7 +610,7 @@ define_zome! {
 
         link_two_entries: {
             inputs: | |,
-            outputs: |result: ZomeApiResult<()>|,
+            outputs: |result: ZomeApiResult<Address>|,
             handler: handle_link_two_entries
         }
 


### PR DESCRIPTION
## PR summary
Short PR that makes usre Remove_entry and LinkAdd return address of their entry types respectively.
## testing/benchmarking notes
-app_spec tests have been modified
## followups
-Nothing to report
## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
