### PR TITLE
Trace signals conditionally exposed

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -297,7 +297,7 @@ scenario2.runTape('delete_entry_post', async (t, { alice, bob }) => {
 
   //delete should fail
   const failedDelete = await bob.callSync("blog", "delete_entry_post", { post_address: createResult.Ok })
-  t.deepEqual(failedDelete.Err, { Internal: 'Entry Could Not Be Found' });
+  t.deepEqual(failedDelete.Err, { Trace: 'Entry Could Not Be Found' });
 
   //get initial entry
   const GetInitialParamsResult = bob.call("blog", "get_initial_post", { post_address: createResult.Ok })
@@ -313,7 +313,7 @@ scenario2.runTape('update_entry_validation', async (t, { alice, bob }) => {
   const updateParams = { post_address: "1234", new_content: "Hello Holo V2" }
   const UpdateResult = await bob.callSync("blog", "update_post", updateParams)
 
-  t.deepEqual(UpdateResult.Err, { Internal: 'failed to update post' });
+  t.deepEqual(UpdateResult.Err, { Trace: 'failed to update post' });
 
   const content = "Hello Holo world 321"
   const in_reply_to = null
@@ -326,7 +326,7 @@ scenario2.runTape('update_entry_validation', async (t, { alice, bob }) => {
 
   const updateParamsV2 = { post_address: createResult.Ok, new_content: "Hello Holo world 321" }
   const UpdateResultV2 = await bob.callSync("blog", "update_post", updateParamsV2)
-  t.deepEqual(JSON.parse(UpdateResultV2.Err.Internal).kind.ValidationFailed, "Trying to modify with same data");
+  t.deepEqual(JSON.parse(UpdateResultV2.Err.Trace).kind.ValidationFailed, "Trying to modify with same data");
 
 
 })
@@ -471,7 +471,7 @@ scenario2.runTape('remove_update_modifed_entry', async (t, { alice, bob }) => {
 
   //failed delete
   const failedDelete = await alice.callSync("blog", "delete_entry_post", { post_address: createResult.Ok })
-  t.deepEqual(failedDelete.Err, { Internal: 'Entry Could Not Be Found' });
+  t.deepEqual(failedDelete.Err, { Trace: 'Entry Could Not Be Found' });
 })
 
 scenario1.runTape('create_post with bad reply to', async (t, { alice }) => {
@@ -483,7 +483,7 @@ scenario1.runTape('create_post with bad reply to', async (t, { alice }) => {
   // bad in_reply_to is an error condition
   t.ok(result.Err)
   t.notOk(result.Ok)
-  const error = JSON.parse(result.Err.Internal)
+  const error = JSON.parse(result.Err.Trace)
   t.deepEqual(error.kind, { ErrorGeneric: "Base for link not found" })
   t.ok(error.file)
   t.ok(error.line)
@@ -498,7 +498,7 @@ scenario2.runTape('delete_post_with_bad_link', async (t, { alice, bob }) => {
   // bad in_reply_to is an error condition
   t.ok(result_bob_delete.Err)
   t.notOk(result_bob_delete.Ok)
-  const error = JSON.parse(result_bob_delete.Err.Internal)
+  const error = JSON.parse(result_bob_delete.Err.Trace)
   t.deepEqual(error.kind, { ErrorGeneric: "Target for link not found" })
   t.ok(error.file)
   t.ok(error.line)
@@ -515,7 +515,7 @@ scenario1.runTape('post max content size 280 characters', async (t, { alice }) =
   t.ok(result.Err);
   t.notOk(result.Ok)
 
-  const inner = JSON.parse(result.Err.Internal)
+  const inner = JSON.parse(result.Err.Trace)
 
   t.ok(inner.file)
   t.deepEqual(inner.kind, { "ValidationFailed": "Content too long" })
@@ -558,7 +558,7 @@ scenario1.runTape('my_posts_immediate_timeout', async (t, { alice }) => {
 
   t.ok(result.Err)
   console.log(result)
-  t.equal(JSON.parse(result.Err.Internal).kind, "Timeout")
+  t.equal(JSON.parse(result.Err.Trace).kind, "Timeout")
 })
 
 scenario2.runTape('get_sources_from_link', async (t, { alice, bob }) => {

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -201,12 +201,18 @@ impl Conductor {
                         signal_tx.clone().map(|s| s.send(signal.clone()));
                         let broadcasters = broadcasters.read().unwrap();
                         let interfaces_with_instance: Vec<&InterfaceConfiguration> = match signal {
-                            // Send internal signals only to admin interfaces:
-                            Signal::Trace(_) => config
-                                .interfaces
-                                .iter()
-                                .filter(|interface_config| interface_config.admin)
-                                .collect(),
+                            // Send internal signals only to admin interfaces, if expose_trace_signals is set:
+                            Signal::Trace(_) => {
+                                if config.expose_trace_signals {
+                                    config
+                                        .interfaces
+                                        .iter()
+                                        .filter(|interface_config| interface_config.admin)
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                }
+                            }
 
                             // Pass through user-defined  signals to the according interfaces
                             // in which the source instance is exposed:

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -202,7 +202,7 @@ impl Conductor {
                         let broadcasters = broadcasters.read().unwrap();
                         let interfaces_with_instance: Vec<&InterfaceConfiguration> = match signal {
                             // Send internal signals only to admin interfaces:
-                            Signal::Internal(_) => config
+                            Signal::Trace(_) => config
                                 .interfaces
                                 .iter()
                                 .filter(|interface_config| interface_config.admin)
@@ -1549,11 +1549,11 @@ pub mod tests {
 
         assert!(received_signals.len() >= 3);
         assert!(received_signals[0]
-            .starts_with("{\"signal\":{\"Internal\":\"SignalZomeFunctionCall(ZomeFnCall {"));
+            .starts_with("{\"signal\":{\"Trace\":\"SignalZomeFunctionCall(ZomeFnCall {"));
         assert!(received_signals[1]
-            .starts_with("{\"signal\":{\"Internal\":\"SignalZomeFunctionCall(ZomeFnCall {"));
+            .starts_with("{\"signal\":{\"Trace\":\"SignalZomeFunctionCall(ZomeFnCall {"));
         assert!(received_signals[2].starts_with(
-            "{\"signal\":{\"Internal\":\"ReturnZomeFunctionResult(ExecuteZomeFnResponse {"
+            "{\"signal\":{\"Trace\":\"ReturnZomeFunctionResult(ExecuteZomeFnResponse {"
         ));
     }
 }

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -77,6 +77,10 @@ pub struct Configuration {
     /// Optional DPKI configuration if conductor is using a DPKI app to initalize and manage
     /// keys for new instances
     pub dpki: Option<DpkiConfiguration>,
+
+    /// Send Trace signals through interfaces along with other signals
+    #[serde(default)]
+    pub expose_trace_signals: bool,
 }
 
 pub fn default_persistence_dir() -> PathBuf {

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -726,12 +726,12 @@ mod tests {
             let msg_publish = signal_rx
                 .recv_timeout(Duration::from_millis(timeout))
                 .expect("no more signals to receive (outer)");
-            if let Signal::Internal(Action::Publish(address)) = msg_publish {
+            if let Signal::Trace(Action::Publish(address)) = msg_publish {
                 loop {
                     let msg_hold = signal_rx
                         .recv_timeout(Duration::from_millis(timeout))
                         .expect("no more signals to receive (inner)");
-                    if let Signal::Internal(Action::Hold(entry)) = msg_hold {
+                    if let Signal::Trace(Action::Hold(entry)) = msg_hold {
                         assert_eq!(address, entry.address());
                         break 'outer;
                     }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -229,12 +229,12 @@ impl Instance {
     }
 
     /// Given an `Action` that is being processed, decide whether or not it should be
-    /// emitted as a `Signal::Internal`, and if so, send it
+    /// emitted as a `Signal::Trace`, and if so, send it
     fn maybe_emit_action_signal(&self, context: &Arc<Context>, action: ActionWrapper) {
         if let Some(tx) = context.signal_tx() {
             // @TODO: if needed for performance, could add a filter predicate here
             // to prevent emitting too many unneeded signals
-            let signal = Signal::Internal(action);
+            let signal = Signal::Trace(action);
             tx.send(signal).unwrap_or_else(|e| {
                 context.log(format!(
                     "warn/reduce: Signal channel is closed! No signals can be sent ({:?}).",

--- a/core/src/signal.rs
+++ b/core/src/signal.rs
@@ -7,7 +7,7 @@ use std::thread;
 #[derive(Clone, Debug, Serialize, DefaultJson)]
 #[serde(tag = "signal_type")]
 pub enum Signal {
-    Internal(ActionWrapper),
+    Trace(ActionWrapper),
     User(JsonString),
 }
 

--- a/doc/holochain_101/src/state/actors.md
+++ b/doc/holochain_101/src/state/actors.md
@@ -1,4 +1,4 @@
-# Internal actors
+# Trace actors
 
 Actors are discussed in two contexts:
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -71,7 +71,7 @@ macro_rules! def_api_fns {
                 input: I,
             ) -> ZomeApiResult<O> {
                 let mut mem_stack = unsafe { G_MEM_STACK }
-                .ok_or_else(|| ZomeApiError::Internal("debug failed to load mem_stack".to_string()))?;
+                .ok_or_else(|| ZomeApiError::Trace("debug failed to load mem_stack".to_string()))?;
 
                 let wasm_allocation = mem_stack.write_json(input)?;
 
@@ -171,11 +171,11 @@ def_api_fns! {
 // ZOME API GLOBAL VARIABLES
 //--------------------------------------------------------------------------------------------------
 
-/// Internal global for memory usage
+/// Trace global for memory usage
 pub static mut G_MEM_STACK: Option<WasmStack> = None;
 
 lazy_static! {
-    /// Internal global for retrieving all Zome API globals
+    /// Trace global for retrieving all Zome API globals
     pub(crate) static ref GLOBALS: ZomeApiGlobals = init_globals().unwrap();
 
     /// The `name` property as taken from the DNA.
@@ -1181,7 +1181,7 @@ pub fn get_links_and_load<S: Into<String>>(
         let get_type = get_result?.result;
         match get_type {
             GetEntryResultType::Single(elem) => Ok(elem.entry.unwrap().to_owned()),
-            GetEntryResultType::All(_) => Err(ZomeApiError::Internal("Invalid response. get_links_result returned all entries when latest was requested".to_string()))
+            GetEntryResultType::All(_) => Err(ZomeApiError::Trace("Invalid response. get_links_result returned all entries when latest was requested".to_string()))
         }
     })
     .collect();

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -399,7 +399,7 @@ fn convert_entry_validation_to_native<T: TryFrom<AppEntryValue> + Clone>(
 ) -> ZomeApiResult<T> {
     match entry {
         Entry::App(_, entry_value) => T::try_from(entry_value.to_owned()).map_err(|_| {
-            ZomeApiError::Internal(
+            ZomeApiError::Trace(
                 vec![
                     "Could not convert Entry result to requested type : ".to_string(),
                     entry_value.to_string(),
@@ -407,7 +407,7 @@ fn convert_entry_validation_to_native<T: TryFrom<AppEntryValue> + Clone>(
                 .join(&String::new()),
             )
         }),
-        _ => Err(ZomeApiError::Internal(
+        _ => Err(ZomeApiError::Trace(
             "Entry did not return an app entry".to_string(),
         )),
     }

--- a/hdk-rust/src/error.rs
+++ b/hdk-rust/src/error.rs
@@ -11,7 +11,7 @@ use std::{error::Error, fmt};
 /// This does not have to be sent back to Ribosome unless its an InternalError.
 #[derive(Debug, Serialize, Deserialize, PartialEq, DefaultJson, Clone)]
 pub enum ZomeApiError {
-    Internal(String),
+    Trace(String),
     FunctionNotImplemented,
     HashNotFound,
     ValidationFailed(String),
@@ -40,7 +40,7 @@ impl From<HolochainError> for ZomeApiError {
         match holochain_error {
             HolochainError::ValidationFailed(s) => ZomeApiError::ValidationFailed(s),
             HolochainError::Timeout => ZomeApiError::Timeout,
-            _ => ZomeApiError::Internal(holochain_error.to_string()),
+            _ => ZomeApiError::Trace(holochain_error.to_string()),
         }
     }
 }
@@ -53,7 +53,7 @@ impl From<!> for ZomeApiError {
 
 impl From<String> for ZomeApiError {
     fn from(s: String) -> ZomeApiError {
-        ZomeApiError::Internal(s)
+        ZomeApiError::Trace(s)
     }
 }
 
@@ -66,15 +66,13 @@ impl From<RibosomeErrorCode> for ZomeApiError {
 impl From<AllocationError> for ZomeApiError {
     fn from(allocation_error: AllocationError) -> ZomeApiError {
         match allocation_error {
-            AllocationError::OutOfBounds => {
-                ZomeApiError::Internal("Allocation out of bounds".into())
-            }
-            AllocationError::ZeroLength => ZomeApiError::Internal("Allocation zero length".into()),
+            AllocationError::OutOfBounds => ZomeApiError::Trace("Allocation out of bounds".into()),
+            AllocationError::ZeroLength => ZomeApiError::Trace("Allocation zero length".into()),
             AllocationError::BadStackAlignment => {
-                ZomeApiError::Internal("Allocation out of alignment with stack".into())
+                ZomeApiError::Trace("Allocation out of alignment with stack".into())
             }
             AllocationError::Serialization => {
-                ZomeApiError::Internal("Allocation serialization failure".into())
+                ZomeApiError::Trace("Allocation serialization failure".into())
             }
         }
     }
@@ -85,7 +83,7 @@ impl Error for ZomeApiError {}
 impl fmt::Display for ZomeApiError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ZomeApiError::Internal(msg) => write!(f, "{}", msg),
+            ZomeApiError::Trace(msg) => write!(f, "{}", msg),
             ZomeApiError::FunctionNotImplemented => write!(f, "Function not implemented"),
             ZomeApiError::HashNotFound => write!(f, "Hash not found"),
             ZomeApiError::ValidationFailed(msg) => write!(f, "{}", msg),

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -25,17 +25,17 @@ pub fn get_links_and_load_type<S: Into<String>, R: TryFrom<AppEntryValue>>(
             Ok(entry) => match entry {
                 Entry::App(_, entry_value) => {
                     let typed_entry = R::try_from(entry_value.to_owned()).map_err(|_| {
-                        ZomeApiError::Internal(
+                        ZomeApiError::Trace(
                             "Could not convert get_links result to requested type".to_string(),
                         )
                     })?;
                     Ok(typed_entry)
                 }
-                _ => Err(ZomeApiError::Internal(
+                _ => Err(ZomeApiError::Trace(
                     "get_links did not return an app entry".to_string(),
                 )),
             },
-            _ => Err(ZomeApiError::Internal(
+            _ => Err(ZomeApiError::Trace(
                 "get_links did not return an app entry".to_string(),
             )),
         })
@@ -48,15 +48,12 @@ pub fn get_links_and_load_type<S: Into<String>, R: TryFrom<AppEntryValue>>(
 ///
 pub fn get_as_type<R: TryFrom<AppEntryValue>>(address: Address) -> ZomeApiResult<R> {
     let get_result = hdk::get_entry(&address)?;
-    let entry =
-        get_result.ok_or_else(|| ZomeApiError::Internal("No entry at this address".into()))?;
+    let entry = get_result.ok_or_else(|| ZomeApiError::Trace("No entry at this address".into()))?;
     match entry {
         Entry::App(_, entry_value) => R::try_from(entry_value.to_owned()).map_err(|_| {
-            ZomeApiError::Internal(
-                "Could not convert get_links result to requested type".to_string(),
-            )
+            ZomeApiError::Trace("Could not convert get_links result to requested type".to_string())
         }),
-        _ => Err(ZomeApiError::Internal(
+        _ => Err(ZomeApiError::Trace(
             "get_links did not return an app entry".to_string(),
         )),
     }

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -520,7 +520,7 @@ fn can_invalidate_invalid_commit() {
     );
     assert!(result.is_ok(), "result = {:?}", result);
     assert!(
-        result.unwrap().to_string().contains("{\"Err\":{\"Internal\":\"{\\\"kind\\\":{\\\"ValidationFailed\\\":\\\"FAIL content is not allowed\\\"},\\\"file\\\":\\\"core/src/nucleus/ribosome/runtime.rs\\\",\\\"line\\\":\\\"")
+        result.unwrap().to_string().contains("{\"Err\":{\"Trace\":\"{\\\"kind\\\":{\\\"ValidationFailed\\\":\\\"FAIL content is not allowed\\\"},\\\"file\\\":\\\"core/src/nucleus/ribosome/runtime.rs\\\",\\\"line\\\":\\\"")
     );
 }
 
@@ -563,7 +563,7 @@ fn has_populated_validation_data() {
     //
     /*
     assert_eq!(
-        JsonString::from_json("{\"Err\":{\"Internal\":\"{\\\"package\\\":{\\\"chain_header\\\":{\\\"entry_type\\\":{\\\"App\\\":\\\"validation_package_tester\\\"},\\\"entry_address\\\":\\\"QmYQPp1fExXdKfmcmYTbkw88HnCr3DzMSFUZ4ncEd9iGBY\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmSQqKHPpYZbafF7PXPKx31UwAbNAmPVuSHHxcBoDcYsci\\\",\\\"link_same_type\\\":null,\\\"timestamp\\\":\\\"\\\"},\\\"source_chain_entries\\\":[{\\\"value\\\":\\\"\\\\\\\"non fail\\\\\\\"\\\",\\\"entry_type\\\":\\\"testEntryType\\\"},{\\\"value\\\":\\\"\\\\\\\"non fail\\\\\\\"\\\",\\\"entry_type\\\":\\\"testEntryType\\\"},{\\\"value\\\":\\\"alex\\\",\\\"entry_type\\\":\\\"%agent_id\\\"}],\\\"source_chain_headers\\\":[{\\\"entry_type\\\":{\\\"App\\\":\\\"testEntryType\\\"},\\\"entry_address\\\":\\\"QmXxdzM9uHiSfV1xDwUxMm5jX4rVU8jhtWVaeCzjkFW249\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmRHUwiUuFJiMyRmKaA1U49fXEnT8qbZMoj2V9maa4Q3JE\\\",\\\"link_same_type\\\":\\\"QmRHUwiUuFJiMyRmKaA1U49fXEnT8qbZMoj2V9maa4Q3JE\\\",\\\"timestamp\\\":\\\"\\\"},{\\\"entry_type\\\":{\\\"App\\\":\\\"testEntryType\\\"},\\\"entry_address\\\":\\\"QmXxdzM9uHiSfV1xDwUxMm5jX4rVU8jhtWVaeCzjkFW249\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmRYerwRRXYxmYoxq1LTZMVVRfjNMAeqmdELTNDxURtHEZ\\\",\\\"link_same_type\\\":null,\\\"timestamp\\\":\\\"\\\"},{\\\"entry_type\\\":\\\"AgentId\\\",\\\"entry_address\\\":\\\"QmQw3V41bAWkQA9kwpNfU3ZDNzr9YW4p9RV4QHhFD3BkqA\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmQJxUSfJe2QoxTyEwKQX9ypbkcNv3cw1vasGTx1CUpJFm\\\",\\\"link_same_type\\\":null,\\\"timestamp\\\":\\\"\\\"}],\\\"custom\\\":null},\\\"sources\\\":[\\\"<insert your agent key here>\\\"],\\\"lifecycle\\\":\\\"Chain\\\",\\\"action\\\":\\\"Commit\\\"}\"}}"),
+        JsonString::from_json("{\"Err\":{\"Trace\":\"{\\\"package\\\":{\\\"chain_header\\\":{\\\"entry_type\\\":{\\\"App\\\":\\\"validation_package_tester\\\"},\\\"entry_address\\\":\\\"QmYQPp1fExXdKfmcmYTbkw88HnCr3DzMSFUZ4ncEd9iGBY\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmSQqKHPpYZbafF7PXPKx31UwAbNAmPVuSHHxcBoDcYsci\\\",\\\"link_same_type\\\":null,\\\"timestamp\\\":\\\"\\\"},\\\"source_chain_entries\\\":[{\\\"value\\\":\\\"\\\\\\\"non fail\\\\\\\"\\\",\\\"entry_type\\\":\\\"testEntryType\\\"},{\\\"value\\\":\\\"\\\\\\\"non fail\\\\\\\"\\\",\\\"entry_type\\\":\\\"testEntryType\\\"},{\\\"value\\\":\\\"alex\\\",\\\"entry_type\\\":\\\"%agent_id\\\"}],\\\"source_chain_headers\\\":[{\\\"entry_type\\\":{\\\"App\\\":\\\"testEntryType\\\"},\\\"entry_address\\\":\\\"QmXxdzM9uHiSfV1xDwUxMm5jX4rVU8jhtWVaeCzjkFW249\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmRHUwiUuFJiMyRmKaA1U49fXEnT8qbZMoj2V9maa4Q3JE\\\",\\\"link_same_type\\\":\\\"QmRHUwiUuFJiMyRmKaA1U49fXEnT8qbZMoj2V9maa4Q3JE\\\",\\\"timestamp\\\":\\\"\\\"},{\\\"entry_type\\\":{\\\"App\\\":\\\"testEntryType\\\"},\\\"entry_address\\\":\\\"QmXxdzM9uHiSfV1xDwUxMm5jX4rVU8jhtWVaeCzjkFW249\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmRYerwRRXYxmYoxq1LTZMVVRfjNMAeqmdELTNDxURtHEZ\\\",\\\"link_same_type\\\":null,\\\"timestamp\\\":\\\"\\\"},{\\\"entry_type\\\":\\\"AgentId\\\",\\\"entry_address\\\":\\\"QmQw3V41bAWkQA9kwpNfU3ZDNzr9YW4p9RV4QHhFD3BkqA\\\",\\\"entry_signature\\\":\\\"\\\",\\\"link\\\":\\\"QmQJxUSfJe2QoxTyEwKQX9ypbkcNv3cw1vasGTx1CUpJFm\\\",\\\"link_same_type\\\":null,\\\"timestamp\\\":\\\"\\\"}],\\\"custom\\\":null},\\\"sources\\\":[\\\"<insert your agent key here>\\\"],\\\"lifecycle\\\":\\\"Chain\\\",\\\"action\\\":\\\"Commit\\\"}\"}}"),
         result.unwrap(),
     );
     */
@@ -726,7 +726,7 @@ fn can_validate_links() {
     let zome_result: Result<(), ZomeApiError> =
         serde_json::from_str(&result.unwrap().to_string()).unwrap();
     assert!(zome_result.is_err());
-    if let ZomeApiError::Internal(error) = zome_result.err().unwrap() {
+    if let ZomeApiError::Trace(error) = zome_result.err().unwrap() {
         let core_error: CoreError = serde_json::from_str(&error).unwrap();
         assert_eq!(
             core_error.kind,

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -12,13 +12,15 @@ extern crate holochain_core_types_derive;
 
 use boolinator::Boolinator;
 use hdk::{
+    api::G_MEM_STACK,
     error::{ZomeApiError, ZomeApiResult},
+    global_fns::init_global_memory,
 };
 use holochain_wasm_utils::{
     api_serialization::{
         get_entry::{GetEntryOptions, GetEntryResult},
         get_links::GetLinksResult,
-        query::{ QueryArgsNames, QueryArgsOptions, QueryResult },
+        query::{QueryArgsNames, QueryArgsOptions, QueryResult},
     },
     holochain_core_types::{
         cas::content::{Address, AddressableContent},
@@ -27,24 +29,18 @@ use holochain_wasm_utils::{
             entry_type::{AppEntryType, EntryType},
             AppEntryValue, Entry,
         },
-        error::{
-            HolochainError,
-            RibosomeErrorCode,
-        },
-        json::{JsonString,RawString},
+        error::{HolochainError, RibosomeEncodedValue, RibosomeEncodingBits, RibosomeErrorCode},
+        json::{JsonString, RawString},
+        validation::{EntryValidationData, LinkValidationData},
+    },
+    memory::{
+        allocation::WasmAllocation,
+        ribosome::{load_ribosome_encoded_json, return_code_for_allocation_result},
     },
 };
-use holochain_wasm_utils::holochain_core_types::{validation::{LinkValidationData,EntryValidationData},error::RibosomeEncodingBits};
-use holochain_wasm_utils::memory::ribosome::load_ribosome_encoded_json;
-use holochain_wasm_utils::memory::ribosome::return_code_for_allocation_result;
-use holochain_wasm_utils::memory::allocation::WasmAllocation;
-use hdk::global_fns::init_global_memory;
-use holochain_wasm_utils::holochain_core_types::error::RibosomeEncodedValue;
-use std::convert::TryFrom;
-use std::time::Duration;
-use hdk::api::G_MEM_STACK;
+use std::{convert::TryFrom, time::Duration};
 
-#[derive(Serialize, Deserialize, Debug, DefaultJson,Clone)]
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
 struct TestEntryType {
     stuff: String,
 }
@@ -65,8 +61,9 @@ pub extern "C" fn handle_check_global() -> Address {
 }
 
 #[no_mangle]
-pub extern "C" fn check_commit_entry(encoded_allocation_of_input: RibosomeEncodingBits) -> RibosomeEncodingBits {
-
+pub extern "C" fn check_commit_entry(
+    encoded_allocation_of_input: RibosomeEncodingBits,
+) -> RibosomeEncodingBits {
     let allocation = match WasmAllocation::try_from_ribosome_encoding(encoded_allocation_of_input) {
         Ok(allocation) => allocation,
         Err(allocation_error) => return allocation_error.as_ribosome_encoding(),
@@ -82,8 +79,9 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: RibosomeEncodi
         Ok(entry) => entry,
         Err(hc_err) => {
             hdk::debug(format!("ERROR: {:?}", hc_err.to_string())).ok();
-            return RibosomeEncodedValue::Failure(RibosomeErrorCode::ArgumentDeserializationFailed).into();
-        },
+            return RibosomeEncodedValue::Failure(RibosomeErrorCode::ArgumentDeserializationFailed)
+                .into();
+        }
     };
 
     hdk::debug(format!("Entry: {:?}", entry)).ok();
@@ -100,10 +98,7 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: RibosomeEncodi
         None => return RibosomeEncodedValue::Failure(RibosomeErrorCode::OutOfMemory).into(),
     };
 
-    return_code_for_allocation_result(
-        wasm_stack.write_json(res_obj)
-    ).into()
-
+    return_code_for_allocation_result(wasm_stack.write_json(res_obj)).into()
 }
 
 fn handle_check_commit_entry_macro(entry: Entry) -> ZomeApiResult<Address> {
@@ -169,7 +164,6 @@ fn handle_remove_link() -> ZomeApiResult<()> {
     hdk::commit_entry(&entry_2)?;
     hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")?;
     hdk::remove_link(&entry_1.address(), &entry_2.address(), "test-tag")
-
 }
 
 /// Commit 3 entries
@@ -222,7 +216,7 @@ fn handle_links_roundtrip_get_and_load(
 fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     println!("handle_check_query");
     fn err(s: &str) -> ZomeApiResult<Vec<Address>> {
-        Err(ZomeApiError::Internal(s.to_owned()))
+        Err(ZomeApiError::Trace(s.to_owned()))
     }
 
     // Query DNA entry; EntryTypes will convert into the appropriate single-name enum type
@@ -302,17 +296,27 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     }
 
     // Confirm same results via hdk::query_result
-    let addresses = match hdk::query_result(vec!["[%]*","testEntryType"].into(),
-                                            QueryArgsOptions::default()).unwrap() {
+    let addresses = match hdk::query_result(
+        vec!["[%]*", "testEntryType"].into(),
+        QueryArgsOptions::default(),
+    )
+    .unwrap()
+    {
         QueryResult::Addresses(av) => av,
         _ => return err("Unexpected hdk::query_result"),
     };
     if !addresses.len() == 5 {
         return err("System + testEntryType Addresses enum not length 5");
     };
-    let headers = match hdk::query_result(vec!["[%]*","testEntryType"].into(),
-                                          QueryArgsOptions{ headers: true,
-                                                            ..Default::default()}).unwrap() {
+    let headers = match hdk::query_result(
+        vec!["[%]*", "testEntryType"].into(),
+        QueryArgsOptions {
+            headers: true,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    {
         QueryResult::Headers(hv) => hv,
         _ => return err("Unexpected hdk::query_result"),
     };

--- a/nodejs_conductor/native/src/config.rs
+++ b/nodejs_conductor/native/src/config.rs
@@ -128,6 +128,7 @@ fn make_config(
         instances: instance_configs,
         bridges: bridges,
         logger,
+        expose_trace_signals: true,
         ..Default::default()
     };
     config

--- a/nodejs_conductor/native/src/js_test_conductor.rs
+++ b/nodejs_conductor/native/src/js_test_conductor.rs
@@ -11,19 +11,15 @@ use std::{
 
 use holochain_conductor_api::{
     conductor::Conductor as RustConductor,
-    key_loaders::test_keystore_loader,
     config::{load_configuration, Configuration},
+    key_loaders::test_keystore_loader,
 };
 use holochain_core::{
     action::Action,
-    signal::{signal_channel, Signal, SignalReceiver},
     nucleus::actions::call_zome_function::make_cap_request_for_call,
+    signal::{signal_channel, Signal, SignalReceiver},
 };
-use holochain_core_types::{
-    cas::content::AddressableContent,
-    entry::Entry,
-    json::JsonString,
-};
+use holochain_core_types::{cas::content::AddressableContent, entry::Entry, json::JsonString};
 use holochain_node_test_waiter::waiter::{CallBlockingTask, ControlMsg, MainBackgroundTask};
 
 /// Block until Hold(agent.public_address) is seen for each agent in the conductor.
@@ -36,7 +32,7 @@ fn await_held_agent_ids(config: Configuration, signal_rx: &SignalReceiver) {
         .map(|c| c.public_address.to_string())
         .collect();
     loop {
-        if let Ok(Signal::Internal(aw)) = signal_rx.recv_timeout(Duration::from_millis(10)) {
+        if let Ok(Signal::Trace(aw)) = signal_rx.recv_timeout(Duration::from_millis(10)) {
             let action = aw.action();
             if let Action::Hold(EntryWithHeader {
                 entry: Entry::AgentId(id),

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -158,7 +158,7 @@ impl Waiter {
     pub fn process_signal(&mut self, sig: Signal) {
         let num_instances = self.num_instances;
         match sig {
-            Signal::Internal(ref aw) => {
+            Signal::Trace(ref aw) => {
                 let aw = aw.clone();
                 match (self.current_checker(), aw.action().clone()) {
                     // Pair every `SignalZomeFunctionCall` with one `ReturnZomeFunctionResult`
@@ -377,7 +377,7 @@ mod tests {
     use std::sync::mpsc::sync_channel;
 
     fn sig(a: Action) -> Signal {
-        Signal::Internal(ActionWrapper::new(a))
+        Signal::Trace(ActionWrapper::new(a))
     }
 
     fn mk_entry(ty: &'static str, content: &'static str) -> Entry {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -14,8 +14,7 @@ use holochain_core::{
     logger::{test_logger, TestLogger},
     nucleus::actions::call_zome_function::make_cap_request_for_call,
     signal::Signal,
-}
-;
+};
 use holochain_core_types::{
     cas::content::AddressableContent,
     dna::{
@@ -34,9 +33,9 @@ use holochain_net::p2p_config::P2pConfig;
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap},
     fs::File,
-    path::PathBuf,
     hash::{Hash, Hasher},
     io::prelude::*,
+    path::PathBuf,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -116,7 +115,6 @@ pub fn create_test_dna_with_wasm(zome_name: &str, wasm: Vec<u8>) -> Dna {
         EntryType::App(AppEntryType::from("testEntryTypeC")),
         test_entry_c_def,
     );
-
 
     let mut zome = Zome::new(
         "some zome description",
@@ -290,7 +288,7 @@ where
             .recv_timeout(Duration::from_millis(timeout))
             .map_err(|e| e.to_string())?
         {
-            Signal::Internal(aw) => {
+            Signal::Trace(aw) => {
                 let action = aw.action().clone();
                 if f(&action) {
                     return Ok(action);


### PR DESCRIPTION
## PR summary

* Rename `Signal::Internal` to `Signal::Trace`
* Add `expose_trace_signals` bool to `Configuration`, if false then Trace signals will never be emitted over any interface
* Set `expose_trace_signals` to true for nodejs conductor config

**The first commit is noisy, it's just the sweeping rename to `Trace`. Look at the second commit for the actual filtering logic**

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
