### PR TITLE
Rename link tag to type

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renames link tags to link_type  [#1400](https://github.com/holochain/holochain-rust/pull/1400) to make way for the new tag implementation
+
 ### Deprecated
 
 ### Removed

--- a/app_spec/test/regressions.js
+++ b/app_spec/test/regressions.js
@@ -70,7 +70,7 @@ scenario.runTape('alice create & publish post -> recommend own post to self', as
     agent_address: alice.agentId
   })
   console.log("linked: ", linked)
-  t.equal(linked.Ok, "QmQja9SJhYWA5B3myrtnd9bR6dNeaFj6Lr3DRjumfTPWaX")
+  t.equal(linked.Ok, "QmcYVHtb9QUQ7zweee7qqvZRYUpdy8A4byTm6k1HmDggtq")
 
   const recommendedPosts = alice.call('blog', 'my_recommended_posts', {})
   console.log("recommendedPosts", recommendedPosts)
@@ -94,7 +94,7 @@ scenario.runTape('alice create & publish post -> tash recommend to self', async 
     agent_address: tash.agentId
   })
   console.log("linked: ", linked)
-  t.equal(linked.Ok, "QmYZKfRGykurtW96zv9ra8D9cof7Ki4Df8XFSgupWP711Y")
+  t.equal(linked.Ok, "QmaWawMUZk4gczKjedqaexj6Z6Lj5ncn5vLd34rCpcMBgj")
 
   const recommendedPosts = tash.call("blog", "my_recommended_posts", {})
   console.log("recommendedPosts", recommendedPosts)
@@ -118,7 +118,7 @@ scenario.runTape('create & publish post -> recommend to other agent', async (t, 
     agent_address: tash.agentId
   })
   console.log("linked: ", linked)
-  t.equal(linked.Ok, "QmZg7WfQhyUMzfd68VJZg9ah6WhtpLSZQe9BHaz8pmN3Pz")
+  t.equal(linked.Ok, "QmP18RAThjHkdWyejYzHQEWKKy5eatn5273qXbYRoGJy1y")
 
   const recommendedPosts = tash.call('blog', 'my_recommended_posts', {})
   console.log("recommendedPosts", recommendedPosts)

