### PR TITLE
WIP: app_spec link indexing showcase & changes to hdk crate to support tag option

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -17,6 +17,30 @@ const scenario1 = new Scenario([instanceAlice], { debugLog:true })
 const scenario2 = new Scenario([instanceAlice, instanceBob], { debugLog: true })
 const scenario3 = new Scenario([instanceAlice, instanceBob, instanceCarol], { debugLog: true })
 
+scenario1.runTape('query capability using link tags', async (t, {alice}) => {
+  const params = {content: "Queryable Blog Post w/Topics", in_reply_to: null, topics: ["holochain", "distributed", "holo"]}
+  const result = await alice.callSync("blog", "create_post", params)
+  t.equal(result.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+
+  const query_result1 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain"]})
+  t.equal(query_result1.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  const query_result2 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holo"]})
+  t.equal(query_result2.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  const query_result3 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed"]})
+  t.equal(query_result3.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+
+  const query_result4 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain", "holo"]})
+  t.equal(query_result4.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  const query_result5 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed", "Holochain"]})
+  t.equal(query_result5.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+
+  const query_result6 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["holo", "distributed"]})
+  t.equal(query_result6.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+
+  const query_result7 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["Holochain", "holo", "distributed"]})
+  t.equal(query_result7.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+})
+
 scenario2.runTape('capabilities grant and claim', async (t, { alice, bob }) => {
 
     // Ask for alice to grant a token for bob  (it's hard-coded for bob in re function for now)
@@ -124,7 +148,7 @@ scenario1.runTape('show_env', async (t, { alice }) => {
 })
 
 scenario3.runTape('get sources', async (t, { alice, bob, carol }) => {
-  const params = { content: 'whatever', in_reply_to: null }
+  const params = { content: 'whatever', in_reply_to: null, topics: []}
   const address = await alice.callSync('blog', 'create_post', params).then(x => x.Ok)
   const address1 = await alice.callSync('blog', 'create_post', params).then(x => x.Ok)
   const address2 = await bob.callSync('blog', 'create_post', params).then(x => x.Ok)
@@ -178,7 +202,8 @@ scenario1.runTape('create_post', async (t, { alice }) => {
 
   const content = "Holo world"
   const in_reply_to = null
-  const params = { content, in_reply_to }
+  const topics = [];
+  const params = { content, in_reply_to, topics}
   const result = alice.call("blog", "create_post", params)
 
   t.ok(result.Ok)
@@ -294,7 +319,7 @@ scenario2.runTape('delete_post', async (t, { alice, bob }) => {
 
   //create post
   const alice_create_post_result = await alice.callSync("blog", "create_post",
-    { "content": "Posty", "in_reply_to": "" }
+    { "content": "Posty", "in_reply_to": "", "topics": [] }
   )
 
   const bob_create_post_result = await bob.callSync("blog", "posts_by_agent",
@@ -354,7 +379,8 @@ scenario2.runTape('update_entry_validation', async (t, { alice, bob }) => {
 
   const content = "Hello Holo world 321"
   const in_reply_to = null
-  const params = { content, in_reply_to }
+  const topics = []
+  const params = { content, in_reply_to, topics}
 
   //commit create_post
   const createResult = await alice.callSync("blog", "create_post", params)
@@ -371,7 +397,8 @@ scenario2.runTape('update_entry_validation', async (t, { alice, bob }) => {
 scenario2.runTape('update_post', async (t, { alice, bob }) => {
   const content = "Hello Holo world 123"
   const in_reply_to = null
-  const params = { content, in_reply_to }
+  const topics = []
+  const params = { content, in_reply_to, topics }
 
   //commit version 1
   const createResult = await alice.callSync("blog", "create_post", params)
@@ -486,7 +513,8 @@ scenario2.runTape('update_post', async (t, { alice, bob }) => {
 scenario2.runTape('remove_update_modifed_entry', async (t, { alice, bob }) => {
   const content = "Hello Holo world 123"
   const in_reply_to = null
-  const params = { content, in_reply_to }
+  const topics = []
+  const params = { content, in_reply_to, topics }
 
   //commit version 1
   const createResult = await alice.callSync("blog", "create_post", params)
@@ -514,7 +542,8 @@ scenario2.runTape('remove_update_modifed_entry', async (t, { alice, bob }) => {
 scenario1.runTape('create_post with bad reply to', async (t, { alice }) => {
   const content = "Holo world"
   const in_reply_to = "bad"
-  const params = { content, in_reply_to }
+  const topics = []
+  const params = { content, in_reply_to, topics }
   const result = alice.call("blog", "create_post", params)
 
   // bad in_reply_to is an error condition
@@ -545,7 +574,8 @@ scenario1.runTape('post max content size 280 characters', async (t, { alice }) =
 
   const content = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
   const in_reply_to = null
-  const params = { content, in_reply_to }
+  const topics = []
+  const params = { content, in_reply_to, topics }
   const result = alice.call("blog", "create_post", params)
 
   // result should be an error
@@ -572,11 +602,11 @@ scenario1.runTape('posts_by_agent', async (t, { alice }) => {
 scenario1.runTape('my_posts', async (t, { alice }) => {
 
   await alice.callSync("blog", "create_post",
-    { "content": "Holo world", "in_reply_to": "" }
+    { "content": "Holo world", "in_reply_to": "", "topics": "[]" }
   )
 
   await alice.callSync("blog", "create_post",
-    { "content": "Another post", "in_reply_to": "" }
+    { "content": "Another post", "in_reply_to": "", "topics": "[]" }
   )
 
   const result = alice.call("blog", "my_posts", {})
@@ -588,7 +618,7 @@ scenario1.runTape('my_posts', async (t, { alice }) => {
 scenario1.runTape('my_posts_immediate_timeout', async (t, { alice }) => {
 
   alice.call("blog", "create_post",
-    { "content": "Holo world", "in_reply_to": "" }
+    { "content": "Holo world", "in_reply_to": "", "topics": "[]" }
   )
 
   const result = alice.call("blog", "my_posts_immediate_timeout", {})
@@ -601,11 +631,11 @@ scenario1.runTape('my_posts_immediate_timeout', async (t, { alice }) => {
 scenario2.runTape('get_sources_from_link', async (t, { alice, bob }) => {
 
   await alice.callSync("blog", "create_post",
-    { "content": "Holo world", "in_reply_to": null }
+    { "content": "Holo world", "in_reply_to": null, "topics": [] }
   );
 
   await bob.callSync("blog", "create_post",
-  { "content": "Another one", "in_reply_to": null }
+  { "content": "Another one", "in_reply_to": null, "topics": [] }
 );
   const alice_posts = bob.call("blog","authored_posts_with_sources",
   {
@@ -651,7 +681,8 @@ scenario1.runTape('create/get_post roundtrip', async (t, { alice }) => {
 
   const content = "Holo world"
   const in_reply_to = null
-  const params = { content, in_reply_to }
+  const topics = []
+  const params = { content, in_reply_to, topics }
   const create_post_result = alice.call("blog", "create_post", params)
   const post_address = create_post_result.Ok
 
@@ -681,10 +712,10 @@ scenario1.runTape('get_post with non-existant address returns null', async (t, {
 scenario2.runTape('scenario test create & publish post -> get from other instance', async (t, { alice, bob }) => {
 
   const initialContent = "Holo world"
-  const params = { content: initialContent, in_reply_to: null }
+  const params = { content: initialContent, in_reply_to: null, topics: [] }
   const create_result = await alice.callSync("blog", "create_post", params)
 
-  const params2 = { content: "post 2", in_reply_to: null }
+  const params2 = { content: "post 2", in_reply_to: null, topics: [] }
   const create_result2 = await bob.callSync("blog", "create_post", params2)
 
   t.equal(create_result.Ok.length, 46)
@@ -701,7 +732,7 @@ scenario2.runTape('scenario test create & publish post -> get from other instanc
 scenarioBridge.runTape('scenario test create & publish -> getting post via bridge', async (t, {alice, bob}) => {
 
   const initialContent = "Holo world"
-  const params = { content: initialContent, in_reply_to: null }
+  const params = { content: initialContent, in_reply_to: null, topics: [] }
   const create_result = await bob.callSync("blog", "create_post", params)
 
   t.equal(create_result.Ok, "QmY6MfiuhHnQ1kg7RwNZJNUQhwDxTFL45AAPnpJMNPEoxk")

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -23,22 +23,22 @@ scenario1.runTape('query capability using link tags', async (t, {alice}) => {
   t.equal(result.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
 
   const query_result1 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain"]})
-  t.equal(query_result1.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result1)
   const query_result2 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holo"]})
-  t.equal(query_result2.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result2)
   const query_result3 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed"]})
-  t.equal(query_result3.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result3)
 
   const query_result4 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain", "holo"]})
-  t.equal(query_result4.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result4)
   const query_result5 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed", "Holochain"]})
-  t.equal(query_result5.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result5)
 
   const query_result6 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["holo", "distributed"]})
-  t.equal(query_result6.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result6)
 
   const query_result7 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["Holochain", "holo", "distributed"]})
-  t.equal(query_result7.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
+  t.ok(query_result7)
 })
 
 scenario2.runTape('capabilities grant and claim', async (t, { alice, bob }) => {

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -22,23 +22,30 @@ scenario1.runTape('query capability using link tags', async (t, {alice}) => {
   const result = await alice.callSync("blog", "create_post", params)
   t.equal(result.Ok, 'QmVdNzdFJnMyKJd6L3k1rNZqptUgwbzJoh78HEQ33z36qm')
 
-  const query_result1 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain"]})
-  t.ok(query_result1)
-  const query_result2 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holo"]})
-  t.ok(query_result2)
-  const query_result3 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed"]})
-  t.ok(query_result3)
+  const query_result1 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain"], query_type: "And"})
+  t.ok(query_result1.Ok)
+  const query_result2 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holo"], query_type: "And"})
+  t.ok(query_result2.Ok)
+  const query_result3 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed"], query_type: "And"})
+  t.ok(query_result3.Ok)
 
-  const query_result4 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain", "holo"]})
-  t.ok(query_result4)
-  const query_result5 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed", "Holochain"]})
-  t.ok(query_result5)
+  const query_result4 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain", "holo"], query_type: "And"})
+  t.ok(query_result4.Ok)
+  const query_result5 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["distributed", "Holochain"], query_type: "And"})
+  t.ok(query_result5.Ok)
 
-  const query_result6 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["holo", "distributed"]})
-  t.ok(query_result6)
+  const query_result6 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["holo", "distributed"], query_type: "And"})
+  t.ok(query_result6.Ok)
 
-  const query_result7 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["Holochain", "holo", "distributed"]})
-  t.ok(query_result7)
+  const query_result7 = await alice.callSync("blog", "get_posts_by_topic", {base_topic: ["Holochain", "holo", "distributed"], query_type: "And"})
+  t.ok(query_result7.Ok)
+
+  const params2 = {content: "Queryable Blog Post 2 w/Topics", in_reply_to: null, topics: ["holochain", "distributed", "holo"]}
+  const result2 = await alice.callSync("blog", "create_post", params2)
+  t.equal(result2.Ok, 'Qmf4m4nmTAXNgJ2bu3WCFdBoArNeDPMxujDGKqoGT3fnP3')
+
+  const query_result8 = await alice.callSync("blog", "get_posts_by_topic", {topics: ["Holochain" , "distributed", "holo"], query_type: "Or"})
+  t.ok(query_result8.Ok) //should return first post and second post as query_type is or for a topic they both belong to
 })
 
 scenario2.runTape('capabilities grant and claim', async (t, { alice, bob }) => {

--- a/app_spec/zomes/blog/code/Cargo.toml
+++ b/app_spec/zomes/blog/code/Cargo.toml
@@ -10,6 +10,7 @@ hdk = { path = "../../../../hdk-rust" }
 holochain_core_types_derive = { path = "../../../../core_types_derive" }
 serde_derive = "=1.0.89"
 boolinator = "=2.4.0"
+itertools = "=0.8"
 
 [lib]
 path = "src/lib.rs"

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -22,10 +22,12 @@ use hdk::{
 
 use memo::Memo;
 use post::Post;
+use topic::Topic;
 use std::{
     collections::BTreeMap,
     convert::{TryFrom, TryInto},
 };
+use itertools::Itertools;
 
 #[derive(Serialize, Deserialize, Debug, DefaultJson, PartialEq)]
 struct SumInput {
@@ -239,7 +241,7 @@ pub fn handle_receive(from: Address, json_msg: JsonString) -> String {
                             };
                             let _ =
                                 hdk::debug("For some reason this link_entries statement fails!?!?");
-                            //                            let _ = hdk::link_entries(&AGENT_ADDRESS, &Address::from(x.clone()), "authored_posts");
+                            //                            let _ = hdk::link_entries(&AGENT_ADDRESS, &Address::from(x.clone()), "authored_posts", None);
 
                             x
 
@@ -319,18 +321,71 @@ pub fn handle_memo_address(content: String) -> ZomeApiResult<Address> {
     hdk::entry_address(&memo_entry(content))
 }
 
-pub fn handle_create_post(content: String, in_reply_to: Option<Address>) -> ZomeApiResult<Address> {
-    let address = hdk::commit_entry(&post_entry(content))?;
+pub fn create_topics(topics: &Vec<String>) -> ZomeApiResult<Vec<Address>> {
+    let mut topic_addresses = vec![];
+    for topic in topics{
+        hdk::debug("creating topic")?;
+        hdk::debug(topic.clone())?;
+        let entry = Entry::App("topic".into(), Topic{topic: topic.to_string()}.into());
+        let topic_entry_address = hdk::entry_address(&entry)?;
+        match hdk::get_entry(&topic_entry_address)? {
+            Some(_entry) => {
+                topic_addresses.push(topic_entry_address);
+            },
+            None => {
+                let address = hdk::commit_entry(&entry)?;
+                topic_addresses.push(address);
+            }
+        }
+    };
+    Ok(topic_addresses)
+}
 
-    hdk::link_entries(&AGENT_ADDRESS, &address, "authored_posts")?;
+pub fn create_topic_indexs(post: &Address, mut topics: Vec<String>) -> ZomeApiResult<String> {
+    let mut link_combinations = vec![]; //Vector for link combinations on post
+    topics = topics.iter().map(|topic| topic.to_lowercase()).collect(); //put topics to lowercase
+    topics.sort_by(|a, b| b.cmp(&a)); //sort topics to be in decending alphabetical order - allows less links to be made
+
+    for (i, _) in topics.iter().enumerate(){ //Iterate over topics and get all permutations of topics
+        let combinations = topics.iter().combinations(i);
+        for c in combinations.into_iter(){
+            link_combinations.push(c);
+        };
+    };
+    link_combinations.push(topics.iter().collect());
+    link_combinations = link_combinations[1..link_combinations.len()].to_vec();
+    hdk::debug(format!("Topic combination links to be made: {:?}", link_combinations))?;
+    for link in link_combinations{ //Create link combinations for expression indexing
+        let link_strings: Vec<String> = link.iter().map(|link_value| format!("{}", link_value,) ).collect(); //Create link string for each set of topic combinations
+        let link_string = link_strings.join(":");
+        let start_address = hdk::entry_address(&Entry::App("topic".into(), Topic{topic: link[0].to_string()}.into()))?;
+        hdk::link_entries(&start_address, post, "topic_index".to_string(), Some(link_string))?; //create link with type: topic_index and generate link_string
+    };
+    Ok("Link indexs created".to_string())
+}
+
+pub fn handle_create_post(content: String, in_reply_to: Option<Address>, topics: Vec<String>) -> ZomeApiResult<Address> {
+    let address = hdk::commit_entry(&post_entry(content))?;
+    create_topics(&topics)?;
+    create_topic_indexs(&address, topics)?;
+
+    hdk::link_entries(&AGENT_ADDRESS, &address, "authored_posts", None)?;
 
     if let Some(in_reply_to_address) = in_reply_to {
         // return with Err if in_reply_to_address points to missing entry
         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions::default())?;
-        hdk::link_entries(&in_reply_to_address, &address, "comments")?;
+        hdk::link_entries(&in_reply_to_address, &address, "comments", None)?;
     }
 
     Ok(address)
+}
+
+pub fn handle_get_post_by_topics(mut topics: Vec<String>) -> ZomeApiResult<Vec<Post>> {
+    topics = topics.iter().map(|topic| topic.to_lowercase()).collect();
+    topics.sort_by(|a, b| b.cmp(&a)); //make sure topics are in the correct decending alphabetical order as they were saved
+    let base_topic_address = hdk::entry_address(&Entry::App("topic".into(), Topic{topic: topics[0].clone()}.into()))?; 
+    let entries = hdk::utils::get_links_and_load_type::<String, Post>(&base_topic_address, "topic_index".to_string(), Some(topics.join(":")))?;
+    Ok(entries)
 }
 
 pub fn handle_create_post_countersigned(content: String, in_reply_to: Option<Address>,
@@ -342,12 +397,12 @@ pub fn handle_create_post_countersigned(content: String, in_reply_to: Option<Add
 
     let address = hdk::commit_entry_result(&entry, options).unwrap().address();
 
-    hdk::link_entries(&AGENT_ADDRESS, &address, "authored_posts")?;
+    hdk::link_entries(&AGENT_ADDRESS, &address, "authored_posts", None)?;
 
     if let Some(in_reply_to_address) = in_reply_to {
         // return with Err if in_reply_to_address points to missing entry
         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions::default())?;
-        hdk::link_entries(&in_reply_to_address, &address, "comments")?;
+        hdk::link_entries(&in_reply_to_address, &address, "comments", None)?;
     }
 
     Ok(address)
@@ -361,12 +416,12 @@ pub fn handle_create_post_with_agent(
 ) -> ZomeApiResult<Address> {
     let address = hdk::commit_entry(&post_entry(content))?;
 
-    hdk::link_entries(&agent_id, &address, "authored_posts")?;
+    hdk::link_entries(&agent_id, &address, "authored_posts", None)?;
 
     if let Some(in_reply_to_address) = in_reply_to {
         // return with Err if in_reply_to_address points to missing entry
         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions::default())?;
-        hdk::link_entries(&in_reply_to_address, &address, "comments")?;
+        hdk::link_entries(&in_reply_to_address, &address, "comments", None)?;
     }
 
     Ok(address)
@@ -385,11 +440,11 @@ pub fn handle_delete_post(content: String) -> ZomeApiResult<Address> {
 }
 
 pub fn handle_posts_by_agent(agent: Address) -> ZomeApiResult<GetLinksResult> {
-    hdk::get_links(&agent, "authored_posts")
+    hdk::get_links(&agent, "authored_posts", None)
 }
 
 pub fn handle_my_posts() -> ZomeApiResult<GetLinksResult> {
-    hdk::get_links(&AGENT_ADDRESS, "authored_posts")
+    hdk::get_links(&AGENT_ADDRESS, "authored_posts", None)
 }
 
 pub fn handle_my_memos() -> ZomeApiResult<Vec<Address>> {
@@ -405,6 +460,7 @@ pub fn handle_my_posts_immediate_timeout() -> ZomeApiResult<GetLinksResult> {
     hdk::get_links_with_options(
         &AGENT_ADDRESS,
         "authored_posts",
+        None,
         GetLinksOptions {
             timeout: 0.into(),
             ..Default::default()
@@ -416,6 +472,7 @@ pub fn handle_my_posts_get_my_sources(agent: Address) -> ZomeApiResult<GetLinksR
     hdk::get_links_with_options(
         &agent,
         "authored_posts",
+        None,
         GetLinksOptions {
             headers: true,
             ..Default::default()
@@ -494,11 +551,11 @@ pub fn handle_update_post(post_address: Address, new_content: String) -> ZomeApi
 pub fn handle_recommend_post(post_address: Address, agent_address: Address) -> ZomeApiResult<Address> {
     hdk::debug(format!("my address:\n{:?}", AGENT_ADDRESS.to_string()))?;
     hdk::debug(format!("other address:\n{:?}", agent_address.to_string()))?;
-    hdk::link_entries(&agent_address, &post_address, "recommended_posts")
+    hdk::link_entries(&agent_address, &post_address, "recommended_posts", None)
 }
 
 pub fn handle_my_recommended_posts() -> ZomeApiResult<GetLinksResult> {
-    hdk::get_links(&AGENT_ADDRESS, "recommended_posts")
+    hdk::get_links(&AGENT_ADDRESS, "recommended_posts", None)
 }
 
 pub fn handle_get_post_bridged(post_address: Address) -> ZomeApiResult<Option<Entry>> {

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -9,10 +9,12 @@ extern crate boolinator;
 extern crate serde_json;
 #[macro_use]
 extern crate holochain_core_types_derive;
+extern crate itertools;
 
 pub mod blog;
 pub mod memo;
 pub mod post;
+pub mod topic;
 
 use blog::Env;
 use hdk::{
@@ -31,7 +33,8 @@ define_zome! {
 
     entries: [
         post::definition(),
-        memo::definition()
+        memo::definition(),
+        topic::definition()
     ]
 
     genesis: || {
@@ -81,9 +84,15 @@ define_zome! {
         }
 
         create_post: {
-            inputs: |content: String, in_reply_to: Option<Address>|,
+            inputs: |content: String, in_reply_to: Option<Address>, topics: Vec<String>|,
             outputs: |result: ZomeApiResult<Address>|,
             handler: blog::handle_create_post
+        }
+
+        get_posts_by_topic: {
+            inputs: |topics: Vec<String>|,
+            outputs: |result: ZomeApiResult<Vec<post::Post>>|,
+            handler: blog::handle_get_post_by_topics
         }
 
         create_post_with_agent: {
@@ -239,6 +248,6 @@ define_zome! {
     ]
 
     traits: {
-        hc_public [show_env, check_sum, ping, get_sources, post_address, create_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged]
+        hc_public [show_env, check_sum, ping, get_sources, post_address, create_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged, get_posts_by_topic]
     }
 }

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -90,7 +90,7 @@ define_zome! {
         }
 
         get_posts_by_topic: {
-            inputs: |topics: Vec<String>|,
+            inputs: |topics: Vec<String>, query_type: topic::QueryType|,
             outputs: |result: ZomeApiResult<Vec<post::Post>>|,
             handler: blog::handle_get_post_by_topics
         }

--- a/app_spec/zomes/blog/code/src/post.rs
+++ b/app_spec/zomes/blog/code/src/post.rs
@@ -96,6 +96,16 @@ pub fn definition() -> ValidatingEntryType {
                 validation: | _validation_data: hdk::LinkValidationData | {
                     Ok(())
                 }
+            ),
+            from!(
+                "topic",
+                link_type: "topic_index",
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::ChainFull
+                },
+                validation: | _validation_data: hdk::LinkValidationData| {
+                    Ok(())
+                }
             )
         ]
     )
@@ -149,6 +159,10 @@ mod tests {
                     base_type: "%agent_id".to_string(),
                     link_type: "recommended_posts".to_string(),
                 },
+                LinkedFrom {
+                    base_type: "topic".to_string(),
+                    link_type: "topic_index".to_string(),
+                }
             ],
             links_to: Vec::new(),
             sharing: Sharing::Public,

--- a/app_spec/zomes/blog/code/src/topic.rs
+++ b/app_spec/zomes/blog/code/src/topic.rs
@@ -1,0 +1,141 @@
+//use boolinator::Boolinator;
+use hdk::entry_definition::ValidatingEntryType;
+/// This file holds everything that represents the "post" entry type.
+use hdk::holochain_core_types::{
+    dna::entry_types::Sharing, error::HolochainError, json::JsonString,
+};
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
+pub struct Topic {
+    pub topic: String
+}
+
+impl Topic {
+    pub fn new(topic: &str) -> Topic {
+        Topic {
+            topic: topic.to_owned()
+        }
+    }
+
+    pub fn content(&self) -> String {
+        self.topic.clone()
+    }
+}
+
+pub fn definition() -> ValidatingEntryType {
+    entry!(
+        name: "topic",
+        description: "A topic entry - used for indexing posts based on their topic",
+        sharing: Sharing::Public,
+
+        validation_package: || {
+            hdk::ValidationPackageDefinition::ChainFull
+        },
+
+        validation: |_validation_data: hdk::EntryValidationData<Topic>| {
+            Ok(())
+        },
+
+        links: [
+            to!(
+                "post",
+                link_type: "topic_index",
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::ChainFull
+                },
+                validation: |_validation_data: hdk::LinkValidationData| {
+                    Ok(())
+                }   
+            )
+        ]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::topic::{
+        Topic,
+        definition
+    };
+    use hdk::{
+        holochain_core_types::{
+            chain_header::test_chain_header,
+            dna::entry_types::{EntryTypeDef, LinksTo, Sharing},
+            entry::{
+                entry_type::{AppEntryType, EntryType},
+                Entry,
+            },
+            validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
+        },
+        holochain_wasm_utils::api_serialization::validation::LinkDirection,
+    };
+
+    #[test]
+    fn time_smoke_test() {
+        let content = "test-topic";
+        let topic = Topic::new(content);
+
+        assert_eq!(content.to_string(), topic.content(),);
+    }
+
+    #[test]
+    fn time_definition_test() {
+        let mut topic_definition = definition();
+
+        let expected_name = EntryType::from("topic");
+        assert_eq!(expected_name, topic_definition.name.clone());
+
+        let expected_definition = EntryTypeDef {
+            description: "A topic entry - used for indexing posts based on their topic".to_string(),
+            linked_from: Vec::new(),
+            links_to: vec![          
+                LinksTo {
+                    target_type: "post".to_string(),
+                    link_type: "topic_index".to_string(),
+                }
+            ],
+            sharing: Sharing::Public,
+        };
+        assert_eq!(
+            expected_definition,
+            topic_definition.entry_type_definition.clone(),
+        );
+
+        let expected_validation_package_definition = hdk::ValidationPackageDefinition::ChainFull;
+        assert_eq!(
+            expected_validation_package_definition,
+            (topic_definition.package_creator)(),
+        );
+
+        let post_ok = Topic::new("foo");
+        let entry = Entry::App(AppEntryType::from("topic"), post_ok.into());
+        let validation_data = ValidationData {
+            package: ValidationPackage::only_header(test_chain_header()),
+            lifecycle: EntryLifecycle::Chain,
+        };
+        assert_eq!(
+            (topic_definition.validator)(EntryValidationData::Create {
+                entry,
+                validation_data
+            }),
+            Ok(()),
+        );
+
+        let topic_definition_link = topic_definition.links.first().unwrap();
+
+        let expected_link_base = "post";
+        assert_eq!(
+            topic_definition_link.other_entry_type.to_owned(),
+            expected_link_base,
+        );
+
+        let expected_link_direction = LinkDirection::To;
+        assert_eq!(
+            topic_definition_link.direction.to_owned(),
+            expected_link_direction,
+        );
+
+        let expected_link_type = "topic_index";
+        assert_eq!(topic_definition_link.link_type.to_owned(), expected_link_type,);
+    }
+}

--- a/app_spec/zomes/blog/code/src/topic.rs
+++ b/app_spec/zomes/blog/code/src/topic.rs
@@ -6,6 +6,12 @@ use hdk::holochain_core_types::{
 };
 
 #[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
+pub enum QueryType {
+    And,
+    Or
+}
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
 pub struct Topic {
     pub topic: String
 }

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -813,7 +813,7 @@ pub fn link_entries<S: Into<String>>(
         link_type: link_type.into(),
         tag: match tag {
             Some(s) => s.into(),
-            None => "*".to_string()
+            None => "*".to_string(),
         },
     })
 }
@@ -1146,16 +1146,20 @@ pub fn get_links_with_options<S: Into<String>>(
     Dispatch::GetLinks.with_input(GetLinksArgs {
         entry_address: base.clone(),
         link_type: link_type.into(),
-        tag: match tag{
+        tag: match tag {
             Some(t) => Some(t.into()),
-            None => None
+            None => None,
         },
         options,
     })
 }
 
 /// Helper function for get_links. Returns a vector with the default return results.
-pub fn get_links<S: Into<String>>(base: &Address, link_type: S, tag: Option<S>) -> ZomeApiResult<GetLinksResult> {
+pub fn get_links<S: Into<String>>(
+    base: &Address,
+    link_type: S,
+    tag: Option<S>,
+) -> ZomeApiResult<GetLinksResult> {
     get_links_with_options(base, link_type, tag, GetLinksOptions::default())
 }
 

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -787,12 +787,13 @@ pub fn get_entry_result(
 ///         &AGENT_ADDRESS,
 ///         &address,
 ///         "authored_posts",
+///         None //not using a tag on this link - type will do fine
 ///     )?;
 ///
 ///     if let Some(in_reply_to_address) = in_reply_to {
 ///         // return with Err if in_reply_to_address points to missing entry
 ///         hdk::get_entry_result(&in_reply_to_address, GetEntryOptions { status_request: StatusRequestKind::All, entry: false, headers: false, timeout: Default::default() })?;
-///         hdk::link_entries(&in_reply_to_address, &address, "comments")?;
+///         hdk::link_entries(&in_reply_to_address, &address, "comments", None)?;
 ///     }
 ///
 ///     Ok(address)
@@ -804,12 +805,16 @@ pub fn link_entries<S: Into<String>>(
     base: &Address,
     target: &Address,
     link_type: S,
+    tag: Option<S>,
 ) -> Result<Address, ZomeApiError> {
     Dispatch::LinkEntries.with_input(LinkEntriesArgs {
         base: base.clone(),
         target: target.clone(),
         link_type: link_type.into(),
-        tag: "".to_string(),
+        tag: match tag {
+            Some(s) => s.into(),
+            None => "*".to_string()
+        },
     })
 }
 
@@ -1128,26 +1133,30 @@ pub fn remove_entry(address: &Address) -> ZomeApiResult<Address> {
 ///
 /// # fn main() {
 /// pub fn handle_posts_by_agent(agent: Address) -> ZomeApiResult<GetLinksResult> {
-///     hdk::get_links_with_options(&agent, "authored_posts", GetLinksOptions::default())
+///     hdk::get_links_with_options(&agent, "authored_posts", None, GetLinksOptions::default())
 /// }
 /// # }
 /// ```
 pub fn get_links_with_options<S: Into<String>>(
     base: &Address,
     link_type: S,
+    tag: Option<S>,
     options: GetLinksOptions,
 ) -> ZomeApiResult<GetLinksResult> {
     Dispatch::GetLinks.with_input(GetLinksArgs {
         entry_address: base.clone(),
         link_type: link_type.into(),
-        tag: Some("".into()), // TODO: Expose actual parameter
+        tag: match tag{
+            Some(t) => Some(t.into()),
+            None => None
+        },
         options,
     })
 }
 
 /// Helper function for get_links. Returns a vector with the default return results.
-pub fn get_links<S: Into<String>>(base: &Address, link_type: S) -> ZomeApiResult<GetLinksResult> {
-    get_links_with_options(base, link_type, GetLinksOptions::default())
+pub fn get_links<S: Into<String>>(base: &Address, link_type: S, tag: Option<S>) -> ZomeApiResult<GetLinksResult> {
+    get_links_with_options(base, link_type, tag, GetLinksOptions::default())
 }
 
 /// Retrieves data about entries linked to a base address with a given type. This is the most general version of the various get_links
@@ -1166,17 +1175,18 @@ pub fn get_links<S: Into<String>>(base: &Address, link_type: S) -> ZomeApiResult
 ///
 /// # fn main() {
 /// fn hangle_get_links_result(address: Address) -> ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>> {
-///    hdk::get_links_result(&address, "test-link", GetLinksOptions::default(), GetEntryOptions::default())
+///    hdk::get_links_result(&address, "test-link", None, GetLinksOptions::default(), GetEntryOptions::default())
 /// }
 /// # }
 /// ```
 pub fn get_links_result<S: Into<String>>(
     base: &Address,
     link_type: S,
+    tag: Option<S>,
     options: GetLinksOptions,
     get_entry_options: GetEntryOptions,
 ) -> ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>> {
-    let get_links_result = get_links_with_options(base, link_type, options)?;
+    let get_links_result = get_links_with_options(base, link_type, tag, options)?;
     let result = get_links_result
         .addresses()
         .iter()
@@ -1189,10 +1199,12 @@ pub fn get_links_result<S: Into<String>>(
 pub fn get_links_and_load<S: Into<String>>(
     base: &HashString,
     link_type: S,
+    tag: Option<S>,
 ) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
     let get_links_result = get_links_result(
         base,
         link_type,
+        tag,
         GetLinksOptions::default(),
         GetEntryOptions::default(),
     )?;

--- a/hdk-rust/src/api.rs
+++ b/hdk-rust/src/api.rs
@@ -805,7 +805,7 @@ pub fn link_entries<S: Into<String>>(
     base: &Address,
     target: &Address,
     link_type: S,
-    tag: Option<S>,
+    tag: S,
 ) -> Result<Address, ZomeApiError> {
     Dispatch::LinkEntries.with_input(LinkEntriesArgs {
         base: base.clone(),

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -16,8 +16,9 @@ use std::convert::TryFrom;
 pub fn get_links_and_load_type<S: Into<String>, R: TryFrom<AppEntryValue>>(
     base: &Address,
     link_type: S,
+    tag: Option<S>,
 ) -> ZomeApiResult<Vec<R>> {
-    let link_load_results = hdk::get_links_and_load(base, link_type)?;
+    let link_load_results = hdk::get_links_and_load(base, link_type, tag)?;
 
     Ok(link_load_results
         .iter()
@@ -69,9 +70,11 @@ pub fn link_entries_bidir<S: Into<String>>(
     b: &Address,
     link_type_a_b: S,
     link_type_b_a: S,
+    link_tag_a_b: Option<S>,
+    link_tag_b_a: Option<S>
 ) -> ZomeApiResult<()> {
-    hdk::link_entries(a, b, link_type_a_b)?;
-    hdk::link_entries(b, a, link_type_b_a)?;
+    hdk::link_entries(a, b, link_type_a_b, link_tag_a_b)?;
+    hdk::link_entries(b, a, link_type_b_a, link_tag_b_a)?;
     Ok(())
 }
 
@@ -81,8 +84,9 @@ pub fn commit_and_link<S: Into<String>>(
     entry: &Entry,
     base: &Address,
     link_type: S,
+    tag: Option<S>,
 ) -> ZomeApiResult<Address> {
     let entry_addr = hdk::commit_entry(entry)?;
-    hdk::link_entries(base, &entry_addr, link_type)?;
+    hdk::link_entries(base, &entry_addr, link_type, tag)?;
     Ok(entry_addr)
 }

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -71,7 +71,7 @@ pub fn link_entries_bidir<S: Into<String>>(
     link_type_a_b: S,
     link_type_b_a: S,
     link_tag_a_b: Option<S>,
-    link_tag_b_a: Option<S>
+    link_tag_b_a: Option<S>,
 ) -> ZomeApiResult<()> {
     hdk::link_entries(a, b, link_type_a_b, link_tag_a_b)?;
     hdk::link_entries(b, a, link_type_b_a, link_tag_b_a)?;


### PR DESCRIPTION
## PR summary

Implemented a showcase in app_spec which shows how links can be used for indexing of entries when link types are supported (and dynamic tag creation). Showcase uses topics which can be specified when making a post - topics are created from topic data received in `create_post` function - then link index's are made between topics and post entry. Posts can be retrieved by topics at: `get_posts_by_topics`. Accepts a vector of topics and will return any entries that are present in all topics in vector. 

Also made small changes to HDK crate so that functions associated to getting/linking of entries can accept a tag w/ type: `Option`. If option is `None` we use the following string for link data: `"*"` otherwise string inside `Some()` is used. 

Currently something funny is happening with `link_entries` & `get_links` functions. They don't seem to fully execute and don't return an error or success - just `undefined`. 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
