### PR TITLE
add default nix for dist builds

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- default.nix file added to facilitate `nix-env` based binary installation [#1356](https://github.com/holochain/holochain-rust/pull/1356)
+
 ### Changed
 
 ### Deprecated
@@ -15,5 +17,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
-
-

--- a/default.nix
+++ b/default.nix
@@ -1,19 +1,4 @@
-let
-
-  pkgs = import ./holonix/nixpkgs/nixpkgs.nix;
-
+{
   cli = import ./holonix/dist/cli/build.nix;
   conductor = import ./holonix/dist/conductor/build.nix;
-
-in
-with pkgs;
-stdenv.mkDerivation rec {
-
- name = "holochain-binaries";
-
- buildInputs = [
-  cli
-  conductor
- ];
-
 }

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ in
 with pkgs;
 stdenv.mkDerivation rec {
 
- name = "holonix-binaries";
+ name = "holochain-binaries";
 
  buildInputs = [
   cli

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@ let
   pkgs = import ./holonix/nixpkgs/nixpkgs.nix;
 
   cli = import ./holonix/dist/cli/build.nix;
-  conductor = import ./holonix/dist/conductor.build.nix;
+  conductor = import ./holonix/dist/conductor/build.nix;
 
 in
 with pkgs;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+let
+
+  pkgs = import ./holonix/nixpkgs/nixpkgs.nix;
+
+in
+with pkgs;
+stdenv.mkDerivation rec {
+
+ name = "holonix-binaries";
+
+ buildInputs = import ./holonix/dist/build.nix;
+
+}

--- a/default.nix
+++ b/default.nix
@@ -2,12 +2,18 @@ let
 
   pkgs = import ./holonix/nixpkgs/nixpkgs.nix;
 
+  cli = import ./holonix/dist/cli/build.nix;
+  conductor = import ./holonix/dist/conductor.build.nix;
+
 in
 with pkgs;
 stdenv.mkDerivation rec {
 
  name = "holonix-binaries";
 
- buildInputs = import ./holonix/dist/build.nix;
+ buildInputs = [
+  cli
+  conductor
+ ];
 
 }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
 {
-  cli = import ./holonix/dist/cli/build.nix;
-  conductor = import ./holonix/dist/conductor/build.nix;
+  hc = import ./holonix/dist/cli/build.nix;
+  holochain = import ./holonix/dist/conductor/build.nix;
 }

--- a/holonix/dist/src/lib.nix
+++ b/holonix/dist/src/lib.nix
@@ -11,7 +11,7 @@ in rec
 
  binary-derivation = args:
   pkgs.stdenv.mkDerivation {
-   name = "holochain-${args.name}";
+   name = "${args.binary}";
 
    src = pkgs.fetchurl {
     url = artifact-url ( { target = dist.artifact-target; } // args );


### PR DESCRIPTION
## PR summary

Adds a `default.nix` file that includes _only the binaries_.

Facilitates pointing `nix-env` straight at a tarball if all you want is the binaries.

Ignores all of the dependencies!

I'm chasing up a vanity URL from @duffybelfield 

The "easy install" for binaries would look like this:

```shell
# install nix tooling on mac/linux
curl https://nixos.org/nix/install | sh

# drop holochain and hc binaries into the user's path
nix-env -f https://holochain.love -iA hc holochain
```

### How does this work?

1. the nix installer 1-liner creates `nix-shell` and `nix-env` (and others) on mac/linux
1. pointing `nix-env` at a URL will look for a tarball, unpack it and look for `default.nix`
1. `https://holochain.love` (will) points to `https://github.com/holochain/holochain-rust/archive/master.tar.gz`
1. the `default.nix` (added in this PR) exposes the `hc` and `holochain` binary derivations from `holonix`
1. the `-i` flag tells `nix-env` to "install"
1. the `-A` flag tells `nix-env` the names of the derivations to be installed
1. `nix-env` copies the output of the `hc` and `holochain` derivations into the user's home directory (just the binaries)
1. `hc` and `holochain` end up in `~/.nix-profile/bin`

and then later... to upgrade...

```shell
# upgrade derivations
nix-env -f https://holochain.love -uA hc holochain
```

at least i think this works :thinking:

i guess we will find out!!!

finally, to uninstall...

```shell
# uninstall binaries
nix-env -e hc holochain
```

to track `develop` rather than `master` we have `https://holochain.love/nightly` as well

## testing/benchmarking notes

Example of a round trip (installing and uninstalling):

Currently `https://bit.ly/2DG8SW9` points to `https://github.com/holochain/holochain-rust/archive/675685ae62392805d95da0a961d8a1d5d32a80de.tar.gz`

```shell
[thedavidmeister@nixos:~]$ hc -V
hc: command not found

[thedavidmeister@nixos:~]$ holochain -V
holochain: command not found

[thedavidmeister@nixos:~]$ nix-env -f https://bit.ly/2DG8SW9 -iA hc holochain
installing 'hc'
installing 'holochain'

[thedavidmeister@nixos:~]$ hc -V
hc 0.0.13-alpha1

[thedavidmeister@nixos:~]$ holochain -V
holochain 0.0.13-alpha1

[thedavidmeister@nixos:~]$ which hc
/home/thedavidmeister/.nix-profile/bin/hc

[thedavidmeister@nixos:~]$ which holochain
/home/thedavidmeister/.nix-profile/bin/holochain

[thedavidmeister@nixos:~]$ nix-env -f https://bit.ly/2DG8SW9 -e hc holochain
uninstalling 'hc'
uninstalling 'holochain'

[thedavidmeister@nixos:~]$ hc -V
hc: command not found

[thedavidmeister@nixos:~]$ holochain -V
holochain: command not found

[thedavidmeister@nixos:~]$ 
```

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so there is an 'Unreleased' CHANGELOG item, with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
