### PR TITLE
Get entry from local chain in responsd_validation_package

### DIFF
--- a/core/src/workflows/respond_validation_package_request.rs
+++ b/core/src/workflows/respond_validation_package_request.rs
@@ -4,14 +4,11 @@ use crate::{
     instance::dispatch_action,
     network::direct_message::DirectMessage,
     nucleus::actions::{
-        build_validation_package::build_validation_package,
-        get_entry::get_entry_from_agent_chain
+        build_validation_package::build_validation_package, get_entry::get_entry_from_agent_chain,
     },
 };
 
-use holochain_core_types::{
-    cas::content::Address, signature::Provenance,
-};
+use holochain_core_types::{cas::content::Address, signature::Provenance};
 use std::{sync::Arc, vec::Vec};
 
 pub async fn respond_validation_package_request(
@@ -21,14 +18,16 @@ pub async fn respond_validation_package_request(
     context: Arc<Context>,
     provenances: &Vec<Provenance>,
 ) {
-    let maybe_validation_package = match get_entry_from_agent_chain(&context, &requested_entry_address) {
-        Ok(Some(entry)) => await!(build_validation_package(
-            &entry,
-            context.clone(),
-            provenances
-        )).ok(),
-        _ => None,
-    };
+    let maybe_validation_package =
+        match get_entry_from_agent_chain(&context, &requested_entry_address) {
+            Ok(Some(entry)) => await!(build_validation_package(
+                &entry,
+                context.clone(),
+                provenances
+            ))
+            .ok(),
+            _ => None,
+        };
 
     if maybe_validation_package.is_some() {
         context.log(format!(

--- a/core/src/workflows/respond_validation_package_request.rs
+++ b/core/src/workflows/respond_validation_package_request.rs
@@ -3,30 +3,16 @@ use crate::{
     context::Context,
     instance::dispatch_action,
     network::direct_message::DirectMessage,
-    nucleus::actions::build_validation_package::build_validation_package,
+    nucleus::actions::{
+        build_validation_package::build_validation_package,
+        get_entry::get_entry_from_agent_chain
+    },
 };
 
 use holochain_core_types::{
-    cas::content::Address, entry::Entry, error::HolochainError, signature::Provenance,
+    cas::content::Address, signature::Provenance,
 };
-use std::{convert::TryFrom, sync::Arc, vec::Vec};
-
-fn get_entry(address: &Address, context: &Arc<Context>) -> Result<Entry, HolochainError> {
-    let raw = context
-        .state()
-        .unwrap()
-        .agent()
-        .chain_store()
-        .content_storage()
-        .read()
-        .unwrap()
-        .fetch(address)?
-        .ok_or(HolochainError::ErrorGeneric(
-            "Entry not found when trying to build validation package".to_string(),
-        ))?;
-
-    Entry::try_from(raw)
-}
+use std::{sync::Arc, vec::Vec};
 
 pub async fn respond_validation_package_request(
     to_agent_id: Address,
@@ -35,14 +21,13 @@ pub async fn respond_validation_package_request(
     context: Arc<Context>,
     provenances: &Vec<Provenance>,
 ) {
-    let maybe_validation_package = match get_entry(&requested_entry_address, &context) {
-        Ok(entry) => await!(build_validation_package(
+    let maybe_validation_package = match get_entry_from_agent_chain(&context, &requested_entry_address) {
+        Ok(Some(entry)) => await!(build_validation_package(
             &entry,
             context.clone(),
             provenances
-        ))
-        .ok(),
-        Err(_) => None,
+        )).ok(),
+        _ => None,
     };
 
     if maybe_validation_package.is_some() {


### PR DESCRIPTION
## PR summary

Removes the custom get_entry function in this module and uses the existing `get_entry_from_agent_chain` instead

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
