### PR TITLE
WIP: Link type tagging

### DIFF
--- a/app_spec/test/query.js
+++ b/app_spec/test/query.js
@@ -1,0 +1,36 @@
+const path = require('path')
+const { Config, Conductor, Scenario } = require('../../nodejs_conductor')
+Scenario.setTape(require('tape'))
+
+const dnaPath = path.join(__dirname, "../dist/app_spec.dna.json")
+const dna = Config.dna(dnaPath, 'app-spec')
+const agentAlice = Config.agent("alice")
+
+const instanceAlice = Config.instance(agentAlice, dna)
+
+const scenario = new Scenario([instanceAlice], { debugLog: true })
+
+scenario.runTape('query posts based using time index', async (t, {alice}) => {
+    let date = new Date(); //Get current timestamp - post should be linked to the same timestamps
+    date.toISOString();
+    let year = date.getFullYear().toString();
+    let month = date.getMonth().toString();
+    let day = date.getDate().toString();
+    let hour = date.getHours().toString();
+    
+    //create post which will create index links on following timestamp anchors: year, month, day, hour
+    const create1 = await alice.callSync("blog","create_post", {content: 'hi', in_reply_to: null})
+    t.ok(create1)
+
+    //Get the hash of the month timestamp we want to start our query from
+    const timestamp_base_hash_month = await alice.callSync("blog", "get_timestamp_address", {timestamp: month, time_type: "Month"})
+    t.equal(timestamp_base_hash_month.Ok, 'QmaNY1DwVqCA5S1PEgzBgSxcVo7XU6oFxMjf4ABpo7i74h')
+  
+    //Query where month is current month, year, day and hour. This would return all posts which where posted in given year, month, day, hour
+    const query = await alice.callSync("blog", "query_posts", {base: timestamp_base_hash_month.Ok, query_string: year+"<Time:Y>:"+day+"<Time:D>:"+hour+"<Time:H>"})
+    t.ok(query)
+
+    //Query to return all posts posted in given month and year
+    const query = await alice.callSync("blog", "query_posts", {base: timestamp_base_hash_month.Ok, query_string: year+"<Time:Y>"})
+    t.ok(query)
+  })

--- a/app_spec/test/query.js
+++ b/app_spec/test/query.js
@@ -31,6 +31,6 @@ scenario.runTape('query posts based using time index', async (t, {alice}) => {
     t.ok(query)
 
     //Query to return all posts posted in given month and year
-    const query = await alice.callSync("blog", "query_posts", {base: timestamp_base_hash_month.Ok, query_string: year+"<Time:Y>"})
-    t.ok(query)
+    const query2 = await alice.callSync("blog", "query_posts", {base: timestamp_base_hash_month.Ok, query_string: year+"<Time:Y>"})
+    t.ok(query2)
   })

--- a/app_spec/test/run.sh
+++ b/app_spec/test/run.sh
@@ -1,6 +1,6 @@
 if [ -z $1 ]
 then
-	tape test.js regressions.js | tee test.out~ | faucet || ( cat test.out~; false )
+	tape test.js regressions.js query.js | tee test.out~ | faucet || ( cat test.out~; false )
 else
 	tape $1
 fi

--- a/app_spec/zomes/blog/code/Cargo.toml
+++ b/app_spec/zomes/blog/code/Cargo.toml
@@ -10,6 +10,8 @@ hdk = { path = "../../../../hdk-rust" }
 holochain_core_types_derive = { path = "../../../../core_types_derive" }
 serde_derive = "=1.0.89"
 boolinator = "=2.4.0"
+maplit = "=1.0.1"
+itertools = "=0.8"
 
 [lib]
 path = "src/lib.rs"

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -5,14 +5,18 @@ extern crate hdk;
 #[macro_use]
 extern crate serde_derive;
 extern crate boolinator;
+#[macro_use] 
+extern crate maplit;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate holochain_core_types_derive;
+extern crate itertools;
 
 pub mod blog;
 pub mod memo;
 pub mod post;
