### PR TITLE
adds get_public_key hdk fn

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds a new hdk::keystore_get_public_key function which returns the public key of a key secret from the keystore.
+
 ### Changed
 - Adds new RPC method to conductor `test/agent/add` which adds an agent but does not save the config or generate a keystore. This is added to enable tests that run against the Rust conductor [PR#1359](https://github.com/holochain/holochain-rust/pull/1359)
 - Updated linked [n3h](https://github.com/holochain/n3h) version to v0.0.12-alpha [#1369](https://github.com/holochain/holochain-rust/pull/1369)

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -62,6 +62,10 @@ scenario2.runTape('secrets', async (t, { alice }) => {
     const VerificationResult1 = alice.call("converse", "verify_message", { message, provenance: provenance1 });
     t.deepEqual(VerificationResult1, { Ok: false });
 
+    const GetKeyResult = alice.call("converse", "get_pubkey", {src_id: "app_key:1" });
+    t.ok(GetKeyResult)
+    t.deepEqual(GetKeyResult,AddKeyResult)
+
 })
 
 scenario2.runTape('agentId', async (t, { alice, bob }) => {

--- a/app_spec/zomes/converse/code/src/lib.rs
+++ b/app_spec/zomes/converse/code/src/lib.rs
@@ -32,6 +32,11 @@ pub fn handle_add_key(src_id: String, dst_id: String) -> ZomeApiResult<JsonStrin
     Ok(JsonString::from_json(&key_str))
 }
 
+pub fn handle_get_pubkey(src_id: String) -> ZomeApiResult<JsonString> {
+    let key_str = hdk::keystore_get_public_key(src_id)?;
+    Ok(JsonString::from_json(&key_str))
+}
+
 pub fn handle_add_seed(src_id: String, dst_id: String, index: u64) -> ZomeApiResult<()> {
     hdk::keystore_derive_seed(src_id, dst_id, "mycntext".to_string(), index)
 }
@@ -77,6 +82,12 @@ define_zome! {
             handler: handle_add_key
         }
 
+        get_pubkey: {
+            inputs: |src_id: String|,
+            outputs: |result: ZomeApiResult<JsonString>|,
+            handler: handle_get_pubkey
+        }
+
         list_secrets: {
             inputs: | |,
             outputs: |result: ZomeApiResult<Vec<String>>|,
@@ -86,6 +97,6 @@ define_zome! {
     ]
 
     traits: {
-        hc_public [sign_message, verify_message, add_key, add_seed, list_secrets]
+        hc_public [sign_message, verify_message, add_key, add_seed, list_secrets, get_pubkey]
     }
 }

--- a/core/src/nucleus/ribosome/api/keystore.rs
+++ b/core/src/nucleus/ribosome/api/keystore.rs
@@ -185,3 +185,38 @@ pub fn invoke_keystore_sign(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeAp
 
     runtime.store_result(Ok(JsonString::from_json(&string)))
 }
+
+pub fn invoke_keystore_get_public_key(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
+    let context = runtime.context()?;
+    // deserialize args
+    let args_str = runtime.load_json_string_from_args(&args);
+
+    let result = conductor_callback(
+        "agent/keystore/get_public_key",
+        &args_str.to_string(),
+        context.clone(),
+    );
+    let string: String = match result {
+        Ok(json_string) => {
+            context.log(format!(
+                "debug/zome: keystore_get_public_key json_string:{:?}",
+                json_string
+            ));
+            let value: Value = serde_json::from_str(&json_string.to_string()).unwrap();
+            value["pub_key"].to_string()
+        }
+        Err(err) => {
+            context.log(format!(
+                "err/zome: agent/keystore/get_public_key callback failed: {:?}",
+                err
+            ));
+            return ribosome_error_code!(CallbackFailed);
+        }
+    };
+
+    context.log(format!(
+        "debug/zome: pubkey for args:{:?} is:{:?}",
+        args_str, string
+    ));
+    runtime.store_result(Ok(JsonString::from_json(&string)))
+}

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -33,8 +33,9 @@ use crate::nucleus::ribosome::{
         get_links::invoke_get_links,
         init_globals::invoke_init_globals,
         keystore::{
-            invoke_keystore_derive_key, invoke_keystore_derive_seed, invoke_keystore_list,
-            invoke_keystore_new_random, invoke_keystore_sign,
+            invoke_keystore_derive_key, invoke_keystore_derive_seed,
+            invoke_keystore_get_public_key, invoke_keystore_list, invoke_keystore_new_random,
+            invoke_keystore_sign,
         },
         link_entries::invoke_link_entries,
         query::invoke_query,
@@ -129,6 +130,9 @@ link_zome_api! {
 
     /// Sign a block of data using a key in the keystore
     "hc_keystore_sign", KeystoreSign, invoke_keystore_sign;
+
+    /// Get the public key for a given secret
+    "hc_keystore_get_public_key", KeystoreGetPublicKey, invoke_keystore_get_public_key;
 
     /// Commit a capability grant to the source chain
     "hc_grant_capability", GrantCapability, invoke_grant_capability;

--- a/doc/holochain_101/src/zome/crypto.md
+++ b/doc/holochain_101/src/zome/crypto.md
@@ -17,6 +17,7 @@ Here are the available functions:
 - `keystore_derive_seed(src_id,dst_id,context,index)` -> derives a higherarchical deterministic key seed to be identifided by `dst_id` from the `src_id`.  Uses `context` and `index` as part of the derivation path.
 - `keystore_derive_key(src_id,dst_id,key_type)`-> derives a key (signing or encrypting) to be identified by `dst_id` from a previously created seed identified by `src_id`.  This function returns the public key of the keypair.
 - `keystore_sign(src_id,payload)` -> returns a signature of the payload as signed by the key identified by `src_id`
+- `keystore_get_public_key(src_id)` -> returns a the public key of a key identified by `src_id`.  Returns an error if you pass an identifier of a seed secret.
 - `sign(payload)` -> signs the payload using the DNA's instance agent ID public key.  This is a convenience function which is equivalent to calling `keystore_sign("primary_keybundle:sign_key",payload)`
 - `sign_one_time(payload_list)` -> signs the payloads with a randomly generated key-pair, returning the signatures and the public key of the key-pair after shredding the private-key.
 - `verify_signature(provenance, payload)` -> verifies that the `payload` matches the `provenance` which is a public key/signature pair.

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -24,8 +24,8 @@ use holochain_wasm_utils::{
         },
         get_links::{GetLinksArgs, GetLinksOptions, GetLinksResult},
         keystore::{
-            KeyType, KeystoreDeriveKeyArgs, KeystoreDeriveSeedArgs, KeystoreListResult,
-            KeystoreNewRandomArgs, KeystoreSignArgs,
+            KeyType, KeystoreDeriveKeyArgs, KeystoreDeriveSeedArgs, KeystoreGetPublicKeyArgs,
+            KeystoreListResult, KeystoreNewRandomArgs, KeystoreSignArgs,
         },
         link_entries::LinkEntriesArgs,
         send::{SendArgs, SendOptions},
@@ -164,6 +164,7 @@ def_api_fns! {
     hc_keystore_derive_seed, KeystoreDeriveSeed;
     hc_keystore_derive_key, KeystoreDeriveKey;
     hc_keystore_sign, KeystoreSign;
+    hc_keystore_get_public_key, KeystoreGetPublicKey;
     hc_grant_capability, GrantCapability;
 }
 
@@ -407,6 +408,8 @@ pub enum BundleOnClose {
 /// # pub fn hc_keystore_derive_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 /// # #[no_mangle]
 /// # pub fn hc_keystore_sign(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
+/// # #[no_mangle]
+/// # pub fn hc_keystore_get_public_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 /// #[no_mangle]
 /// # pub fn hc_grant_capability(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 ///
@@ -507,6 +510,8 @@ pub enum BundleOnClose {
 /// # pub fn hc_keystore_derive_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 /// # #[no_mangle]
 /// # pub fn hc_keystore_sign(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
+/// # #[no_mangle]
+/// # pub fn hc_keystore_get_public_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 /// #[no_mangle]
 /// # pub fn hc_grant_capability(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 ///
@@ -979,6 +984,15 @@ pub fn keystore_sign<S: Into<String>>(src_id: S, payload: S) -> ZomeApiResult<St
     })
 }
 
+/// Returns the public key of a key secret
+/// Accepts one argument: the keystore ID of the desired public key.
+/// Fails if the id is a Seed secret.
+pub fn keystore_get_public_key<S: Into<String>>(src_id: S) -> ZomeApiResult<String> {
+    Dispatch::KeystoreGetPublicKey.with_input(KeystoreGetPublicKeyArgs {
+        src_id: src_id.into(),
+    })
+}
+
 /// NOT YET AVAILABLE
 // Returns a DNA property, which are defined by the DNA developer.
 // They are custom values that are defined in the DNA file
@@ -1349,6 +1363,8 @@ pub fn query_result(
 /// # pub fn hc_keystore_derive_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 /// # #[no_mangle]
 /// # pub fn hc_keystore_sign(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
+/// # #[no_mangle]
+/// # pub fn hc_keystore_get_public_key(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 /// #[no_mangle]
 /// # pub fn hc_grant_capability(_: RibosomeEncodingBits) -> RibosomeEncodingBits { RibosomeEncodedValue::Success.into() }
 ///

--- a/wasm_utils/src/api_serialization/keystore.rs
+++ b/wasm_utils/src/api_serialization/keystore.rs
@@ -41,3 +41,8 @@ pub struct KeystoreSignArgs {
     pub src_id: String,
     pub payload: String,
 }
+
+#[derive(Deserialize, Clone, PartialEq, Eq, Hash, Debug, Serialize, DefaultJson)]
+pub struct KeystoreGetPublicKeyArgs {
+    pub src_id: String,
+}


### PR DESCRIPTION
## PR summary

Added new hdk function `keystore_get_public_key(<id>)` 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
