### PR TITLE
adds the agent keystore to the config struct. The line that was missing

### DIFF
--- a/conductor_api/src/conductor/test_admin.rs
+++ b/conductor_api/src/conductor/test_admin.rs
@@ -49,10 +49,12 @@ pub mod tests {
     #[test]
     fn test_add_test_agent() {
         let test_name = "test_add_test_agent";
+        let agent_id = "testAgent1".to_string();
         let mut conductor = create_test_conductor(test_name, 5001);
         let agent_address = conductor
-            .add_test_agent("testAgent1".to_string(), "Test Agent 1".to_string())
+            .add_test_agent(agent_id.clone(), "Test Agent 1".to_string())
             .expect("Could not add test agent");
-        assert_eq!(agent_address.len(), 63,)
+        assert_eq!(agent_address.len(), 63,);
+        assert!(conductor.get_keystore_for_agent(&agent_id).is_ok());
     }
 }

--- a/conductor_api/src/conductor/test_admin.rs
+++ b/conductor_api/src/conductor/test_admin.rs
@@ -34,6 +34,7 @@ impl ConductorTestAdmin for Conductor {
         new_config.agents.push(new_agent);
         new_config.check_consistency()?;
         self.config = new_config;
+        self.add_agent_keystore(id.clone(), keystore);
         // self.save_config()?; we don't actually want to save it for tests
         notify(format!("Added agent \"{}\"", id));
         Ok(public_address)


### PR DESCRIPTION
## PR summary

one-liner! (excluding the test code)

Adds the piece that was missing and preventing the test agent from working correctly. The keystore was not being assigned to the conductor object so it was trying to load it later from a non-existent file.

Fixes bug in #1359

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