+pub mod time;
 
 use blog::Env;
 use hdk::{
@@ -31,7 +35,8 @@ define_zome! {
 
     entries: [
         post::definition(),
-        memo::definition()
+        memo::definition(),
+        time::definition()
     ]
 
     genesis: || {
@@ -182,6 +187,18 @@ define_zome! {
             handler : blog::handle_get_history_post
         }
 
+        get_timestamp_address: {
+            inputs: |timestamp: String, time_type: time::TimeType|,
+            outputs: |result: ZomeApiResult<Address>|,
+            handler: blog::handle_get_timestamp_address
+        }
+
+        query_posts: {
+            inputs: |base: Address, query_string: String|,
+            outputs: |result: ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>>|,
+            handler: blog::handle_query_posts
+        }
+
         my_posts: {
             inputs: | |,
             outputs: |post_hashes: ZomeApiResult<GetLinksResult>|,
@@ -239,6 +256,6 @@ define_zome! {
     ]
 
     traits: {
-        hc_public [show_env, check_sum, ping, get_sources, post_address, create_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged]
+        hc_public [show_env, check_sum, ping, get_sources, post_address, create_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged, query_posts, get_timestamp_address]
     }
 }

--- a/app_spec/zomes/blog/code/src/post.rs
+++ b/app_spec/zomes/blog/code/src/post.rs
@@ -80,6 +80,7 @@ pub fn definition() -> ValidatingEntryType {
             from!(
                 "%agent_id",
                 tag: "authored_posts",
+                r#type: "authored_posts",
                 validation_package: || {
                     hdk::ValidationPackageDefinition::ChainFull
                 },
@@ -90,6 +91,18 @@ pub fn definition() -> ValidatingEntryType {
             from!(
                 "%agent_id",
                 tag: "recommended_posts",
+                r#type: "recommended_posts",
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::ChainFull
+                },
+                validation: | _validation_data: hdk::LinkValidationData | {
+                    Ok(())
+                }
+            ),
+            from!(
+                "time",
+                tag: "*",
+                r#type: "time_index",
                 validation_package: || {
                     hdk::ValidationPackageDefinition::ChainFull
                 },
@@ -144,10 +157,17 @@ mod tests {
                 LinkedFrom {
                     base_type: "%agent_id".to_string(),
                     tag: "authored_posts".to_string(),
+                    r#type: "authored_posts".to_string(),
                 },
                 LinkedFrom {
                     base_type: "%agent_id".to_string(),
                     tag: "recommended_posts".to_string(),
+                    r#type: "recommended_posts".to_string(),
+                },
+                LinkedFrom { 
+                    base_type: "time".to_string(),
+                    tag: "*".to_string(),
+                    r#type: "time_index".to_string(), 
                 },
             ],
             links_to: Vec::new(),
@@ -215,5 +235,9 @@ mod tests {
 
         let expected_link_tag = "authored_posts";
         assert_eq!(post_definition_link.tag.to_owned(), expected_link_tag,);
+
+        //assert expected post type
+        let expected_link_type = "authored_posts";
+        assert_eq!(post_definition_link.r#type.to_owned(), expected_link_type,)
     }
 }

--- a/app_spec/zomes/blog/code/src/time.rs
+++ b/app_spec/zomes/blog/code/src/time.rs
@@ -1,0 +1,88 @@
+//use boolinator::Boolinator;
+use hdk::entry_definition::ValidatingEntryType;
+/// This file holds everything that represents the "post" entry type.
+use hdk::holochain_core_types::{
+    dna::entry_types::Sharing, error::HolochainError, json::JsonString,
+};
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone, PartialEq)]
+pub enum TimeType {
+    Year, 
+    Month,
+    Day,
+    Hour
+}
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
+pub struct Time {
+    pub time: String,
+    pub time_type: TimeType,
+}
+
+impl Time {
+    pub fn new(time: &str, time_type: &TimeType) -> Time {
+        Time {
+            time: time.to_owned(),
+            time_type: time_type.to_owned(),
+        }
+    }
+
+    pub fn content(&self) -> String {
+        self.time.clone()
+    }
+
+    pub fn time_type(&self) -> TimeType{
+        self.time_type.clone()
+    }
+}
+
+pub fn definition() -> ValidatingEntryType {
+    entry!(
+        name: "time",
+        description: "A time entry - used for time based indexing",
+        sharing: Sharing::Public,
+
+        validation_package: || {
+            hdk::ValidationPackageDefinition::ChainFull
+        },
+
+        validation: |_validation_data: hdk::EntryValidationData<Time>| {
+            Ok(())
+        },
+
+        links: [
+            to!(
+                "post",
+                tag: "*", //Any tag or expression tag
+                r#type: "time_index",
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::ChainFull
+                },
+                validation: |_validation_data: hdk::LinkValidationData| {
+                    Ok(())
+                }   
+            )
+        ]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::time::{Time, TimeType};
+
+    #[test]
+    fn time_smoke_test() {
+        let content = "01";
+        let time_type = TimeType::Month;
+        let time = Time::new(content, &time_type);
+
+        assert_eq!(content.to_string(), time.content(),);
+
+        assert_eq!(time_type, time.time_type(),);
+    }
+
+    #[test]
+    fn time_definition_test() {
+
+    }
+}

--- a/core/src/dht/actions/add_link.rs
+++ b/core/src/dht/actions/add_link.rs
@@ -74,7 +74,7 @@ mod tests {
         nucleus::actions::tests::commit(base.clone(), &context);
 
         let target = base.clone();
-        let link = Link::new(&base.address(), &target.address(), "test-tag");
+        let link = Link::new(&base.address(), &target.address(), "test-tag", "test-type");
 
         let result = context.block_on(add_link(&link, &context.clone()));
 
@@ -87,7 +87,7 @@ mod tests {
 
         let base = test_entry();
         let target = base.clone();
-        let link = Link::new(&base.address(), &target.address(), "test-tag");
+        let link = Link::new(&base.address(), &target.address(), "test-tag", "test-type");
 
         let result = context.block_on(add_link(&link, &context.clone()));
 

--- a/core/src/dht/dht_reducers.rs
+++ b/core/src/dht/dht_reducers.rs
@@ -414,7 +414,7 @@ pub mod tests {
         let _ = (storage.write().unwrap()).add(&entry);
         let context = Arc::new(context);
 
-        let link = Link::new(&entry.address(), &entry.address(), "test-tag");
+        let link = Link::new(&entry.address(), &entry.address(), "test-tag", "test-type");
         let action = ActionWrapper::new(Action::AddLink(link.clone()));
 
         let new_dht_store: DhtStore;
@@ -454,7 +454,7 @@ pub mod tests {
         let _ = (storage.write().unwrap()).add(&entry);
         let context = Arc::new(context);
 
-        let link = Link::new(&entry.address(), &entry.address(), "test-tag");
+        let link = Link::new(&entry.address(), &entry.address(), "test-tag", "test-type");
         let mut action = ActionWrapper::new(Action::AddLink(link.clone()));
 
         let new_dht_store: DhtStore;
@@ -508,7 +508,7 @@ pub mod tests {
         context.set_state(locked_state.clone());
         let context = Arc::new(context);
 
-        let link = Link::new(&entry.address(), &entry.address(), "test-tag");
+        let link = Link::new(&entry.address(), &entry.address(), "test-tag", "test-type");
         let action = ActionWrapper::new(Action::AddLink(link.clone()));
 
         let new_dht_store: DhtStore;

--- a/core/src/link_tests.rs
+++ b/core/src/link_tests.rs
@@ -20,6 +20,7 @@ pub mod tests {
             &Address::from("12".to_string()),
             &Address::from("34".to_string()),
             "fake",
+            "fake",
         )
     }
 
@@ -32,6 +33,7 @@ pub mod tests {
             &Address::from("56".to_string()),
             &Address::from("78".to_string()),
             "faux",
+            "faux",
         )
     }
 
@@ -39,6 +41,7 @@ pub mod tests {
         Link::new(
             &Address::from("90".to_string()),
             &Address::from("ab".to_string()),
+            "fake",
             "fake",
         )
     }

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -246,8 +246,18 @@ pub mod tests {
             entry_addresses.push(address);
         }
 
-        let link1 = LinkData::new_add(&entry_addresses[0], &entry_addresses[1], "test-tag");
-        let link2 = LinkData::new_add(&entry_addresses[0], &entry_addresses[2], "test-tag");
+        let link1 = LinkData::new_add(
+            &entry_addresses[0],
+            &entry_addresses[1],
+            "test-tag",
+            "test-type",
+        );
+        let link2 = LinkData::new_add(
+            &entry_addresses[0],
+            &entry_addresses[2],
+            "test-tag",
+            "test-type",
+        );
 
         // Store link1 on the network
         println!("\n add_link(link1) ...");

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -87,8 +87,18 @@ pub mod tests {
             entry_addresses.push(address);
         }
 
-        let link1 = Link::new(&entry_addresses[0], &entry_addresses[1], "test-tag");
-        let link2 = Link::new(&entry_addresses[0], &entry_addresses[2], "test-tag");
+        let link1 = Link::new(
+            &entry_addresses[0],
+            &entry_addresses[1],
+            "test-tag",
+            "test-type",
+        );
+        let link2 = Link::new(
+            &entry_addresses[0],
+            &entry_addresses[2],
+            "test-tag",
+            "test-type",
+        );
 
         assert!(initialized_context
             .block_on(add_link(&link1, &initialized_context))

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -71,20 +71,21 @@ pub mod tests {
     }
 
     /// dummy link_entries args from standard test entry
-    pub fn test_link_args_bytes(tag: String) -> Vec<u8> {
+    pub fn test_link_args_bytes(tag: String, r#type: String) -> Vec<u8> {
         let entry = test_entry();
 
         let args = LinkEntriesArgs {
             base: entry.address(),
             target: entry.address(),
             tag,
+            r#type,
         };
         serde_json::to_string(&args)
             .expect("args should serialize")
             .into_bytes()
     }
 
-    pub fn test_link_2_args_bytes(tag: String) -> Vec<u8> {
+    pub fn test_link_2_args_bytes(tag: String, r#type: String) -> Vec<u8> {
         let base = test_entry();
         let target = test_entry_b();
 
@@ -92,6 +93,7 @@ pub mod tests {
             base: base.address(),
             target: target.address(),
             tag,
+            r#type,
         };
         serde_json::to_string(&args)
             .expect("args should serialize")
@@ -143,11 +145,11 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             context.clone(),
-            test_link_args_bytes(String::from("test-tag")),
+            test_link_args_bytes(String::from("test-tag"), String::from("test-type")),
         );
 
         let no_entry: Option<Address> = Some(HashString::from(
-            "QmWXM2r3iujqGvka8XMKU2wLdz5N14bEhvDp7Rx3R3oaEP",
+            "QmeLY55YdjqJJbVKuQjrvCWSkSBJYnXVWNSjMDezowSMuW",
         ));
         let result = ZomeApiInternalResult::success(no_entry);
         assert_eq!(
@@ -166,7 +168,7 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             context.clone(),
-            test_link_args_bytes(String::from("wrong-tag")),
+            test_link_args_bytes(String::from("wrong-tag"), String::from("wrong-type")),
         );
 
         let result = ZomeApiInternalResult::try_from(call_result)
@@ -190,11 +192,11 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             context.clone(),
-            test_link_2_args_bytes(String::from("test-tag")),
+            test_link_2_args_bytes(String::from("test-tag"), String::from("test-type")),
         );
 
         let no_entry: Option<Address> = Some(HashString::from(
-            "QmcmcrbAfoaqJMZun74Xs1TsCUndXAohJNrKu7xZyr68P8",
+            "QmTLKV2DVQMaLpXau7DJGVTXhx7iac8Skv7oB8xRc2G2ts",
         ));
         let result = ZomeApiInternalResult::success(no_entry);
 

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -58,6 +58,7 @@ pub struct LinkDefinitionPath {
     pub entry_type_name: String,
     pub direction: LinkDirection,
     pub tag: String,
+    pub r#type: String,
 }
 
 /// This function tries to find the link definition for a link given by base type,
@@ -73,6 +74,7 @@ pub struct LinkDefinitionPath {
 pub fn find_link_definition_in_dna(
     base_type: &EntryType,
     tag: &String,
+    r#type: &String,
     target_type: &EntryType,
     context: &Arc<Context>,
 ) -> Result<LinkDefinitionPath, HolochainError> {
@@ -86,7 +88,8 @@ pub fn find_link_definition_in_dna(
             .links_to
             .iter()
             .find(|&link_def| {
-                link_def.target_type == String::from(target_type.clone()) && &link_def.tag == tag
+                link_def.target_type == String::from(target_type.clone())
+                    && (&link_def.tag == tag) | (&link_def.r#type == r#type)
             })
             .and_then(|link_def| {
                 Some(LinkDefinitionPath {
@@ -94,6 +97,7 @@ pub fn find_link_definition_in_dna(
                     entry_type_name: app_entry_type.to_string(),
                     direction: LinkDirection::To,
                     tag: link_def.tag.clone(),
+                    r#type: link_def.r#type.clone(),
                 })
             }),
         _ => None,
@@ -107,7 +111,8 @@ pub fn find_link_definition_in_dna(
             .linked_from
             .iter()
             .find(|&link_def| {
-                link_def.base_type == String::from(base_type.clone()) && &link_def.tag == tag
+                link_def.base_type == String::from(base_type.clone())
+                    && (&link_def.tag == tag) | (&link_def.r#type == r#type)
             })
             .and_then(|link_def| {
                 Some(LinkDefinitionPath {
@@ -115,6 +120,7 @@ pub fn find_link_definition_in_dna(
                     entry_type_name: app_entry_type.to_string(),
                     direction: LinkDirection::From,
                     tag: link_def.tag.clone(),
+                    r#type: link_def.r#type.clone(),
                 })
             }),
         _ => None,

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -56,6 +56,7 @@ pub fn get_validation_package_definition(
             let link_definition_path = links_utils::find_link_definition_in_dna(
                 &base.entry_type(),
                 link_add.link().tag(),
+                link_add.link().r#type(),
                 &target.entry_type(),
                 &context,
             )?;
@@ -63,6 +64,7 @@ pub fn get_validation_package_definition(
             let params = LinkValidationPackageArgs {
                 entry_type: link_definition_path.entry_type_name,
                 tag: link_definition_path.tag,
+                r#type: link_definition_path.r#type,
                 direction: link_definition_path.direction,
             };
 
@@ -91,6 +93,7 @@ pub fn get_validation_package_definition(
             let link_definition_path = links_utils::find_link_definition_in_dna(
                 &base.entry_type(),
                 link_remove.link().tag(),
+                link_remove.link().r#type(),
                 &target.entry_type(),
                 &context,
             )?;
@@ -98,6 +101,7 @@ pub fn get_validation_package_definition(
             let params = LinkValidationPackageArgs {
                 entry_type: link_definition_path.entry_type_name,
                 tag: link_definition_path.tag,
+                r#type: link_definition_path.r#type,
                 direction: link_definition_path.direction,
             };
 

--- a/core/src/nucleus/validation/link_entry.rs
+++ b/core/src/nucleus/validation/link_entry.rs
@@ -40,6 +40,7 @@ pub async fn validate_link_entry(
     let link_definition_path = links_utils::find_link_definition_in_dna(
         &base.entry_type(),
         link.tag(),
+        link.r#type(),
         &target.entry_type(),
         context,
     )

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -141,7 +141,7 @@ pub mod tests {
             .block_on(author_entry(&entry, None, &context1))
             .unwrap();
 
-        let link_add = LinkData::new_add(&entry_address, &entry_address, "test-tag");
+        let link_add = LinkData::new_add(&entry_address, &entry_address, "test-tag", "test-type");
         let link_entry = Entry::LinkAdd(link_add);
 
         let _ = context1

--- a/core_types/src/dna/entry_types.rs
+++ b/core_types/src/dna/entry_types.rs
@@ -44,6 +44,9 @@ pub struct LinksTo {
     /// The tag of this links_to entry
     #[serde(default)]
     pub tag: String,
+
+    #[serde(default)]
+    pub r#type: String,
 }
 
 impl Default for LinksTo {
@@ -52,6 +55,7 @@ impl Default for LinksTo {
         LinksTo {
             target_type: String::new(),
             tag: String::new(),
+            r#type: String::new(),
         }
     }
 }
@@ -74,6 +78,9 @@ pub struct LinkedFrom {
     /// The tag of this links_to entry
     #[serde(default)]
     pub tag: String,
+
+    #[serde(default)]
+    pub r#type: String,
 }
 
 impl Default for LinkedFrom {
@@ -82,6 +89,7 @@ impl Default for LinkedFrom {
         LinkedFrom {
             base_type: String::new(),
             tag: String::new(),
+            r#type: String::new(),
         }
     }
 }
@@ -167,13 +175,15 @@ mod tests {
                 "links_to": [
                     {
                         "target_type": "test",
-                        "tag": "test"
+                        "tag": "test",
+                        "type": "test"
                     }
                 ],
                 "linked_from": [
                     {
                         "base_type": "HcSysAgentKeyHash",
-                        "tag": "authored_posts"
+                        "tag": "authored_posts",
+                        "type": "authored_posts_type"
                     }
                 ]
             }"#,
@@ -187,11 +197,13 @@ mod tests {
         let mut link = LinksTo::new();
         link.target_type = String::from("test");
         link.tag = String::from("test");
+        link.r#type = String::from("test");
         entry.links_to.push(link);
 
         let mut linked = LinkedFrom::new();
         linked.base_type = String::from("HcSysAgentKeyHash");
         linked.tag = String::from("authored_posts");
+        linked.r#type = String::from("authored_posts_type");
         entry.linked_from.push(linked);
 
         assert_eq!(fixture, entry);

--- a/core_types/src/dna/mod.rs
+++ b/core_types/src/dna/mod.rs
@@ -305,7 +305,8 @@ pub mod tests {
                                 "links_to": [
                                     {
                                         "target_type": "test",
-                                        "tag": "test"
+                                        "tag": "test",
+                                        "type": "test"
                                     }
                                 ],
                                 "linked_from": []
@@ -480,7 +481,8 @@ pub mod tests {
                                 "links_to": [
                                     {
                                         "target_type": "test",
-                                        "tag": "test"
+                                        "tag": "test",
+                                        "type": "test"
                                     }
                                 ],
                                 "linked_from": []

--- a/core_types/src/link/link_data.rs
+++ b/core_types/src/link/link_data.rs
@@ -16,17 +16,17 @@ pub struct LinkData {
 }
 
 impl LinkData {
-    pub fn new_add(base: &Address, target: &Address, tag: &str) -> Self {
+    pub fn new_add(base: &Address, target: &Address, tag: &str, r#type: &str) -> Self {
         LinkData {
             action_kind: LinkActionKind::ADD,
-            link: Link::new(base, target, tag),
+            link: Link::new(base, target, tag, r#type),
         }
     }
 
-    pub fn new_delete(base: &Address, target: &Address, tag: &str) -> Self {
+    pub fn new_delete(base: &Address, target: &Address, tag: &str, r#type: &str) -> Self {
         LinkData {
             action_kind: LinkActionKind::REMOVE,
-            link: Link::new(base, target, tag),
+            link: Link::new(base, target, tag, r#type),
         }
     }
 
@@ -62,7 +62,7 @@ pub mod tests {
 
     pub fn example_link_add() -> LinkData {
         let link = example_link();
-        LinkData::new_add(link.base(), link.target(), link.tag())
+        LinkData::new_add(link.base(), link.target(), link.tag(), link.r#type())
     }
 
     pub fn test_link_entry() -> Entry {
@@ -71,7 +71,7 @@ pub mod tests {
 
     pub fn test_link_entry_json_string() -> JsonString {
         JsonString::from_json(&format!(
-            "{{\"LinkAdd\":{{\"action_kind\":\"ADD\",\"link\":{{\"base\":\"{}\",\"target\":\"{}\",\"tag\":\"foo-tag\"}}}}}}",
+            "{{\"LinkAdd\":{{\"action_kind\":\"ADD\",\"link\":{{\"base\":\"{}\",\"target\":\"{}\",\"tag\":\"foo-tag\",\"type\":\"foo-type\"}}}}}}",
             test_entry_a().address(),
             test_entry_b().address(),
         ))

--- a/core_types/src/link/mod.rs
+++ b/core_types/src/link/mod.rs
@@ -8,20 +8,23 @@ pub mod link_list;
 use crate::{cas::content::Address, error::HolochainError, json::JsonString};
 
 type LinkTag = String;
+type LinkType = String;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, DefaultJson)]
 pub struct Link {
     base: Address,
     target: Address,
     tag: LinkTag,
+    r#type: LinkType,
 }
 
 impl Link {
-    pub fn new(base: &Address, target: &Address, tag: &str) -> Self {
+    pub fn new(base: &Address, target: &Address, tag: &str, r#type: &str) -> Self {
         Link {
             base: base.to_owned(),
             target: target.to_owned(),
             tag: tag.to_owned(),
+            r#type: r#type.to_owned(),
         }
     }
 
@@ -36,6 +39,10 @@ impl Link {
 
     pub fn tag(&self) -> &LinkTag {
         &self.tag
+    }
+
+    pub fn r#type(&self) -> &LinkType {
+        &self.r#type
     }
 }
 
@@ -52,11 +59,15 @@ pub mod tests {
     use crate::{
         cas::content::AddressableContent,
         entry::{test_entry_a, test_entry_b},
-        link::{Link, LinkActionKind, LinkTag},
+        link::{Link, LinkActionKind, LinkTag, LinkType},
     };
 
     pub fn example_link_tag() -> LinkTag {
         LinkTag::from("foo-tag")
+    }
+
+    pub fn example_link_type() -> LinkType {
+        LinkType::from("foo-type")
     }
 
     pub fn example_link() -> Link {
@@ -64,6 +75,7 @@ pub mod tests {
             &test_entry_a().address(),
             &test_entry_b().address(),
             &example_link_tag(),
+            &example_link_type(),
         )
     }
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -787,12 +787,13 @@ pub fn get_entry_result(
 ///         &AGENT_ADDRESS,
 ///         &address,
 ///         "authored_posts",
+///         "authored_posts",
 ///     )?;
 ///
 ///     if let Some(in_reply_to_address) = in_reply_to {
 ///         // return with Err if in_reply_to_address points to missing entry
 ///         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions { status_request: StatusRequestKind::All, entry: false, headers: false, timeout: Default::default() })?;
-///         hdk::link_entries(&in_reply_to_address, &address, "comments")?;
+///         hdk::link_entries(&in_reply_to_address, &address, "comments", "comments")?;
 ///     }
 ///
 ///     Ok(address)
@@ -800,15 +801,17 @@ pub fn get_entry_result(
 /// }
 /// # }
 /// ```
-pub fn link_entries<S: Into<String>>(
+pub fn link_entries<S: Into<String>, TS: Into<String>>(
     base: &Address,
     target: &Address,
     tag: S,
+    r#type: TS,
 ) -> Result<Address, ZomeApiError> {
     Dispatch::LinkEntries.with_input(LinkEntriesArgs {
         base: base.clone(),
         target: target.clone(),
         tag: tag.into(),
+        r#type: r#type.into(),
     })
 }
 
@@ -856,6 +859,7 @@ pub fn link_entries<S: Into<String>>(
 ///         &AGENT_ADDRESS,
 ///         &address,
 ///         "authored_posts",
+///         "authored_posts",
 ///     )?;
 ///
 ///
@@ -864,15 +868,17 @@ pub fn link_entries<S: Into<String>>(
 /// }
 /// # }
 /// ```
-pub fn remove_link<S: Into<String>>(
+pub fn remove_link<S: Into<String>, TS: Into<String>>(
     base: &Address,
     target: &Address,
     tag: S,
+    r#type: TS,
 ) -> Result<(), ZomeApiError> {
     Dispatch::RemoveLink.with_input(LinkEntriesArgs {
         base: base.clone(),
         target: target.clone(),
         tag: tag.into(),
+        r#type: r#type.into(),
     })
 }
 

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -55,6 +55,7 @@ pub struct ValidatingLinkDefinition {
     pub other_entry_type: String,
     /// Tag (i.e. name) of this type of links
     pub tag: String,
+    pub r#type: String,
     /// Callback that returns a validation package definition that Holochain reads in order
     /// to create the right validation package to pass in to the validator callback on validation.
     pub package_creator: PackageCreator,
@@ -145,6 +146,7 @@ pub struct ValidatingLinkDefinition {
 ///             to!(
 ///                 "post",
 ///                 tag: "comments",
+///                 r#type: "comments",
 ///
 ///                 validation_package: || {
 ///                     hdk::ValidationPackageDefinition::ChainFull
@@ -193,6 +195,7 @@ macro_rules! entry {
                             $crate::holochain_core_types::dna::entry_types::LinksTo{
                                 target_type: $link_expr.other_entry_type,
                                 tag: $link_expr.tag,
+                                r#type: $link_expr.r#type,
                             }
                         );
                     },
@@ -201,6 +204,7 @@ macro_rules! entry {
                             $crate::holochain_core_types::dna::entry_types::LinkedFrom{
                                 base_type: $link_expr.other_entry_type,
                                 tag: $link_expr.tag,
+                                r#type: $link_expr.r#type,
                             }
                         );
                     }
@@ -274,6 +278,7 @@ macro_rules! link {
         direction: $direction:expr,
         other_type: $other_type:expr,
         tag: $tag:expr,
+        r#type: $r#type:expr,
 
         validation_package: || $package_creator:expr,
         validation: | $validation_data:ident : hdk::LinkValidationData | $link_validation:expr
@@ -294,6 +299,7 @@ macro_rules! link {
                 link_type: $direction,
                 other_entry_type: String::from($other_type),
                 tag: String::from($tag),
+                r#type: String::from($r#type),
                 package_creator,
                 validator,
             }
@@ -310,6 +316,7 @@ macro_rules! to {
     (
         $other_type:expr,
         tag: $tag:expr,
+        r#type: $r#type:expr,
 
         validation_package: || $package_creator:expr,
         validation: | $validation_data:ident : hdk::LinkValidationData | $link_validation:expr
@@ -318,6 +325,7 @@ macro_rules! to {
             direction: $crate::LinkDirection::To,
             other_type: $other_type,
             tag: $tag,
+            r#type: $r#type,
 
             validation_package: || $package_creator,
             validation: | $validation_data : hdk::LinkValidationData | $link_validation
@@ -334,6 +342,7 @@ macro_rules! from {
     (
         $other_type:expr,
         tag: $tag:expr,
+        r#type: $r#type:expr,
 
         validation_package: || $package_creator:expr,
         validation: |  $validation_data:ident : hdk::LinkValidationData | $link_validation:expr
@@ -342,6 +351,7 @@ macro_rules! from {
             direction: $crate::LinkDirection::From,
             other_type: $other_type,
             tag: $tag,
+            r#type: $r#type,
 
             validation_package: || $package_creator,
             validation: |  $validation_data : hdk::LinkValidationData | $link_validation

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -164,7 +164,8 @@ pub extern "C" fn __hdk_get_validation_package_for_link(
             })
             .and_then(|entry_type| {
                 entry_type.links.into_iter().find(|ref link_definition| {
-                    link_definition.tag == input.tag && link_definition.link_type == input.direction
+                    (link_definition.tag == input.tag) | (link_definition.r#type == input.r#type)
+                        && link_definition.link_type == input.direction
                 })
             })
             .and_then(|mut link_definition| {
@@ -208,7 +209,8 @@ pub extern "C" fn __hdk_validate_link(
                     .links
                     .into_iter()
                     .find(|link_definition| {
-                        link_definition.tag == *input.link.tag()
+                        (link_definition.tag == *input.link.tag())
+                            | (link_definition.r#type == *input.link.r#type())
                             && link_definition.link_type == input.direction
                     })
             })

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -64,25 +64,28 @@ pub fn get_as_type<R: TryFrom<AppEntryValue>>(address: Address) -> ZomeApiResult
 
 /// Creates two links:
 /// From A to B, and from B to A, with given tags.
-pub fn link_entries_bidir<S: Into<String>>(
+pub fn link_entries_bidir<S: Into<String>, TS: Into<String>>(
     a: &Address,
     b: &Address,
     tag_a_b: S,
     tag_b_a: S,
+    type_a_b: TS,
+    type_b_a: TS,
 ) -> ZomeApiResult<()> {
-    hdk::link_entries(a, b, tag_a_b)?;
-    hdk::link_entries(b, a, tag_b_a)?;
+    hdk::link_entries(a, b, tag_a_b, type_a_b)?;
+    hdk::link_entries(b, a, tag_b_a, type_b_a)?;
     Ok(())
 }
 
 /// Commits the given entry and links it from the base
 /// with the given tag.
-pub fn commit_and_link<S: Into<String>>(
+pub fn commit_and_link<S: Into<String>, TS: Into<String>>(
     entry: &Entry,
     base: &Address,
     tag: S,
+    r#type: TS,
 ) -> ZomeApiResult<Address> {
     let entry_addr = hdk::commit_entry(entry)?;
-    hdk::link_entries(base, &entry_addr, tag)?;
+    hdk::link_entries(base, &entry_addr, tag, r#type)?;
     Ok(entry_addr)
 }

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -326,6 +326,7 @@ fn start_holochain_instance<T: Into<String>>(
         test_entry_type.links_to.push(LinksTo {
             target_type: String::from("testEntryType"),
             tag: String::from("test-tag"),
+            r#type: String::from("test-type"),
         });
     }
 
@@ -335,6 +336,7 @@ fn start_holochain_instance<T: Into<String>>(
         link_validator.links_to.push(LinksTo {
             target_type: String::from("link_validator"),
             tag: String::from("longer"),
+            r#type: String::from("longer"),
         });
         entry_types.insert(EntryType::from("link_validator"), link_validator);
     }
@@ -582,7 +584,7 @@ fn can_link_entries() {
     assert!(result.is_ok(), "\t result = {:?}", result);
     assert_eq!(
         result.unwrap(),
-        JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#)
+        JsonString::from_json(r#"{"Ok":"QmQNegznAMwXEXjEP3K7EhfwFsiUZABntcDpiwouKn5KyY"}"#)
     );
 }
 
@@ -594,7 +596,7 @@ fn can_remove_link() {
     assert!(result.is_ok(), "\t result = {:?}", result);
     assert_eq!(
         result.unwrap(),
-        JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#)
+        JsonString::from_json(r#"{"Ok":"QmQNegznAMwXEXjEP3K7EhfwFsiUZABntcDpiwouKn5KyY"}"#)
     );
 }
 

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -145,7 +145,7 @@ fn handle_link_two_entries() -> ZomeApiResult<Address> {
 
     hdk::commit_entry(&entry_2)?;
 
-    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")
+    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag", "test-type")
 }
 
 fn handle_remove_link() -> ZomeApiResult<()> {
@@ -167,8 +167,8 @@ fn handle_remove_link() -> ZomeApiResult<()> {
     );
 
     hdk::commit_entry(&entry_2)?;
-    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")?;
-    hdk::remove_link(&entry_1.address(), &entry_2.address(), "test-tag")
+    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag", "test-type")?;
+    hdk::remove_link(&entry_1.address(), &entry_2.address(), "test-tag", "test-type")
 
 }
 
@@ -204,8 +204,8 @@ fn handle_links_roundtrip_create() -> ZomeApiResult<Address> {
     );
     hdk::commit_entry(&entry_3)?;
 
-    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")?;
-    hdk::link_entries(&entry_1.address(), &entry_3.address(), "test-tag")?;
+    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag", "test-type")?;
+    hdk::link_entries(&entry_1.address(), &entry_3.address(), "test-tag", "test-type")?;
     Ok(entry_1.address())
 }
 
@@ -420,6 +420,7 @@ fn handle_link_validation(stuff1: String, stuff2: String) -> JsonString {
         &entry1.address(),
         &entry2.address(),
         "longer",
+        "longer",
     ))
 }
 
@@ -475,6 +476,7 @@ define_zome! {
                 to!(
                     "testEntryType",
                     tag: "test-tag",
+                    r#type: "test-type",
                     validation_package: || {
                         hdk::ValidationPackageDefinition::ChainFull
                     },
@@ -524,6 +526,7 @@ define_zome! {
                 to!(
                     "link_validator",
                     tag: "longer",
+                    r#type: "longer",
                     validation_package: || {
                         hdk::ValidationPackageDefinition::Entry
                     },

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -595,6 +595,7 @@ mod tests {
             &"base".to_string().into(),
             &"target".to_string().into(),
             "tag",
+            "type",
         );
         let entry = Entry::LinkAdd(link_add.clone());
         let entry_wh = mk_entry_wh(entry.clone());

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -91,12 +91,14 @@ pub fn create_test_dna_with_wasm(zome_name: &str, wasm: Vec<u8>) -> Dna {
     test_entry_def.links_to.push(LinksTo {
         target_type: String::from("testEntryType"),
         tag: String::from("test-tag"),
+        r#type: String::from("test-type"),
     });
 
     let mut test_entry_b_def = EntryTypeDef::new();
     test_entry_b_def.linked_from.push(LinkedFrom {
         base_type: String::from("testEntryType"),
         tag: String::from("test-tag"),
+        r#type: String::from("test-type"),
     });
 
     let mut test_entry_c_def = EntryTypeDef::new();

--- a/wasm_utils/src/api_serialization/link_entries.rs
+++ b/wasm_utils/src/api_serialization/link_entries.rs
@@ -5,10 +5,11 @@ pub struct LinkEntriesArgs {
     pub base: Address,
     pub target: Address,
     pub tag: String,
+    pub r#type: String,
 }
 
 impl LinkEntriesArgs {
     pub fn to_link(&self) -> Link {
-        Link::new(&self.base, &self.target, &self.tag)
+        Link::new(&self.base, &self.target, &self.tag, &self.r#type)
     }
 }

--- a/wasm_utils/src/api_serialization/validation.rs
+++ b/wasm_utils/src/api_serialization/validation.rs
@@ -21,6 +21,7 @@ pub enum LinkDirection {
 pub struct LinkValidationPackageArgs {
     pub entry_type: String,
     pub tag: String,
+    pub r#type: String,
     pub direction: LinkDirection,
 }
 


### PR DESCRIPTION
## PR summary

This pull requests attempts to implement type tagging on links for the purpose of validation on tag based indexing.

Currently I am building a social network (@juntofoundation) on Holochain. One of the things we wish to be able to support in our application is "advanced querying". The ability to query an entry based on more than one parameter - for example being to filter all entries by a given timestamp and category. My current research leads me to believe there is two ways to do this on holochain (please correct me if I am wrong). 

1/ Get links on each query item and then compare results to find matches in the link results. 
2/ Saving all possible permutations of queries as links from query anchors to entry(s) we wish to be able to query for. 

The first implementation of querying would work fine when you only have a few links on each query parameter you care for, but in a public production setting where you may wish to be able to query against a large number of entries this could mean filtering and matching over millions of items. The second implementation introduces added link complexity due to saving all permutation of query values in the tag(s), but the query you wish to make could happen instantly - no sorting would need to happen.

Currently writing validation rules for the kind of behaviour outlined in implementation 2 is not possible. There is no way to associate validation to the given links as the tag is mostly unknown. If we could specify a type for links this would allow validation to run on groups of links rather than validation running on one specific link that has a matching tag. 

## Current status

I have added an example in app_spec detailing when this ability may be utilised. I have also modified all function/data types I could find which interact with link commit's and validation. However upon running my test file in app_spec: `query.js` I receive the following error when `hdk::link_entries` is called: 
```
Zome function failure: Argument deserialization failed, when calling: CallbackFnCall { id: ProcessUniqueId { prefix: 12, offset: 0 }, zome_name: "blog", fn_name: "__hdk_get_validation_package_for_link", parameters: JsonString("{\"entry_type\":\"post\",\"tag\":\"authored_posts\",\"direction\":\"From\"}") }
```

My understanding of how all parts of `holochain-rust` function is limited so help implementing this feature as well as an audit of the work/proposal as it is would be wonderful.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
