### PR TITLE
holochain_net: Basic multiDna tests

### DIFF
--- a/test_bin/src/basic_workflows.rs
+++ b/test_bin/src/basic_workflows.rs
@@ -245,7 +245,7 @@ pub fn send_test(alex: &mut TestNode, billy: &mut TestNode, can_connect: bool) -
         JsonProtocol::HandleSendMessage(msg) => msg,
         _ => unreachable!(),
     };
-    assert_eq!("{\"ry\":\"hello\"}".to_string(), msg.content.to_string());
+    assert_eq!(ENTRY_CONTENT_1.to_string(), msg.content.to_string());
 
     // Send a message back from billy to alex
     billy.send_reponse(
@@ -390,6 +390,7 @@ pub fn dht_test(alex: &mut TestNode, billy: &mut TestNode, can_connect: bool) ->
 
 /// Sending a Message before doing a 'TrackDna' should fail
 pub fn no_setup_test(alex: &mut TestNode, billy: &mut TestNode, _connect: bool) -> NetResult<()> {
+    // Little dance for making alex have its current_dna set to DNA_ADDRESS_A
     alex.track_dna(&DNA_ADDRESS_A, true)
         .expect("Failed sending TrackDna message on alex");
     alex.untrack_current_dna()

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -20,6 +20,7 @@ pub mod predicate;
 pub mod basic_workflows;
 pub mod connection_workflows;
 pub mod constants;
+pub mod multidna_workflows;
 pub mod p2p_node;
 pub mod publish_hold_workflows;
 pub mod three_workflows;
@@ -65,6 +66,9 @@ lazy_static! {
     pub static ref THREE_NODES_TEST_FNS: Vec<ThreeNodesTestFn> = vec![
         three_workflows::hold_and_publish_test,
         three_workflows::publish_entry_stress_test,
+        multidna_workflows::send_test,
+        multidna_workflows::dht_test,
+        multidna_workflows::meta_test,
     ];
     pub static ref MULTI_NODES_TEST_FNS: Vec<MultiNodesTestFn> = vec![
     ];

--- a/test_bin/src/multidna_workflows.rs
+++ b/test_bin/src/multidna_workflows.rs
@@ -1,0 +1,227 @@
+use crate::three_workflows::setup_three_nodes;
+use constants::*;
+use holochain_core_types::cas::content::Address;
+use holochain_net::{
+    connection::{json_protocol::JsonProtocol, NetResult},
+    tweetlog::TWEETLOG,
+};
+use p2p_node::test_node::TestNode;
+
+/// Have multiple nodes track multiple dnas
+#[cfg_attr(tarpaulin, skip)]
+pub fn multi_track(mut nodes: Vec<&mut TestNode>, dnas: &[&Address]) -> NetResult<()> {
+    for dna in dnas {
+        for mut node in &mut nodes {
+            node.track_dna(dna, false)?;
+        }
+    }
+    Ok(())
+}
+
+/// Have multiple nodes untrack multiple dnas
+#[cfg_attr(tarpaulin, skip)]
+pub fn multi_untrack(mut nodes: Vec<&mut TestNode>, dnas: &[&Address]) -> NetResult<()> {
+    for mut node in &mut nodes {
+        for dna in dnas {
+            node.untrack_dna(dna)?;
+        }
+    }
+    Ok(())
+}
+
+/// Have 3 nodes.
+/// Each pair of nodes are tracking the same DNA
+/// Pairs should be able to send messages between them.
+/// Non-pairs should not.
+#[cfg_attr(tarpaulin, skip)]
+pub fn send_test(
+    alex: &mut TestNode,
+    billy: &mut TestNode,
+    camille: &mut TestNode,
+    can_connect: bool,
+) -> NetResult<()> {
+    // Setup
+    setup_three_nodes(alex, billy, camille, &DNA_ADDRESS_A, can_connect)?;
+    multi_untrack(vec![billy], &[&DNA_ADDRESS_A])?;
+    multi_track(vec![alex, billy], &[&DNA_ADDRESS_B])?;
+    multi_track(vec![billy, camille], &[&DNA_ADDRESS_C])?;
+
+    // Send messages on DNA A
+    // ======================
+    alex.set_current_dna(&DNA_ADDRESS_A);
+    billy.set_current_dna(&DNA_ADDRESS_A);
+    camille.set_current_dna(&DNA_ADDRESS_A);
+
+    // Camille should receive it
+    alex.send_message(CAMILLE_AGENT_ID.to_string(), ENTRY_CONTENT_1.clone());
+    let res = camille
+        .wait(Box::new(one_is!(JsonProtocol::HandleSendMessage(_))))
+        .unwrap();
+    log_i!("#### got: {:?}", res);
+    let msg = match res {
+        JsonProtocol::HandleSendMessage(msg) => msg,
+        _ => unreachable!(),
+    };
+    assert_eq!(ENTRY_CONTENT_1.to_string(), msg.content.to_string());
+    log_i!("Send messages on DNA A COMPLETE \n\n\n");
+
+    // Billy should not receive it
+    alex.send_message(BILLY_AGENT_ID.to_string(), ENTRY_CONTENT_1.clone());
+    let res = billy.wait_with_timeout(Box::new(one_is!(JsonProtocol::HandleSendMessage(_))), 1000);
+    assert!(res.is_none());
+
+    // Send messages on DNA B
+    // ======================
+    alex.set_current_dna(&DNA_ADDRESS_B);
+    billy.set_current_dna(&DNA_ADDRESS_B);
+    camille.set_current_dna(&DNA_ADDRESS_B);
+
+    // Billy should receive it
+    alex.send_message(BILLY_AGENT_ID.to_string(), ENTRY_CONTENT_2.clone());
+    let res = billy
+        .wait(Box::new(one_is!(JsonProtocol::HandleSendMessage(_))))
+        .unwrap();
+    log_i!("#### got: {:?}", res);
+    let msg = match res {
+        JsonProtocol::HandleSendMessage(msg) => msg,
+        _ => unreachable!(),
+    };
+    assert_eq!(ENTRY_CONTENT_2.to_string(), msg.content.to_string());
+
+    // Camille should not receive it
+    alex.send_message(CAMILLE_AGENT_ID.to_string(), ENTRY_CONTENT_2.clone());
+    let res =
+        camille.wait_with_timeout(Box::new(one_is!(JsonProtocol::HandleSendMessage(_))), 1000);
+    assert!(res.is_none());
+    log_i!("Send messages on DNA B COMPLETE \n\n\n");
+
+    // Send messages on DNA C
+    // ======================
+    alex.set_current_dna(&DNA_ADDRESS_C);
+    billy.set_current_dna(&DNA_ADDRESS_C);
+    camille.set_current_dna(&DNA_ADDRESS_C);
+
+    // Camille should receive it
+    camille.send_message(BILLY_AGENT_ID.to_string(), ENTRY_CONTENT_3.clone());
+    let res = billy
+        .wait(Box::new(one_is!(JsonProtocol::HandleSendMessage(_))))
+        .unwrap();
+    log_i!("#### got: {:?}", res);
+    let msg = match res {
+        JsonProtocol::HandleSendMessage(msg) => msg,
+        _ => unreachable!(),
+    };
+    assert_eq!(ENTRY_CONTENT_3.to_string(), msg.content.to_string());
+
+    // Alex should not receive it
+    camille.send_message(ALEX_AGENT_ID.to_string(), ENTRY_CONTENT_3.clone());
+    let res = alex.wait_with_timeout(Box::new(one_is!(JsonProtocol::HandleSendMessage(_))), 1000);
+    assert!(res.is_none());
+    log_i!("Send messages on DNA C COMPLETE \n\n\n");
+
+    // Done
+    Ok(())
+}
+
+// this is all debug code, no need to track code test coverage
+#[cfg_attr(tarpaulin, skip)]
+pub fn dht_test(
+    alex: &mut TestNode,
+    billy: &mut TestNode,
+    camille: &mut TestNode,
+    can_connect: bool,
+) -> NetResult<()> {
+    // Setup
+    setup_three_nodes(alex, billy, camille, &DNA_ADDRESS_A, can_connect)?;
+    multi_untrack(vec![billy], &[&DNA_ADDRESS_A])?;
+    multi_track(vec![alex, billy], &[&DNA_ADDRESS_B])?;
+    multi_track(vec![billy, camille], &[&DNA_ADDRESS_C])?;
+    alex.set_current_dna(&DNA_ADDRESS_A);
+
+    // wait for gossip
+    let _msg_count = alex.listen(200);
+
+    // Alex publish data on the network
+    alex.author_entry(&ENTRY_ADDRESS_1, &ENTRY_CONTENT_1, true)?;
+
+    // Camille asks for that data
+    let fetch_data = camille.request_entry(ENTRY_ADDRESS_1.clone());
+
+    // Alex sends that data back to the network
+    alex.reply_to_HandleFetchEntry(&fetch_data)?;
+
+    // Camille should receive requested data
+    let result = camille
+        .wait(Box::new(one_is!(JsonProtocol::FetchEntryResult(_))))
+        .unwrap();
+    log_i!("got FetchEntryResult: {:?}", result);
+
+    // Billy asks for data on unknown DNA
+    let fetch_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
+
+    // Alex sends that data back to the network
+    alex.reply_to_HandleFetchEntry(&fetch_data)?;
+
+    // Billy might receive FailureResult
+    let result = billy.wait_with_timeout(Box::new(one_is!(JsonProtocol::FailureResult(_))), 1000);
+    log_i!("got FailureResult: {:?}", result);
+
+    // Done
+    Ok(())
+}
+
+// this is all debug code, no need to track code test coverage
+#[cfg_attr(tarpaulin, skip)]
+pub fn meta_test(
+    alex: &mut TestNode,
+    billy: &mut TestNode,
+    camille: &mut TestNode,
+    can_connect: bool,
+) -> NetResult<()> {
+    // Setup
+    setup_three_nodes(alex, billy, camille, &DNA_ADDRESS_A, can_connect)?;
+    multi_untrack(vec![billy], &[&DNA_ADDRESS_A])?;
+    multi_track(vec![alex, billy], &[&DNA_ADDRESS_B])?;
+    multi_track(vec![billy, camille], &[&DNA_ADDRESS_C])?;
+    alex.set_current_dna(&DNA_ADDRESS_B);
+    billy.set_current_dna(&DNA_ADDRESS_B);
+
+    // wait for gossip
+    let _msg_count = billy.listen(200);
+
+    // Alex publishs entry & meta on DNA B
+    alex.author_entry(&ENTRY_ADDRESS_3, &ENTRY_CONTENT_3, true)?;
+    alex.author_meta(
+        &ENTRY_ADDRESS_3,
+        &META_LINK_ATTRIBUTE.to_string(),
+        &META_LINK_CONTENT_3,
+        true,
+    )?;
+
+    // Billy requests that meta
+    let fetch_meta = billy.request_meta(ENTRY_ADDRESS_3.clone(), META_LINK_ATTRIBUTE.to_string());
+    // Alex sends HandleFetchMetaResult message
+    alex.reply_to_HandleFetchMeta(&fetch_meta)?;
+    // billy should receive requested metadata
+    let result = billy
+        .wait(Box::new(one_is!(JsonProtocol::FetchMetaResult(_))))
+        .unwrap();
+    log_i!("got GetMetaResult: {:?}", result);
+    let meta_data = unwrap_to!(result => JsonProtocol::FetchMetaResult);
+    assert_eq!(meta_data.entry_address, ENTRY_ADDRESS_3.clone());
+    assert_eq!(meta_data.attribute, META_LINK_ATTRIBUTE.clone());
+    assert_eq!(meta_data.content_list.len(), 1);
+    assert_eq!(meta_data.content_list[0], META_LINK_CONTENT_3.clone());
+
+    // Camille requests that meta
+    let _fetch_meta =
+        camille.request_meta(ENTRY_ADDRESS_3.clone(), META_LINK_ATTRIBUTE.to_string());
+    // Camille should not receive requested metadata
+    let result =
+        camille.wait_with_timeout(Box::new(one_is!(JsonProtocol::FetchMetaResult(_))), 1000);
+    log_i!("got GetMetaResult: {:?}", result);
+    assert!(result.is_none());
+
+    // Done
+    Ok(())
+}

--- a/test_bin/src/p2p_node/test_node.rs
+++ b/test_bin/src/p2p_node/test_node.rs
@@ -886,7 +886,6 @@ impl TestNode {
                 // n/a
             }
             JsonProtocol::HandleSendMessage(msg) => {
-                assert!(self.is_tracking(&msg.dna_address));
                 // log the direct message sent to us
                 self.recv_dm_log.push(msg);
             }
@@ -900,8 +899,7 @@ impl TestNode {
             JsonProtocol::FetchEntryResult(_) => {
                 // n/a
             }
-            JsonProtocol::HandleFetchEntry(msg) => {
-                assert!(self.is_tracking(&msg.dna_address));
+            JsonProtocol::HandleFetchEntry(_msg) => {
                 // n/a
             }
             JsonProtocol::HandleFetchEntryResult(_msg) => {
@@ -912,24 +910,26 @@ impl TestNode {
                 panic!("Core should not receive PublishDhtData message");
             }
             JsonProtocol::HandleStoreEntry(msg) => {
-                assert!(self.is_tracking(&msg.dna_address));
-                // Store data in local datastore
-                let mut dna_store = self
-                    .dna_stores
-                    .get_mut(&msg.dna_address)
-                    .expect("No dna_store for this DNA");
-                dna_store
-                    .entry_store
-                    .insert(msg.entry_address, msg.entry_content);
+                if self.is_tracking(&msg.dna_address) {
+                    // Store data in local datastore
+                    let mut dna_store = self
+                        .dna_stores
+                        .get_mut(&msg.dna_address)
+                        .expect("No dna_store for this DNA");
+                    dna_store
+                        .entry_store
+                        .insert(msg.entry_address, msg.entry_content);
+                }
             }
             JsonProtocol::HandleDropEntry(msg) => {
-                assert!(self.is_tracking(&msg.dna_address));
-                // Remove data in local datastore
-                let mut dna_store = self
-                    .dna_stores
-                    .get_mut(&msg.dna_address)
-                    .expect("No dna_store for this DNA");
-                dna_store.entry_store.remove(&msg.entry_address);
+                if self.is_tracking(&msg.dna_address) {
+                    // Remove data in local datastore
+                    let mut dna_store = self
+                        .dna_stores
+                        .get_mut(&msg.dna_address)
+                        .expect("No dna_store for this DNA");
+                    dna_store.entry_store.remove(&msg.entry_address);
+                }
             }
 
             JsonProtocol::FetchMeta(_msg) => {
@@ -938,8 +938,7 @@ impl TestNode {
             JsonProtocol::FetchMetaResult(_msg) => {
                 // n/a
             }
-            JsonProtocol::HandleFetchMeta(msg) => {
-                assert!(self.is_tracking(&msg.dna_address));
+            JsonProtocol::HandleFetchMeta(_msg) => {
                 // n/a
             }
             JsonProtocol::HandleFetchMetaResult(_msg) => {
@@ -950,15 +949,16 @@ impl TestNode {
                 panic!("Core should not receive PublishDhtMeta message");
             }
             JsonProtocol::HandleStoreMeta(msg) => {
-                assert!(self.is_tracking(&msg.dna_address));
-                // Store data in local datastore
-                let meta_key = (msg.entry_address, msg.attribute);
-                let mut dna_store = self
-                    .dna_stores
-                    .get_mut(&msg.dna_address)
-                    .expect("No dna_store for this DNA");
-                for content in msg.content_list {
-                    dna_store.meta_store.insert(meta_key.clone(), content);
+                if self.is_tracking(&msg.dna_address) {
+                    // Store data in local datastore
+                    let meta_key = (msg.entry_address, msg.attribute);
+                    let mut dna_store = self
+                        .dna_stores
+                        .get_mut(&msg.dna_address)
+                        .expect("No dna_store for this DNA");
+                    for content in msg.content_list {
+                        dna_store.meta_store.insert(meta_key.clone(), content);
+                    }
                 }
             }
             // TODO

--- a/test_bin/src/three_workflows.rs
+++ b/test_bin/src/three_workflows.rs
@@ -174,7 +174,6 @@ pub fn hold_and_publish_test(
     can_connect: bool,
 ) -> NetResult<()> {
     // Setup
-    println!("Testing: hold_entry_list_test()");
     setup_three_nodes(alex, billy, camille, &DNA_ADDRESS_A, can_connect)?;
 
     // Have alex hold some data


### PR DESCRIPTION
## PR summary

send, dht & meta tests with three nodes on 3 DNAs.
Remove some `is_tracking` asserts, since a node can actually untrack before telling its network module.

## changelog
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
