### PR TITLE
Make keystore_file optional, for test agents

### DIFF
--- a/cli/src/cli/run.rs
+++ b/cli/src/cli/run.rs
@@ -109,7 +109,7 @@ fn agent_configuration() -> AgentConfiguration {
         id: AGENT_CONFIG_ID.into(),
         name: agent_id.nick,
         public_address: agent_id.pub_sign_key,
-        keystore_file: agent_name,
+        keystore_file: Some(agent_name),
         holo_remote_key: None,
     }
 }

--- a/cli/src/cli/run.rs
+++ b/cli/src/cli/run.rs
@@ -276,7 +276,7 @@ mod tests {
                 name: "testAgent".to_string(),
                 public_address: "HcScjN8wBwrn3tuyg89aab3a69xsIgdzmX5P9537BqQZ5A7TEZu7qCY4Xzzjhma"
                     .to_string(),
-                keystore_file: "testAgent".to_string(),
+                keystore_file: Some("testAgent".to_string()),
                 holo_remote_key: None,
             },
         );

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -444,7 +444,7 @@ impl ConductorAdmin for Conductor {
             id: id.clone(),
             name,
             public_address: public_address.clone(),
-            keystore_file: keystore_file,
+            keystore_file: Some(keystore_file),
             holo_remote_key: holo_remote_key.map(|_| true),
         };
 

--- a/conductor_api/src/conductor/test_admin.rs
+++ b/conductor_api/src/conductor/test_admin.rs
@@ -28,7 +28,7 @@ impl ConductorTestAdmin for Conductor {
             id: id.clone(),
             name: name.clone(),
             public_address: public_address.clone(),
-            keystore_file: name.clone(),
+            keystore_file: None,
             holo_remote_key: None,
         };
         new_config.agents.push(new_agent);

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -358,7 +358,8 @@ pub struct AgentConfiguration {
     pub id: String,
     pub name: String,
     pub public_address: Base32,
-    pub keystore_file: String,
+    #[serde(default)]
+    pub keystore_file: Option<String>,
     /// If set to true conductor will ignore keystore_file and instead use the remote signer
     /// accessible through signing_service_uri to request signatures.
     pub holo_remote_key: Option<bool>,
@@ -613,7 +614,8 @@ pub mod tests {
                 .get(0)
                 .expect("expected at least 2 agents")
                 .clone()
-                .keystore_file,
+                .keystore_file
+                .unwrap(),
             "file/to/serialize"
         );
         assert_eq!(

--- a/nodejs_conductor/native/src/config.rs
+++ b/nodejs_conductor/native/src/config.rs
@@ -102,7 +102,7 @@ fn make_config(
                 id: agent_name.clone(),
                 name: agent_name.clone(),
                 public_address: keybundle.get_id(),
-                keystore_file: agent_name.clone(),
+                keystore_file: Some(agent_name.clone()),
                 holo_remote_key: None,
             };
             config


### PR DESCRIPTION
## PR summary

Add-on to #1359, which attempts to load a bogus keystore_file on instance creation. This makes `keystore_file` optional, with `None` representing a test agent using the `test_keystore`.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