--- a/app_spec/zomes/blog/code/src/post.rs
+++ b/app_spec/zomes/blog/code/src/post.rs
@@ -79,7 +79,7 @@ pub fn definition() -> ValidatingEntryType {
         links: [
             from!(
                 "%agent_id",
-                tag: "authored_posts",
+                link_type: "authored_posts",
                 validation_package: || {
                     hdk::ValidationPackageDefinition::ChainFull
                 },
@@ -89,7 +89,7 @@ pub fn definition() -> ValidatingEntryType {
             ),
             from!(
                 "%agent_id",
-                tag: "recommended_posts",
+                link_type: "recommended_posts",
                 validation_package: || {
                     hdk::ValidationPackageDefinition::ChainFull
                 },
@@ -143,11 +143,11 @@ mod tests {
             linked_from: vec![
                 LinkedFrom {
                     base_type: "%agent_id".to_string(),
-                    tag: "authored_posts".to_string(),
+                    link_type: "authored_posts".to_string(),
                 },
                 LinkedFrom {
                     base_type: "%agent_id".to_string(),
-                    tag: "recommended_posts".to_string(),
+                    link_type: "recommended_posts".to_string(),
                 },
             ],
             links_to: Vec::new(),
@@ -209,11 +209,11 @@ mod tests {
 
         let expected_link_direction = LinkDirection::From;
         assert_eq!(
-            post_definition_link.link_type.to_owned(),
+            post_definition_link.direction.to_owned(),
             expected_link_direction,
         );
 
-        let expected_link_tag = "authored_posts";
-        assert_eq!(post_definition_link.tag.to_owned(), expected_link_tag,);
+        let expected_link_type = "authored_posts";
+        assert_eq!(post_definition_link.link_type.to_owned(), expected_link_type,);
     }
 }

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -238,7 +238,7 @@ pub struct GetLinksKey {
     pub base_address: Address,
 
     /// The link tag
-    pub tag: String,
+    pub link_type: String,
 
     /// A unique ID that is used to pair the eventual result to this request
     pub id: String,

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -146,7 +146,7 @@ pub enum Action {
     ///
     GetEntryTimeout(GetEntryKey),
 
-    /// get links from entry address and tag name
+    /// get links from entry address and link_type name
     /// Last string is the stringified process unique id of this `hdk::get_links` call.
     GetLinks(GetLinksKey),
     GetLinksTimeout(GetLinksKey),
@@ -237,7 +237,7 @@ pub struct GetLinksKey {
     /// The address of the Link base
     pub base_address: Address,
 
-    /// The link tag
+    /// The link type
     pub link_type: String,
 
     /// A unique ID that is used to pair the eventual result to this request

--- a/core/src/dht/actions/add_link.rs
+++ b/core/src/dht/actions/add_link.rs
@@ -74,7 +74,7 @@ mod tests {
         nucleus::actions::tests::commit(base.clone(), &context);
 
         let target = base.clone();
-        let link = Link::new(&base.address(), &target.address(), "test-tag");
+        let link = Link::new(&base.address(), &target.address(), "test-link");
 
         let result = context.block_on(add_link(&link, &context.clone()));
 
@@ -87,7 +87,7 @@ mod tests {
 
         let base = test_entry();
         let target = base.clone();
-        let link = Link::new(&base.address(), &target.address(), "test-tag");
+        let link = Link::new(&base.address(), &target.address(), "test-link");
 
         let result = context.block_on(add_link(&link, &context.clone()));
 

--- a/core/src/dht/dht_reducers.rs
+++ b/core/src/dht/dht_reducers.rs
@@ -437,7 +437,10 @@ pub mod tests {
         let eav = hash_set.iter().nth(0).unwrap();
         assert_eq!(eav.entity(), *link.base());
         assert_eq!(eav.value(), *link.target());
-        assert_eq!(eav.attribute(), Attribute::LinkTag(link.link_type().to_owned()));
+        assert_eq!(
+            eav.attribute(),
+            Attribute::LinkTag(link.link_type().to_owned())
+        );
     }
 
     #[test]

--- a/core/src/dht/dht_reducers.rs
+++ b/core/src/dht/dht_reducers.rs
@@ -130,7 +130,7 @@ pub(crate) fn reduce_add_link(
     } else {
         let eav = EntityAttributeValueIndex::new(
             link.base(),
-            &Attribute::LinkTag(link.tag().to_owned()),
+            &Attribute::LinkTag(link.link_type().to_owned()),
             link.target(),
         );
         eav.map(|e| {
@@ -167,7 +167,7 @@ pub(crate) fn reduce_remove_link(
     } else {
         let eav = EntityAttributeValueIndex::new(
             link.base(),
-            &Attribute::RemovedLink(link.tag().to_string()),
+            &Attribute::RemovedLink(link.link_type().to_string()),
             link.target(),
         );
         eav.map(|e| {
@@ -414,7 +414,7 @@ pub mod tests {
         let _ = (storage.write().unwrap()).add(&entry);
         let context = Arc::new(context);
 
-        let link = Link::new(&entry.address(), &entry.address(), "test-tag");
+        let link = Link::new(&entry.address(), &entry.address(), "test-link");
         let action = ActionWrapper::new(Action::AddLink(link.clone()));
 
         let new_dht_store: DhtStore;
@@ -437,7 +437,7 @@ pub mod tests {
         let eav = hash_set.iter().nth(0).unwrap();
         assert_eq!(eav.entity(), *link.base());
         assert_eq!(eav.value(), *link.target());
-        assert_eq!(eav.attribute(), Attribute::LinkTag(link.tag().to_owned()));
+        assert_eq!(eav.attribute(), Attribute::LinkTag(link.link_type().to_owned()));
     }
 
     #[test]
@@ -454,7 +454,7 @@ pub mod tests {
         let _ = (storage.write().unwrap()).add(&entry);
         let context = Arc::new(context);
 
-        let link = Link::new(&entry.address(), &entry.address(), "test-tag");
+        let link = Link::new(&entry.address(), &entry.address(), "test-link_type");
         let mut action = ActionWrapper::new(Action::AddLink(link.clone()));
 
         let new_dht_store: DhtStore;
@@ -492,7 +492,7 @@ pub mod tests {
         assert_eq!(eav.value(), *link.target());
         assert_eq!(
             eav.attribute(),
-            Attribute::RemovedLink(link.tag().to_string())
+            Attribute::RemovedLink(link.link_type().to_string())
         );
     }
 
@@ -508,7 +508,7 @@ pub mod tests {
         context.set_state(locked_state.clone());
         let context = Arc::new(context);
 
-        let link = Link::new(&entry.address(), &entry.address(), "test-tag");
+        let link = Link::new(&entry.address(), &entry.address(), "test-link_type");
         let action = ActionWrapper::new(Action::AddLink(link.clone()));
 
         let new_dht_store: DhtStore;

--- a/core/src/dht/dht_store.rs
+++ b/core/src/dht/dht_store.rs
@@ -59,13 +59,13 @@ impl DhtStore {
     pub fn get_links(
         &self,
         address: Address,
-        tag: String,
+        link_type: String,
     ) -> Result<BTreeSet<EntityAttributeValueIndex>, HolochainError> {
         let filtered = self.meta_storage.read()?.fetch_eavi(&EaviQuery::new(
             Some(address).into(),
             EavFilter::multiple(vec![
-                Attribute::LinkTag(tag.clone()),
-                Attribute::RemovedLink(tag),
+                Attribute::LinkTag(link_type.clone()),
+                Attribute::RemovedLink(link_type),
             ]),
             None.into(),
             IndexFilter::LatestByAttribute,

--- a/core/src/network/actions/get_links.rs
+++ b/core/src/network/actions/get_links.rs
@@ -17,12 +17,12 @@ use std::{pin::Pin, sync::Arc, thread};
 pub async fn get_links(
     context: Arc<Context>,
     address: Address,
-    tag: String,
+    link_type: String,
     timeout: Timeout,
 ) -> HcResult<Vec<Address>> {
     let key = GetLinksKey {
         base_address: address.clone(),
-        tag: tag.clone(),
+        link_type: link_type.clone(),
         id: ProcessUniqueId::new().to_string(),
     };
     let action_wrapper = ActionWrapper::new(Action::GetLinks(key.clone()));

--- a/core/src/network/handler/get.rs
+++ b/core/src/network/handler/get.rs
@@ -60,14 +60,14 @@ pub fn handle_fetch_entry_result(dht_data: FetchEntryResultData, context: Arc<Co
 }
 
 pub fn handle_fetch_meta(fetch_meta_data: FetchMetaData, context: Arc<Context>) {
-    if let Ok(Attribute::LinkTag(tag)) = fetch_meta_data.attribute.as_str().try_into() {
+    if let Ok(Attribute::LinkTag(link_type)) = fetch_meta_data.attribute.as_str().try_into() {
         let links = context
             .state()
             .unwrap()
             .dht()
             .get_links(
                 Address::from(fetch_meta_data.entry_address.clone()),
-                tag.clone(),
+                link_type.clone(),
             )
             .unwrap_or(BTreeSet::new())
             .into_iter()
@@ -80,8 +80,8 @@ pub fn handle_fetch_meta(fetch_meta_data: FetchMetaData, context: Arc<Context>) 
 
 /// The network comes back with a result to our previous GET META request.
 pub fn handle_fetch_meta_result(dht_meta_data: FetchMetaResultData, context: Arc<Context>) {
-    if let Ok(Attribute::LinkTag(tag)) = dht_meta_data.attribute.as_str().try_into() {
-        let action_wrapper = ActionWrapper::new(Action::HandleGetLinksResult((dht_meta_data, tag)));
+    if let Ok(Attribute::LinkTag(link_type)) = dht_meta_data.attribute.as_str().try_into() {
+        let action_wrapper = ActionWrapper::new(Action::HandleGetLinksResult((dht_meta_data, link_type)));
         dispatch_action(context.action_channel(), action_wrapper.clone());
     }
 }

--- a/core/src/network/handler/get.rs
+++ b/core/src/network/handler/get.rs
@@ -81,7 +81,8 @@ pub fn handle_fetch_meta(fetch_meta_data: FetchMetaData, context: Arc<Context>) 
 /// The network comes back with a result to our previous GET META request.
 pub fn handle_fetch_meta_result(dht_meta_data: FetchMetaResultData, context: Arc<Context>) {
     if let Ok(Attribute::LinkTag(link_type)) = dht_meta_data.attribute.as_str().try_into() {
-        let action_wrapper = ActionWrapper::new(Action::HandleGetLinksResult((dht_meta_data, link_type)));
+        let action_wrapper =
+            ActionWrapper::new(Action::HandleGetLinksResult((dht_meta_data, link_type)));
         dispatch_action(context.action_channel(), action_wrapper.clone());
     }
 }

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -246,8 +246,8 @@ pub mod tests {
             entry_addresses.push(address);
         }
 
-        let link1 = LinkData::new_add(&entry_addresses[0], &entry_addresses[1], "test-tag");
-        let link2 = LinkData::new_add(&entry_addresses[0], &entry_addresses[2], "test-tag");
+        let link1 = LinkData::new_add(&entry_addresses[0], &entry_addresses[1], "test-link");
+        let link2 = LinkData::new_add(&entry_addresses[0], &entry_addresses[2], "test-link");
 
         // Store link1 on the network
         println!("\n add_link(link1) ...");

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -272,7 +272,7 @@ pub mod tests {
         let maybe_links = context2.block_on(get_links(
             context2.clone(),
             entry_addresses[0].clone(),
-            String::from("test-tag"),
+            String::from("test-link"),
             Default::default(),
         ));
 

--- a/core/src/network/reducers/get_links.rs
+++ b/core/src/network/reducers/get_links.rs
@@ -20,7 +20,7 @@ fn reduce_get_links_inner(
             request_id: key.id.clone(),
             dna_address: network_state.dna_address.clone().unwrap(),
             entry_address: HashString::from(key.base_address.clone()),
-            attribute: format!("link__{}", key.tag),
+            attribute: format!("link__{}", key.link_type),
         }),
     )
 }
@@ -77,10 +77,10 @@ mod tests {
         let store = test_store(context.clone());
 
         let entry = test_entry();
-        let tag = String::from("test-tag");
+        let link_type = String::from("test-link");
         let key = GetLinksKey {
             base_address: entry.address(),
-            tag: tag.clone(),
+            link_type: link_type.clone(),
             id: snowflake::ProcessUniqueId::new().to_string(),
         };
         let action_wrapper = ActionWrapper::new(Action::GetLinks(key.clone()));
@@ -119,10 +119,10 @@ mod tests {
         let store = store.reduce(context.clone(), action_wrapper);
 
         let entry = test_entry();
-        let tag = String::from("test-tag");
+        let link_type = String::from("test-link");
         let key = GetLinksKey {
             base_address: entry.address(),
-            tag: tag.clone(),
+            link_type: link_type.clone(),
             id: snowflake::ProcessUniqueId::new().to_string(),
         };
         let action_wrapper = ActionWrapper::new(Action::GetLinks(key.clone()));
@@ -158,10 +158,10 @@ mod tests {
         }
 
         let entry = test_entry();
-        let tag = String::from("test-tag");
+        let link_type = String::from("test-link");
         let key = GetLinksKey {
             base_address: entry.address(),
-            tag: tag.clone(),
+            link_type: link_type.clone(),
             id: snowflake::ProcessUniqueId::new().to_string(),
         };
         let action_wrapper = ActionWrapper::new(Action::GetLinks(key.clone()));

--- a/core/src/network/reducers/handle_get_links_result.rs
+++ b/core/src/network/reducers/handle_get_links_result.rs
@@ -33,7 +33,8 @@ pub fn reduce_handle_get_links_result(
     action_wrapper: &ActionWrapper,
 ) {
     let action = action_wrapper.action();
-    let (dht_meta_data, link_type) = unwrap_to!(action => crate::action::Action::HandleGetLinksResult);
+    let (dht_meta_data, link_type) =
+        unwrap_to!(action => crate::action::Action::HandleGetLinksResult);
 
     context.log(format!(
         "debug/reduce/handle_get_links_result: Got response from {}: {:?}",

--- a/core/src/network/reducers/handle_get_links_result.rs
+++ b/core/src/network/reducers/handle_get_links_result.rs
@@ -33,7 +33,7 @@ pub fn reduce_handle_get_links_result(
     action_wrapper: &ActionWrapper,
 ) {
     let action = action_wrapper.action();
-    let (dht_meta_data, tag) = unwrap_to!(action => crate::action::Action::HandleGetLinksResult);
+    let (dht_meta_data, link_type) = unwrap_to!(action => crate::action::Action::HandleGetLinksResult);
 
     context.log(format!(
         "debug/reduce/handle_get_links_result: Got response from {}: {:?}",
@@ -43,7 +43,7 @@ pub fn reduce_handle_get_links_result(
     let result = reduce_handle_get_links_result_inner(network_state, dht_meta_data);
     let key = GetLinksKey {
         base_address: Address::from(dht_meta_data.entry_address.clone()),
-        tag: tag.clone(),
+        link_type: link_type.clone(),
         id: dht_meta_data.request_id.clone(),
     };
 

--- a/core/src/network/state.rs
+++ b/core/src/network/state.rs
@@ -52,7 +52,7 @@ pub struct NetworkState {
     pub get_entry_with_meta_results: HashMap<GetEntryKey, GetEntryWithMetaResult>,
 
     /// Here we store the results of GET links processes.
-    /// The key of this map is the base address and the tag name for which the links
+    /// The key of this map is the base address and the link_type name for which the links
     /// are requested.
     /// None means that we are still waiting for a result from the network.
     pub get_links_results: HashMap<GetLinksKey, GetLinksResult>,

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -87,8 +87,8 @@ pub mod tests {
             entry_addresses.push(address);
         }
 
-        let link1 = Link::new(&entry_addresses[0], &entry_addresses[1], "test-tag");
-        let link2 = Link::new(&entry_addresses[0], &entry_addresses[2], "test-tag");
+        let link1 = Link::new(&entry_addresses[0], &entry_addresses[1], "test-link");
+        let link2 = Link::new(&entry_addresses[0], &entry_addresses[2], "test-link");
 
         assert!(initialized_context
             .block_on(add_link(&link1, &initialized_context))
@@ -99,7 +99,7 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             initialized_context.clone(),
-            test_get_links_args_bytes(&entry_addresses[0], "test-tag"),
+            test_get_links_args_bytes(&entry_addresses[0], "test-link"),
         );
 
         let expected_1 = JsonString::from_json(

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -53,10 +53,10 @@ pub mod tests {
     use serde_json;
 
     /// dummy link_entries args from standard test entry
-    pub fn test_get_links_args_bytes(base: &Address, tag: &str) -> Vec<u8> {
+    pub fn test_get_links_args_bytes(base: &Address, link_type: &str) -> Vec<u8> {
         let args = GetLinksArgs {
             entry_address: base.clone(),
-            tag: String::from(tag),
+            link_type: String::from(link_type),
             options: Default::default(),
         };
         serde_json::to_string(&args)

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -71,27 +71,27 @@ pub mod tests {
     }
 
     /// dummy link_entries args from standard test entry
-    pub fn test_link_args_bytes(tag: String) -> Vec<u8> {
+    pub fn test_link_args_bytes(link_type: String) -> Vec<u8> {
         let entry = test_entry();
 
         let args = LinkEntriesArgs {
             base: entry.address(),
             target: entry.address(),
-            tag,
+            link_type,
         };
         serde_json::to_string(&args)
             .expect("args should serialize")
             .into_bytes()
     }
 
-    pub fn test_link_2_args_bytes(tag: String) -> Vec<u8> {
+    pub fn test_link_2_args_bytes(link_type: String) -> Vec<u8> {
         let base = test_entry();
         let target = test_entry_b();
 
         let args = LinkEntriesArgs {
             base: base.address(),
             target: target.address(),
-            tag,
+            link_type,
         };
         serde_json::to_string(&args)
             .expect("args should serialize")
@@ -123,7 +123,7 @@ pub mod tests {
     fn errors_if_base_is_not_present_test() {
         // let (call_result, _) = test_zome_api_function(
         //     ZomeApiFunction::LinkEntries.as_str(),
-        //     test_link_args_bytes(String::from("test-tag")),
+        //     test_link_args_bytes(String::from("test-link")),
         // );
         //
         // let result = ZomeApiInternalResult::try_from(call_result)
@@ -143,11 +143,11 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             context.clone(),
-            test_link_args_bytes(String::from("test-tag")),
+            test_link_args_bytes(String::from("test-link")),
         );
 
         let no_entry: Option<Address> = Some(HashString::from(
-            "QmWXM2r3iujqGvka8XMKU2wLdz5N14bEhvDp7Rx3R3oaEP",
+            "QmS7rEQfvv2Jc8GYQSUjMvjvmR6aMxAP2WaacxqXxPp9fa",
         ));
         let result = ZomeApiInternalResult::success(no_entry);
         assert_eq!(
@@ -166,7 +166,7 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             context.clone(),
-            test_link_args_bytes(String::from("wrong-tag")),
+            test_link_args_bytes(String::from("wrong-link")),
         );
 
         let result = ZomeApiInternalResult::try_from(call_result)
@@ -190,11 +190,11 @@ pub mod tests {
 
         let call_result = test_zome_api_function_call(
             context.clone(),
-            test_link_2_args_bytes(String::from("test-tag")),
+            test_link_2_args_bytes(String::from("test-link")),
         );
 
         let no_entry: Option<Address> = Some(HashString::from(
-            "QmcmcrbAfoaqJMZun74Xs1TsCUndXAohJNrKu7xZyr68P8",
+            "QmWjivLnppxzKQzfqn4MpSstnVuHGRFR5VwLLXpDtEe2Bc",
         ));
         let result = ZomeApiInternalResult::success(no_entry);
 

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -86,7 +86,8 @@ pub fn find_link_definition_in_dna(
             .links_to
             .iter()
             .find(|&link_def| {
-                link_def.target_type == String::from(target_type.clone()) && &link_def.link_type == link_type
+                link_def.target_type == String::from(target_type.clone())
+                    && &link_def.link_type == link_type
             })
             .and_then(|link_def| {
                 Some(LinkDefinitionPath {
@@ -107,7 +108,8 @@ pub fn find_link_definition_in_dna(
             .linked_from
             .iter()
             .find(|&link_def| {
-                link_def.base_type == String::from(base_type.clone()) && &link_def.link_type == link_type
+                link_def.base_type == String::from(base_type.clone())
+                    && &link_def.link_type == link_type
             })
             .and_then(|link_def| {
                 Some(LinkDefinitionPath {

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -50,7 +50,7 @@ pub fn get_link_entries(
 /// zome
 ///  |_ entry type
 ///      |_ direction (links_to / linked_from)
-///          |_ tag
+///          |_ link_type
 ///
 /// Needed for link validation to call the right callback
 pub struct LinkDefinitionPath {
@@ -61,10 +61,10 @@ pub struct LinkDefinitionPath {
 }
 
 /// This function tries to find the link definition for a link given by base type,
-/// tag and target type.
+/// link type and target type.
 ///
 /// It first looks at all "links_to" definitions in the base entry type and checks
-/// for matching tag and target type.
+/// for matching link type and target type.
 ///
 /// If nothing could be found there it iterates over all "linked_form" definitions in
 /// the target entry type.

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -57,7 +57,7 @@ pub struct LinkDefinitionPath {
     pub zome_name: String,
     pub entry_type_name: String,
     pub direction: LinkDirection,
-    pub tag: String,
+    pub link_type: String,
 }
 
 /// This function tries to find the link definition for a link given by base type,
@@ -72,7 +72,7 @@ pub struct LinkDefinitionPath {
 /// Returns a LinkDefinitionPath to uniquely reference the link definition in the DNA.
 pub fn find_link_definition_in_dna(
     base_type: &EntryType,
-    tag: &String,
+    link_type: &String,
     target_type: &EntryType,
     context: &Arc<Context>,
 ) -> Result<LinkDefinitionPath, HolochainError> {
@@ -86,14 +86,14 @@ pub fn find_link_definition_in_dna(
             .links_to
             .iter()
             .find(|&link_def| {
-                link_def.target_type == String::from(target_type.clone()) && &link_def.tag == tag
+                link_def.target_type == String::from(target_type.clone()) && &link_def.link_type == link_type
             })
             .and_then(|link_def| {
                 Some(LinkDefinitionPath {
                     zome_name: dna.get_zome_name_for_app_entry_type(app_entry_type)?,
                     entry_type_name: app_entry_type.to_string(),
                     direction: LinkDirection::To,
-                    tag: link_def.tag.clone(),
+                    link_type: link_def.link_type.clone(),
                 })
             }),
         _ => None,
@@ -107,14 +107,14 @@ pub fn find_link_definition_in_dna(
             .linked_from
             .iter()
             .find(|&link_def| {
-                link_def.base_type == String::from(base_type.clone()) && &link_def.tag == tag
+                link_def.base_type == String::from(base_type.clone()) && &link_def.link_type == link_type
             })
             .and_then(|link_def| {
                 Some(LinkDefinitionPath {
                     zome_name: dna.get_zome_name_for_app_entry_type(app_entry_type)?,
                     entry_type_name: app_entry_type.to_string(),
                     direction: LinkDirection::From,
-                    tag: link_def.tag.clone(),
+                    link_type: link_def.link_type.clone(),
                 })
             }),
         _ => None,

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -55,14 +55,14 @@ pub fn get_validation_package_definition(
 
             let link_definition_path = links_utils::find_link_definition_in_dna(
                 &base.entry_type(),
-                link_add.link().tag(),
+                link_add.link().link_type(),
                 &target.entry_type(),
                 &context,
             )?;
 
             let params = LinkValidationPackageArgs {
                 entry_type: link_definition_path.entry_type_name,
-                tag: link_definition_path.tag,
+                link_type: link_definition_path.link_type,
                 direction: link_definition_path.direction,
             };
 
@@ -90,14 +90,14 @@ pub fn get_validation_package_definition(
 
             let link_definition_path = links_utils::find_link_definition_in_dna(
                 &base.entry_type(),
-                link_remove.link().tag(),
+                link_remove.link().link_type(),
                 &target.entry_type(),
                 &context,
             )?;
 
             let params = LinkValidationPackageArgs {
                 entry_type: link_definition_path.entry_type_name,
-                tag: link_definition_path.tag,
+                link_type: link_definition_path.link_type,
                 direction: link_definition_path.direction,
             };
 

--- a/core/src/nucleus/validation/link_entry.rs
+++ b/core/src/nucleus/validation/link_entry.rs
@@ -39,7 +39,7 @@ pub async fn validate_link_entry(
 
     let link_definition_path = links_utils::find_link_definition_in_dna(
         &base.entry_type(),
-        link.tag(),
+        link.link_type(),
         &target.entry_type(),
         context,
     )

--- a/core/src/workflows/get_link_result.rs
+++ b/core/src/workflows/get_link_result.rs
@@ -26,7 +26,7 @@ pub async fn get_link_result_workflow<'a>(
     let links = await!(get_links(
         context.clone(),
         link_args.entry_address.clone(),
-        link_args.tag.clone(),
+        link_args.link_type.clone(),
         link_args.options.timeout.clone()
     ))?;
 

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -141,7 +141,7 @@ pub mod tests {
             .block_on(author_entry(&entry, None, &context1))
             .unwrap();
 
-        let link_add = LinkData::new_add(&entry_address, &entry_address, "test-tag");
+        let link_add = LinkData::new_add(&entry_address, &entry_address, "test-link");
         let link_entry = Entry::LinkAdd(link_add);
 
         let _ = context1

--- a/core_types/src/dna/entry_types.rs
+++ b/core_types/src/dna/entry_types.rs
@@ -43,7 +43,7 @@ pub struct LinksTo {
 
     /// The tag of this links_to entry
     #[serde(default)]
-    pub tag: String,
+    pub link_type: String,
 }
 
 impl Default for LinksTo {
@@ -51,7 +51,7 @@ impl Default for LinksTo {
     fn default() -> Self {
         LinksTo {
             target_type: String::new(),
-            tag: String::new(),
+            link_type: String::new(),
         }
     }
 }
@@ -71,9 +71,9 @@ pub struct LinkedFrom {
     #[serde(default)]
     pub base_type: String,
 
-    /// The tag of this links_to entry
+    /// The link_type of this links_to entry
     #[serde(default)]
-    pub tag: String,
+    pub link_type: String,
 }
 
 impl Default for LinkedFrom {
@@ -81,7 +81,7 @@ impl Default for LinkedFrom {
     fn default() -> Self {
         LinkedFrom {
             base_type: String::new(),
-            tag: String::new(),
+            link_type: String::new(),
         }
     }
 }
@@ -167,13 +167,13 @@ mod tests {
                 "links_to": [
                     {
                         "target_type": "test",
-                        "tag": "test"
+                        "link_type": "test"
                     }
                 ],
                 "linked_from": [
                     {
                         "base_type": "HcSysAgentKeyHash",
-                        "tag": "authored_posts"
+                        "link_type": "authored_posts"
                     }
                 ]
             }"#,
@@ -186,12 +186,12 @@ mod tests {
 
         let mut link = LinksTo::new();
         link.target_type = String::from("test");
-        link.tag = String::from("test");
+        link.link_type = String::from("test");
         entry.links_to.push(link);
 
         let mut linked = LinkedFrom::new();
         linked.base_type = String::from("HcSysAgentKeyHash");
-        linked.tag = String::from("authored_posts");
+        linked.link_type = String::from("authored_posts");
         entry.linked_from.push(linked);
 
         assert_eq!(fixture, entry);

--- a/core_types/src/dna/entry_types.rs
+++ b/core_types/src/dna/entry_types.rs
@@ -41,7 +41,7 @@ pub struct LinksTo {
     #[serde(default)]
     pub target_type: String,
 
-    /// The tag of this links_to entry
+    /// The type of this links_to entry
     #[serde(default)]
     pub link_type: String,
 }

--- a/core_types/src/dna/mod.rs
+++ b/core_types/src/dna/mod.rs
@@ -305,7 +305,7 @@ pub mod tests {
                                 "links_to": [
                                     {
                                         "target_type": "test",
-                                        "tag": "test"
+                                        "link_type": "test"
                                     }
                                 ],
                                 "linked_from": []
@@ -480,7 +480,7 @@ pub mod tests {
                                 "links_to": [
                                     {
                                         "target_type": "test",
-                                        "tag": "test"
+                                        "link_type": "test"
                                     }
                                 ],
                                 "linked_from": []

--- a/core_types/src/eav/eavi.rs
+++ b/core_types/src/eav/eavi.rs
@@ -72,8 +72,8 @@ impl fmt::Display for Attribute {
             Attribute::EntryHeader => write!(f, "entry-header"),
             Attribute::Link => write!(f, "link"),
             Attribute::LinkRemove => write!(f, "link_remove"),
-            Attribute::LinkTag(tag) => write!(f, "link__{}", tag),
-            Attribute::RemovedLink(tag) => write!(f, "removed_link__{}", tag),
+            Attribute::LinkTag(link_type) => write!(f, "link__{}", link_type),
+            Attribute::RemovedLink(link_type) => write!(f, "removed_link__{}", link_type),
             Attribute::PendingEntry => write!(f, "pending-entry"),
         }
     }
@@ -91,11 +91,11 @@ impl TryFrom<&str> for Attribute {
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         use self::Attribute::*;
         if LINK_REGEX.is_match(s) {
-            let tag = LINK_REGEX.captures(s)?.get(1)?.as_str().to_string();
-            Ok(LinkTag(tag))
+            let link_type = LINK_REGEX.captures(s)?.get(1)?.as_str().to_string();
+            Ok(LinkTag(link_type))
         } else if REMOVED_LINK_REGEX.is_match(s) {
-            let tag = REMOVED_LINK_REGEX.captures(s)?.get(1)?.as_str().to_string();
-            Ok(RemovedLink(tag))
+            let link_type = REMOVED_LINK_REGEX.captures(s)?.get(1)?.as_str().to_string();
+            Ok(RemovedLink(link_type))
         } else {
             match s {
                 "crud-status" => Ok(CrudStatus),

--- a/core_types/src/link/link_data.rs
+++ b/core_types/src/link/link_data.rs
@@ -55,14 +55,14 @@ pub mod tests {
         json::JsonString,
         link::{
             link_data::LinkData,
-            tests::{example_link, example_link_action_kind, example_link_tag},
+            tests::{example_link, example_link_action_kind, example_link_type},
         },
     };
     use std::convert::TryFrom;
 
     pub fn example_link_add() -> LinkData {
         let link = example_link();
-        LinkData::new_add(link.base(), link.target(), link.tag())
+        LinkData::new_add(link.base(), link.target(), link.link_type())
     }
 
     pub fn test_link_entry() -> Entry {
@@ -71,7 +71,7 @@ pub mod tests {
 
     pub fn test_link_entry_json_string() -> JsonString {
         JsonString::from_json(&format!(
-            "{{\"LinkAdd\":{{\"action_kind\":\"ADD\",\"link\":{{\"base\":\"{}\",\"target\":\"{}\",\"tag\":\"foo-tag\"}}}}}}",
+            "{{\"LinkAdd\":{{\"action_kind\":\"ADD\",\"link\":{{\"base\":\"{}\",\"target\":\"{}\",\"link_type\":\"foo-link-type\"}}}}}}",
             test_entry_a().address(),
             test_entry_b().address(),
         ))
@@ -94,7 +94,7 @@ pub mod tests {
 
     #[test]
     fn link_tag_test() {
-        assert_eq!(&example_link_tag(), example_link().tag(),);
+        assert_eq!(&example_link_type(), example_link().link_type(),);
     }
 
     #[test]

--- a/core_types/src/link/link_data.rs
+++ b/core_types/src/link/link_data.rs
@@ -16,17 +16,17 @@ pub struct LinkData {
 }
 
 impl LinkData {
-    pub fn new_add(base: &Address, target: &Address, tag: &str) -> Self {
+    pub fn new_add(base: &Address, target: &Address, link_type: &str) -> Self {
         LinkData {
             action_kind: LinkActionKind::ADD,
-            link: Link::new(base, target, tag),
+            link: Link::new(base, target, link_type),
         }
     }
 
-    pub fn new_delete(base: &Address, target: &Address, tag: &str) -> Self {
+    pub fn new_delete(base: &Address, target: &Address, link_type: &str) -> Self {
         LinkData {
             action_kind: LinkActionKind::REMOVE,
-            link: Link::new(base, target, tag),
+            link: Link::new(base, target, link_type),
         }
     }
 
@@ -93,7 +93,7 @@ pub mod tests {
     }
 
     #[test]
-    fn link_tag_test() {
+    fn link_type_test() {
         assert_eq!(&example_link_type(), example_link().link_type(),);
     }
 

--- a/core_types/src/link/mod.rs
+++ b/core_types/src/link/mod.rs
@@ -7,21 +7,21 @@ pub mod link_list;
 
 use crate::{cas::content::Address, error::HolochainError, json::JsonString};
 
-type LinkTag = String;
+type LinkType = String;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, DefaultJson)]
 pub struct Link {
     base: Address,
     target: Address,
-    tag: LinkTag,
+    link_type: LinkType,
 }
 
 impl Link {
-    pub fn new(base: &Address, target: &Address, tag: &str) -> Self {
+    pub fn new(base: &Address, target: &Address, link_type: &str) -> Self {
         Link {
             base: base.to_owned(),
             target: target.to_owned(),
-            tag: tag.to_owned(),
+            link_type: link_type.to_owned(),
         }
     }
 
@@ -34,8 +34,8 @@ impl Link {
         &self.target
     }
 
-    pub fn tag(&self) -> &LinkTag {
-        &self.tag
+    pub fn link_type(&self) -> &LinkType {
+        &self.link_type
     }
 }
 
@@ -52,18 +52,18 @@ pub mod tests {
     use crate::{
         cas::content::AddressableContent,
         entry::{test_entry_a, test_entry_b},
-        link::{Link, LinkActionKind, LinkTag},
+        link::{Link, LinkActionKind, LinkType},
     };
 
-    pub fn example_link_tag() -> LinkTag {
-        LinkTag::from("foo-tag")
+    pub fn example_link_type() -> LinkType {
+        LinkType::from("foo-link-type")
     }
 
     pub fn example_link() -> Link {
         Link::new(
             &test_entry_a().address(),
             &test_entry_b().address(),
-            &example_link_tag(),
+            &example_link_type(),
         )
     }
 

--- a/doc/holochain_101/src/first_steps.md
+++ b/doc/holochain_101/src/first_steps.md
@@ -158,7 +158,7 @@ define_zome! {
             links: [
                 to!(
                     "listItem",
-                    tag: "items",
+                    link_type: "items",
                     validation_package: || hdk::ValidationPackageDefinition::Entry,
                     validation: |_validation_data: hdk::LinkValidationData| {
                         Ok(())
@@ -205,7 +205,7 @@ fn handle_create_list(list: List) -> ZomeApiResult<Address> {
 
 The `hdk::commit_entry` function is how a zome can interact with holochain core to add entries to the DHT or local chain. This will trigger the validation function for the entry and if successful will store the entry and return its hash/address.
 
-The `add_item` function requires the use of holochain links to associate two entries. In holochain-proto this required the use of a commit with a special Links entry but it can now be done using the HDK function `link_entries(address1, address2, tag)`. The add item handler accepts a `ListItem` and an address of a list, commits the `ListItem`, then links it to the list address:
+The `add_item` function requires the use of holochain links to associate two entries. In holochain-proto this required the use of a commit with a special Links entry but it can now be done using the HDK function `link_entries(address1, address2, link_type)`. The add item handler accepts a `ListItem` and an address of a list, commits the `ListItem`, then links it to the list address:
 
 ```rust
 fn handle_add_item(list_item: ListItem, list_addr: HashString) -> ZomeApiResult<Address> {
@@ -223,7 +223,7 @@ fn handle_add_item(list_item: ListItem, list_addr: HashString) -> ZomeApiResult<
 
 At the moment there is no validation done on the link entries. This will be added soon with an additional validation callback.
 
-Finally, `get_list` requires us to use the HDK function `get_links(base_address, tag)`. As you may have guessed, this will return the addresses of all the entries that are linked to the `base_address` with a given tag. As this only returns the addresses, we must then map over each of then and load the required entry.
+Finally, `get_list` requires us to use the HDK function `get_links(base_address, link_type)`. As you may have guessed, this will return the addresses of all the entries that are linked to the `base_address` with a given link_type. As this only returns the addresses, we must then map over each of then and load the required entry.
 
 ```rust
 fn handle_get_list(list_addr: HashString) -> ZomeApiResult<GetListResponse> {
@@ -316,7 +316,7 @@ define_zome! {
             links: [
                 to!(
                     "listItem",
-                    tag: "items",
+                    link_type: "items",
                     validation_package: || hdk::ValidationPackageDefinition::Entry,
                     validation: |_validation_data: hdk::LinkValidationData| {
                         Ok(())

--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -147,7 +147,7 @@ Caller can request additional metadata on the entry such as type or sources
 
 Canonical name: `get_links`
 
-Consumes two values, the first of which is the address of an entry, base, and the second of which is a string, tag, used to describe the relationship between the base and other entries you wish to lookup. Returns a list of addresses of other entries which matched as being linked by the given tag. Links are created in the first place using the Zome API function [link_entries](#link-entries). Once you have the addresses, there is a good likelihood that you will wish to call [get_entry](#get-entry) for each of them.
+Consumes two values, the first of which is the address of an entry, base, and the second of which is a string, link_type, used to describe the relationship between the base and other entries you wish to lookup. Returns a list of addresses of other entries which matched as being linked by the given link type. Links are created in the first place using the Zome API function [link_entries](#link-entries). Once you have the addresses, there is a good likelihood that you will wish to call [get_entry](#get-entry) for each of them.
 
 - [View get_links in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_links.html)
 - [View get_links_and_load in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_links_and_load.html)
@@ -159,7 +159,7 @@ Consumes two values, the first of which is the address of an entry, base, and th
 
 Canonical name: `link_entries`
 
-Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a relationship between them, called a `tag`. Later, lists of entries can be looked up by using `get_links`. Entries can only be looked up in the direction from the `base`, which is the first argument, to the `target`, which is the second. This function returns a hash for the LinkAdd entry on completion.
+Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a relationship between them, called a `link_type`. Later, lists of entries can be looked up by using `get_links`. Entries can only be looked up in the direction from the `base`, which is the first argument, to the `target`, which is the second. This function returns a hash for the LinkAdd entry on completion.
 
 [View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.link_entries.html)
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -745,7 +745,7 @@ pub fn get_entry_result(
 
 /// Adds a named, directed link between two entries on the DHT.
 /// Consumes three values, two of which are the addresses of entries, and one of which is a string that defines a
-/// relationship between them, called a `tag`. Later, lists of entries can be looked up by using [get_links](fn.get_links.html). Entries
+/// relationship between them, called a the `link type`. Later, lists of entries can be looked up by using [get_links](fn.get_links.html). Entries
 /// can only be looked up in the direction from the `base`, which is the first argument, to the `target`.
 /// # Examples
 /// ```rust
@@ -815,7 +815,7 @@ pub fn link_entries<S: Into<String>>(
 /// Commits a LinkRemove entry to your local source chain that marks a link as 'deleted' by setting
 /// its status metadata to `Deleted` which gets published to the DHT.
 /// Consumes three values, two of which are the addresses of entries, and one of which is a string that removes a
-/// relationship between them, called a `tag`. Later, lists of entries.
+/// relationship between them, called its `type`. Later, lists of entries.
 /// # Examples
 /// ```rust
 /// # #![feature(try_from)]
@@ -1107,10 +1107,10 @@ pub fn remove_entry(address: &Address) -> ZomeApiResult<Address> {
     Dispatch::RemoveEntry.with_input(address.to_owned())
 }
 
-/// Consumes three values; the address of an entry get get links from (the base), the tag of the links
+/// Consumes three values; the address of an entry get get links from (the base), the type of the links
 /// to be retrieved, and an options struct for selecting what meta data and crud status links to retrieve.
-/// Note: the tag is intended to describe the relationship between the `base` and other entries you wish to lookup.
-/// This function returns a list of addresses of other entries which matched as being linked by the given `tag`.
+/// Note: the type is intended to describe the relationship between the `base` and other entries you wish to lookup.
+/// This function returns a list of addresses of other entries which matched as being linked by the given `type`.
 /// Links are created using the Zome API function [link_entries](fn.link_entries.html).
 /// If you also need the content of the entry consider using one of the helper functions:
 /// [get_links_result](fn.get_links_result) or [get_links_and_load](fn._get_links_and_load)
@@ -1143,11 +1143,11 @@ pub fn get_links_with_options<S: Into<String>>(
 }
 
 /// Helper function for get_links. Returns a vector with the default return results.
-pub fn get_links<S: Into<String>>(base: &Address, tag: S) -> ZomeApiResult<GetLinksResult> {
-    get_links_with_options(base, tag, GetLinksOptions::default())
+pub fn get_links<S: Into<String>>(base: &Address, link_type: S) -> ZomeApiResult<GetLinksResult> {
+    get_links_with_options(base, link_type, GetLinksOptions::default())
 }
 
-/// Retrieves data about entries linked to a base address with a given tag. This is the most general version of the various get_links
+/// Retrieves data about entries linked to a base address with a given type. This is the most general version of the various get_links
 /// helpers (such as get_links_and_load) and can return the linked addresses, entries, headers and sources. Also supports CRUD status_request.
 /// The data returned is configurable with the GetLinksOptions to specify links options and GetEntryOptions argument wto specify options when loading the entries.
 /// # Examples
@@ -1163,17 +1163,17 @@ pub fn get_links<S: Into<String>>(base: &Address, tag: S) -> ZomeApiResult<GetLi
 ///
 /// # fn main() {
 /// fn hangle_get_links_result(address: Address) -> ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>> {
-///    hdk::get_links_result(&address, "test-tag", GetLinksOptions::default(), GetEntryOptions::default())
+///    hdk::get_links_result(&address, "test-link", GetLinksOptions::default(), GetEntryOptions::default())
 /// }
 /// # }
 /// ```
 pub fn get_links_result<S: Into<String>>(
     base: &Address,
-    tag: S,
+    link_type: S,
     options: GetLinksOptions,
     get_entry_options: GetEntryOptions,
 ) -> ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>> {
-    let get_links_result = get_links_with_options(base, tag, options)?;
+    let get_links_result = get_links_with_options(base, link_type, options)?;
     let result = get_links_result
         .addresses()
         .iter()
@@ -1185,11 +1185,11 @@ pub fn get_links_result<S: Into<String>>(
 /// Helper function for get_links. Returns a vector of the entries themselves
 pub fn get_links_and_load<S: Into<String>>(
     base: &HashString,
-    tag: S,
+    link_type: S,
 ) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
     let get_links_result = get_links_result(
         base,
-        tag,
+        link_type,
         GetLinksOptions::default(),
         GetEntryOptions::default(),
     )?;

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -1132,12 +1132,12 @@ pub fn remove_entry(address: &Address) -> ZomeApiResult<Address> {
 /// ```
 pub fn get_links_with_options<S: Into<String>>(
     base: &Address,
-    tag: S,
+    link_type: S,
     options: GetLinksOptions,
 ) -> ZomeApiResult<GetLinksResult> {
     Dispatch::GetLinks.with_input(GetLinksArgs {
         entry_address: base.clone(),
-        tag: tag.into(),
+        link_type: link_type.into(),
         options,
     })
 }

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -1110,7 +1110,7 @@ pub fn remove_entry(address: &Address) -> ZomeApiResult<Address> {
 /// Consumes three values; the address of an entry get get links from (the base), the type of the links
 /// to be retrieved, and an options struct for selecting what meta data and crud status links to retrieve.
 /// Note: the type is intended to describe the relationship between the `base` and other entries you wish to lookup.
-/// This function returns a list of addresses of other entries which matched as being linked by the given `type`.
+/// This function returns a list of addresses of other entries which matched as being linked by the given `link_type`.
 /// Links are created using the Zome API function [link_entries](fn.link_entries.html).
 /// If you also need the content of the entry consider using one of the helper functions:
 /// [get_links_result](fn.get_links_result) or [get_links_and_load](fn._get_links_and_load)

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -815,7 +815,7 @@ pub fn link_entries<S: Into<String>>(
 /// Commits a LinkRemove entry to your local source chain that marks a link as 'deleted' by setting
 /// its status metadata to `Deleted` which gets published to the DHT.
 /// Consumes three values, two of which are the addresses of entries, and one of which is a string that removes a
-/// relationship between them, called its `type`. Later, lists of entries.
+/// relationship between them, called its `link_type`. Later, lists of entries.
 /// # Examples
 /// ```rust
 /// # #![feature(try_from)]

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -803,12 +803,12 @@ pub fn get_entry_result(
 pub fn link_entries<S: Into<String>>(
     base: &Address,
     target: &Address,
-    tag: S,
+    link_type: S,
 ) -> Result<Address, ZomeApiError> {
     Dispatch::LinkEntries.with_input(LinkEntriesArgs {
         base: base.clone(),
         target: target.clone(),
-        tag: tag.into(),
+        link_type: link_type.into(),
     })
 }
 
@@ -867,12 +867,12 @@ pub fn link_entries<S: Into<String>>(
 pub fn remove_link<S: Into<String>>(
     base: &Address,
     target: &Address,
-    tag: S,
+    link_type: S,
 ) -> Result<(), ZomeApiError> {
     Dispatch::RemoveLink.with_input(LinkEntriesArgs {
         base: base.clone(),
         target: target.clone(),
-        tag: tag.into(),
+        link_type: link_type.into(),
     })
 }
 

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -144,7 +144,7 @@ pub struct ValidatingLinkDefinition {
 ///         links: [
 ///             to!(
 ///                 "post",
-///                 tag: "comments",
+///                 link_type: "comments",
 ///
 ///                 validation_package: || {
 ///                     hdk::ValidationPackageDefinition::ChainFull
@@ -257,7 +257,7 @@ macro_rules! entry {
 ///     or `hdk::LinkDirection::From`.
 /// 2. other_type: `other_type` is the entry type this link connects to. If direction is `to` this
 ///     would be the link target, if direction is `from` this defines the link's base type.
-/// 3. tag: `tag` is the name of this association and thus the handle by which it can be retrieved
+/// 3. link_type: `link_type` is the name of this association and thus the handle by which it can be retrieved
 ///     if given to [get_links()](fn.get_links.html) in conjunction with the base address.
 /// 4. validation_package: Similar to entries, links have to be validated.
 ///        `validation_package` is a special identifier, which declares which data is required from peers

--- a/hdk-rust/src/entry_definition.rs
+++ b/hdk-rust/src/entry_definition.rs
@@ -50,11 +50,11 @@ pub struct ValidatingEntryType {
 pub struct ValidatingLinkDefinition {
     /// Is this link defined as pointing from this entry type to some other type,
     /// or from the other type to this?
-    pub link_type: LinkDirection,
+    pub direction: LinkDirection,
     /// The other entry type the link connects this entry type to
     pub other_entry_type: String,
     /// Tag (i.e. name) of this type of links
-    pub tag: String,
+    pub link_type: String,
     /// Callback that returns a validation package definition that Holochain reads in order
     /// to create the right validation package to pass in to the validator callback on validation.
     pub package_creator: PackageCreator,
@@ -187,12 +187,12 @@ macro_rules! entry {
             entry_type.sharing = $sharing;
 
             $($(
-                match $link_expr.link_type {
+                match $link_expr.direction {
                     $crate::LinkDirection::To => {
                         entry_type.links_to.push(
                             $crate::holochain_core_types::dna::entry_types::LinksTo{
                                 target_type: $link_expr.other_entry_type,
-                                tag: $link_expr.tag,
+                                link_type: $link_expr.link_type,
                             }
                         );
                     },
@@ -200,7 +200,7 @@ macro_rules! entry {
                         entry_type.linked_from.push(
                             $crate::holochain_core_types::dna::entry_types::LinkedFrom{
                                 base_type: $link_expr.other_entry_type,
-                                tag: $link_expr.tag,
+                                link_type: $link_expr.link_type,
                             }
                         );
                     }
@@ -273,7 +273,7 @@ macro_rules! link {
     (
         direction: $direction:expr,
         other_type: $other_type:expr,
-        tag: $tag:expr,
+        link_type: $link_type:expr,
 
         validation_package: || $package_creator:expr,
         validation: | $validation_data:ident : hdk::LinkValidationData | $link_validation:expr
@@ -291,9 +291,9 @@ macro_rules! link {
 
 
             ::hdk::entry_definition::ValidatingLinkDefinition {
-                link_type: $direction,
+                direction: $direction,
                 other_entry_type: String::from($other_type),
-                tag: String::from($tag),
+                link_type: String::from($link_type),
                 package_creator,
                 validator,
             }
@@ -309,7 +309,7 @@ macro_rules! link {
 macro_rules! to {
     (
         $other_type:expr,
-        tag: $tag:expr,
+        link_type: $link_type:expr,
 
         validation_package: || $package_creator:expr,
         validation: | $validation_data:ident : hdk::LinkValidationData | $link_validation:expr
@@ -317,7 +317,7 @@ macro_rules! to {
         link!(
             direction: $crate::LinkDirection::To,
             other_type: $other_type,
-            tag: $tag,
+            link_type: $link_type,
 
             validation_package: || $package_creator,
             validation: | $validation_data : hdk::LinkValidationData | $link_validation
@@ -333,7 +333,7 @@ macro_rules! to {
 macro_rules! from {
     (
         $other_type:expr,
-        tag: $tag:expr,
+        link_type: $link_type:expr,
 
         validation_package: || $package_creator:expr,
         validation: |  $validation_data:ident : hdk::LinkValidationData | $link_validation:expr
@@ -341,7 +341,7 @@ macro_rules! from {
         link!(
             direction: $crate::LinkDirection::From,
             other_type: $other_type,
-            tag: $tag,
+            link_type: $link_type,
 
             validation_package: || $package_creator,
             validation: |  $validation_data : hdk::LinkValidationData | $link_validation

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -164,7 +164,8 @@ pub extern "C" fn __hdk_get_validation_package_for_link(
             })
             .and_then(|entry_type| {
                 entry_type.links.into_iter().find(|ref link_definition| {
-                    link_definition.link_type == input.link_type && link_definition.direction == input.direction
+                    link_definition.link_type == input.link_type
+                        && link_definition.direction == input.direction
                 })
             })
             .and_then(|mut link_definition| {

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -164,7 +164,7 @@ pub extern "C" fn __hdk_get_validation_package_for_link(
             })
             .and_then(|entry_type| {
                 entry_type.links.into_iter().find(|ref link_definition| {
-                    link_definition.tag == input.tag && link_definition.link_type == input.direction
+                    link_definition.link_type == input.link_type && link_definition.direction == input.direction
                 })
             })
             .and_then(|mut link_definition| {
@@ -208,8 +208,8 @@ pub extern "C" fn __hdk_validate_link(
                     .links
                     .into_iter()
                     .find(|link_definition| {
-                        link_definition.tag == *input.link.tag()
-                            && link_definition.link_type == input.direction
+                        link_definition.link_type == *input.link.link_type()
+                            && link_definition.direction == input.direction
                     })
             })
             .and_then(|mut link_definition| {

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -15,9 +15,9 @@ use std::convert::TryFrom;
 ///
 pub fn get_links_and_load_type<S: Into<String>, R: TryFrom<AppEntryValue>>(
     base: &Address,
-    tag: S,
+    link_type: S,
 ) -> ZomeApiResult<Vec<R>> {
-    let link_load_results = hdk::get_links_and_load(base, tag)?;
+    let link_load_results = hdk::get_links_and_load(base, link_type)?;
 
     Ok(link_load_results
         .iter()
@@ -63,26 +63,26 @@ pub fn get_as_type<R: TryFrom<AppEntryValue>>(address: Address) -> ZomeApiResult
 }
 
 /// Creates two links:
-/// From A to B, and from B to A, with given tags.
+/// From A to B, and from B to A, with given link_types.
 pub fn link_entries_bidir<S: Into<String>>(
     a: &Address,
     b: &Address,
-    tag_a_b: S,
-    tag_b_a: S,
+    link_type_a_b: S,
+    link_type_b_a: S,
 ) -> ZomeApiResult<()> {
-    hdk::link_entries(a, b, tag_a_b)?;
-    hdk::link_entries(b, a, tag_b_a)?;
+    hdk::link_entries(a, b, link_type_a_b)?;
+    hdk::link_entries(b, a, link_type_b_a)?;
     Ok(())
 }
 
 /// Commits the given entry and links it from the base
-/// with the given tag.
+/// with the given link_type.
 pub fn commit_and_link<S: Into<String>>(
     entry: &Entry,
     base: &Address,
-    tag: S,
+    link_type: S,
 ) -> ZomeApiResult<Address> {
     let entry_addr = hdk::commit_entry(entry)?;
-    hdk::link_entries(base, &entry_addr, tag)?;
+    hdk::link_entries(base, &entry_addr, link_type)?;
     Ok(entry_addr)
 }

--- a/hdk-rust/tests/integration_test.rs
+++ b/hdk-rust/tests/integration_test.rs
@@ -325,7 +325,7 @@ fn start_holochain_instance<T: Into<String>>(
             .unwrap();
         test_entry_type.links_to.push(LinksTo {
             target_type: String::from("testEntryType"),
-            tag: String::from("test-tag"),
+            link_type: String::from("test"),
         });
     }
 
@@ -334,7 +334,7 @@ fn start_holochain_instance<T: Into<String>>(
         let mut link_validator = EntryTypeDef::new();
         link_validator.links_to.push(LinksTo {
             target_type: String::from("link_validator"),
-            tag: String::from("longer"),
+            link_type: String::from("longer"),
         });
         entry_types.insert(EntryType::from("link_validator"), link_validator);
     }
@@ -582,7 +582,7 @@ fn can_link_entries() {
     assert!(result.is_ok(), "\t result = {:?}", result);
     assert_eq!(
         result.unwrap(),
-        JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#)
+        JsonString::from_json(r#"{"Ok":"QmVB8zcfXUetoYRqScagNs4mbtfCrVYv2UswtS2NbqCFwP"}"#)
     );
 }
 
@@ -594,7 +594,7 @@ fn can_remove_link() {
     assert!(result.is_ok(), "\t result = {:?}", result);
     assert_eq!(
         result.unwrap(),
-        JsonString::from_json(r#"{"Ok":"QmQvTQKNEXSrPxqB8VBz7vmpf44vubPD7jhPTWRBATZuDD"}"#)
+        JsonString::from_json(r#"{"Ok":"QmVB8zcfXUetoYRqScagNs4mbtfCrVYv2UswtS2NbqCFwP"}"#)
     );
 }
 

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -145,7 +145,7 @@ fn handle_link_two_entries() -> ZomeApiResult<Address> {
 
     hdk::commit_entry(&entry_2)?;
 
-    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")
+    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test")
 }
 
 fn handle_remove_link() -> ZomeApiResult<()> {
@@ -167,14 +167,14 @@ fn handle_remove_link() -> ZomeApiResult<()> {
     );
 
     hdk::commit_entry(&entry_2)?;
-    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")?;
-    hdk::remove_link(&entry_1.address(), &entry_2.address(), "test-tag")
+    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test")?;
+    hdk::remove_link(&entry_1.address(), &entry_2.address(), "test")
 
 }
 
 /// Commit 3 entries
-/// Commit a "test-tag" link from entry1 to entry2
-/// Commit a "test-tag" link from entry1 to entry3
+/// Commit a "test" link from entry1 to entry2
+/// Commit a "test" link from entry1 to entry3
 /// return entry1 address
 fn handle_links_roundtrip_create() -> ZomeApiResult<Address> {
     let entry_1 = Entry::App(
@@ -204,19 +204,19 @@ fn handle_links_roundtrip_create() -> ZomeApiResult<Address> {
     );
     hdk::commit_entry(&entry_3)?;
 
-    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test-tag")?;
-    hdk::link_entries(&entry_1.address(), &entry_3.address(), "test-tag")?;
+    hdk::link_entries(&entry_1.address(), &entry_2.address(), "test")?;
+    hdk::link_entries(&entry_1.address(), &entry_3.address(), "test")?;
     Ok(entry_1.address())
 }
 
 fn handle_links_roundtrip_get(address: Address) -> ZomeApiResult<GetLinksResult> {
-    hdk::get_links(&address, "test-tag")
+    hdk::get_links(&address, "test")
 }
 
 fn handle_links_roundtrip_get_and_load(
     address: Address,
 ) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
-    hdk::get_links_and_load(&address, "test-tag")
+    hdk::get_links_and_load(&address, "test")
 }
 
 fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
@@ -474,7 +474,7 @@ define_zome! {
             links: [
                 to!(
                     "testEntryType",
-                    tag: "test-tag",
+                    link_type: "test",
                     validation_package: || {
                         hdk::ValidationPackageDefinition::ChainFull
                     },
@@ -523,7 +523,7 @@ define_zome! {
             links: [
                 to!(
                     "link_validator",
-                    tag: "longer",
+                    link_type: "longer",
                     validation_package: || {
                         hdk::ValidationPackageDefinition::Entry
                     },

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -594,7 +594,7 @@ mod tests {
         let link_add = LinkData::new_add(
             &"base".to_string().into(),
             &"target".to_string().into(),
-            "tag",
+            "link-type",
         );
         let entry = Entry::LinkAdd(link_add.clone());
         let entry_wh = mk_entry_wh(entry.clone());

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -90,13 +90,13 @@ pub fn create_test_dna_with_wasm(zome_name: &str, wasm: Vec<u8>) -> Dna {
     let mut test_entry_def = EntryTypeDef::new();
     test_entry_def.links_to.push(LinksTo {
         target_type: String::from("testEntryType"),
-        tag: String::from("test-tag"),
+        link_type: String::from("test-link"),
     });
 
     let mut test_entry_b_def = EntryTypeDef::new();
     test_entry_b_def.linked_from.push(LinkedFrom {
         base_type: String::from("testEntryType"),
-        tag: String::from("test-tag"),
+        link_type: String::from("test-link"),
     });
 
     let mut test_entry_c_def = EntryTypeDef::new();

--- a/wasm_utils/src/api_serialization/get_links.rs
+++ b/wasm_utils/src/api_serialization/get_links.rs
@@ -5,7 +5,7 @@ use holochain_core_types::{
 #[derive(Deserialize, Default, Debug, Serialize, Clone, PartialEq, Eq, Hash, DefaultJson)]
 pub struct GetLinksArgs {
     pub entry_address: Address,
-    pub tag: String,
+    pub link_type: String,
     pub options: GetLinksOptions,
 }
 

--- a/wasm_utils/src/api_serialization/link_entries.rs
+++ b/wasm_utils/src/api_serialization/link_entries.rs
@@ -4,11 +4,11 @@ use holochain_core_types::{cas::content::Address, error::HolochainError, json::*
 pub struct LinkEntriesArgs {
     pub base: Address,
     pub target: Address,
-    pub tag: String,
+    pub link_type: String,
 }
 
 impl LinkEntriesArgs {
     pub fn to_link(&self) -> Link {
-        Link::new(&self.base, &self.target, &self.tag)
+        Link::new(&self.base, &self.target, &self.link_type)
     }
 }

--- a/wasm_utils/src/api_serialization/validation.rs
+++ b/wasm_utils/src/api_serialization/validation.rs
@@ -20,7 +20,7 @@ pub enum LinkDirection {
 #[derive(Deserialize, Debug, Serialize, DefaultJson, Clone)]
 pub struct LinkValidationPackageArgs {
     pub entry_type: String,
-    pub tag: String,
+    pub link_type: String,
     pub direction: LinkDirection,
 }
 


### PR DESCRIPTION
## PR summary

Renames the `tag` aspect of links to `link_type` in all parts of the code including the HDK and docs.

This is to enable the next iteration which is re-implementing the `tag` as a true tag (e.g. something you can define dynamically at run time) like it was in Holochain proto.

This will be a minor breaking change for zome developers so it may be worth waiting until the entire new set of link features are added before including this in a release.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
