### PR TITLE
Add dna properties to hdk

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Option to show NPM output when pulling deps during `hc test` [PR#1401](https://github.com/holochain/holochain-rust/pull/1401)
 - Adds scaffolding/skeleton for a future WASM conductor [#894](https://github.com/holochain/holochain-rust/pull/894)
+- Adds PROPERTIES static to the HDK which contains a JsonString with the DNA properties object. Also adds a body to the `hdk::properties` stub which allows retrieving fields from the properties object as JsonString. [#1418](https://github.com/holochain/holochain-rust/pull/1418)
 
 ### Changed
 

--- a/app_spec/manifest.json
+++ b/app_spec/manifest.json
@@ -5,6 +5,6 @@
   "uuid": "00000000-0000-0000-0000-000000000000",
   "dna_spec_version": "2.0",
   "properties": {
-      "test": "test"
+      "test_property": "test-property-value"
   }
 }

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -116,6 +116,7 @@ scenario1.runTape('show_env', async (t, { alice }) => {
   t.equal(result.Ok.dna_name, "HDK-spec-rust")
   t.equal(result.Ok.agent_address, alice.agentId)
   t.equal(result.Ok.agent_id, '{"nick":"alice","pub_sign_key":"' + alice.agentId + '"}')
+  t.equal(result.Ok.properties, '{"test_property": "test-property-value"}')
 
   // don't compare the public token because it changes every time we change the dna.
   t.deepEqual(result.Ok.cap_request.provenance, [ alice.agentId, '+78GKy9y3laBbCNK1ajrj2rYVV3lBOxzGAZuuLDqXL2MLJUbMaB4lv7ut/UPWSoEeHx7OuXrTFXfu+PihtMMBQ==' ]

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -116,7 +116,7 @@ scenario1.runTape('show_env', async (t, { alice }) => {
   t.equal(result.Ok.dna_name, "HDK-spec-rust")
   t.equal(result.Ok.agent_address, alice.agentId)
   t.equal(result.Ok.agent_id, '{"nick":"alice","pub_sign_key":"' + alice.agentId + '"}')
-  t.equal(result.Ok.properties, '{"test_property": "test-property-value"}')
+  t.equal(result.Ok.properties, '{"test_property":"test-property-value"}')
 
   // don't compare the public token because it changes every time we change the dna.
   t.deepEqual(result.Ok.cap_request.provenance, [ alice.agentId, '+78GKy9y3laBbCNK1ajrj2rYVV3lBOxzGAZuuLDqXL2MLJUbMaB4lv7ut/UPWSoEeHx7OuXrTFXfu+PihtMMBQ==' ]

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -59,6 +59,10 @@ pub fn handle_show_env() -> ZomeApiResult<Env> {
     })
 }
 
+pub fn handle_get_test_properties() -> ZomeApiResult<JsonString> {
+    hdk::property("test_property")
+}
+
 pub fn handle_get_sources(address: Address) -> ZomeApiResult<Vec<Address>> {
     if let GetEntryResultType::Single(result) = hdk::get_entry_result(
         &address,

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -17,7 +17,7 @@ use hdk::{
         get_links::{GetLinksOptions, GetLinksResult},
         QueryArgsOptions, QueryResult,
     },
-    AGENT_ADDRESS, AGENT_ID_STR, CAPABILITY_REQ, DNA_ADDRESS, DNA_NAME, PUBLIC_TOKEN,
+    AGENT_ADDRESS, AGENT_ID_STR, CAPABILITY_REQ, DNA_ADDRESS, DNA_NAME, PUBLIC_TOKEN, PROPERTIES,
 };
 
 use memo::Memo;
@@ -40,6 +40,7 @@ pub struct Env {
     agent_id: String,
     agent_address: String,
     cap_request: CapabilityRequest,
+    properties: JsonString,
 }
 
 /// This handler shows how you can access the globals that are always available
@@ -54,6 +55,7 @@ pub fn handle_show_env() -> ZomeApiResult<Env> {
         agent_id: AGENT_ID_STR.to_string(),
         agent_address: AGENT_ADDRESS.to_string(),
         cap_request: CAPABILITY_REQ.clone(),
+        properties: PROPERTIES.clone(),
     })
 }
 

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -50,6 +50,12 @@ define_zome! {
             handler: blog::handle_show_env
         }
 
+        get_test_properties: {
+            inputs: | |,
+            outputs: |property: ZomeApiResult<JsonString>|,
+            handler: blog::handle_get_test_properties
+        }
+
         get_sources: {
             inputs: |address: Address|,
             outputs: |sources: ZomeApiResult<Vec<Address>>|,
@@ -239,6 +245,6 @@ define_zome! {
     ]
 
     traits: {
-        hc_public [show_env, check_sum, ping, get_sources, post_address, create_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged]
+        hc_public [show_env, get_test_properties, check_sum, ping, get_sources, post_address, create_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged]
     }
 }

--- a/core/src/nucleus/ribosome/api/init_globals.rs
+++ b/core/src/nucleus/ribosome/api/init_globals.rs
@@ -14,7 +14,8 @@ use wasmi::RuntimeArgs;
 /// Returns an HcApiReturnCode as I64
 pub fn invoke_init_globals(runtime: &mut Runtime, _args: &RuntimeArgs) -> ZomeApiResult {
     let call_data = runtime.call_data()?;
-    let dna_name = runtime.context()?.get_dna().unwrap().name.clone();
+    let dna = runtime.context()?.get_dna().unwrap();
+    let dna_name = dna.name.clone();
     // Create the ZomeApiGlobals struct with some default values
     let mut globals = ZomeApiGlobals {
         dna_name,
@@ -25,6 +26,7 @@ pub fn invoke_init_globals(runtime: &mut Runtime, _args: &RuntimeArgs) -> ZomeAp
         agent_latest_hash: HashString::from(""),
         public_token: Address::from(""),
         cap_request: runtime.zome_call_data()?.call.cap.clone(),
+        properties: JsonString::from(dna.properties),
     };
 
     // Update fields

--- a/hdk-rust/src/api/mod.rs
+++ b/hdk-rust/src/api/mod.rs
@@ -225,6 +225,10 @@ lazy_static! {
     /// The CapabilityRequest under which this wasm function is executing
     pub static ref CAPABILITY_REQ: &'static CapabilityRequest = &GLOBALS.cap_request;
 
+    /// The json string from the DNA top level properties field.
+    /// Deserialize this into a serde_json::Value or a zome specific struct to access the fields 
+    pub static ref PROPERTIES: &'static JsonString = &GLOBALS.properties;
+
 }
 
 impl From<DNA_NAME> for JsonString {

--- a/hdk-rust/src/api/mod.rs
+++ b/hdk-rust/src/api/mod.rs
@@ -226,7 +226,7 @@ lazy_static! {
     pub static ref CAPABILITY_REQ: &'static CapabilityRequest = &GLOBALS.cap_request;
 
     /// The json string from the DNA top level properties field.
-    /// Deserialize this into a serde_json::Value or a zome specific struct to access the fields 
+    /// Deserialize this into a serde_json::Value or a zome specific struct to access the fields
     pub static ref PROPERTIES: &'static JsonString = &GLOBALS.properties;
 
 }

--- a/hdk-rust/src/api/property.rs
+++ b/hdk-rust/src/api/property.rs
@@ -1,17 +1,21 @@
-use holochain_core_types::json::JsonString;
-use error::{ZomeApiError, ZomeApiResult};
-use serde_json::Value;
 use super::super::PROPERTIES;
+use error::{ZomeApiError, ZomeApiResult};
+use holochain_core_types::json::JsonString;
+use serde_json::Value;
 
 // Returns a DNA property, which are defined by the DNA developer.
 // They are custom values that are defined in the DNA file
 // that can be used in the zome code for defining configurable behaviors.
 // (e.g. Name, Language, Description, Author, etc.).
 pub fn property<S: Into<String>>(name: S) -> ZomeApiResult<JsonString> {
-	let properties: Value = serde_json::from_str(&PROPERTIES.to_string())
-		.map_err(|_| ZomeApiError::from("DNA Properties could not be parsed as JSON".to_string()))?;
-		
-	properties.get(name.into())
-		.map(|value| JsonString::from(value.clone()))
-		.ok_or(ZomeApiError::from("field does not exist in DNA properties".to_string()))
+    let properties: Value = serde_json::from_str(&PROPERTIES.to_string()).map_err(|_| {
+        ZomeApiError::from("DNA Properties could not be parsed as JSON".to_string())
+    })?;
+
+    properties
+        .get(name.into())
+        .map(|value| JsonString::from(value.clone()))
+        .ok_or(ZomeApiError::from(
+            "field does not exist in DNA properties".to_string(),
+        ))
 }

--- a/hdk-rust/src/api/property.rs
+++ b/hdk-rust/src/api/property.rs
@@ -1,10 +1,17 @@
+use holochain_core_types::json::JsonString;
 use error::{ZomeApiError, ZomeApiResult};
+use serde_json::Value;
+use super::super::PROPERTIES;
 
-/// NOT YET AVAILABLE
 // Returns a DNA property, which are defined by the DNA developer.
 // They are custom values that are defined in the DNA file
 // that can be used in the zome code for defining configurable behaviors.
 // (e.g. Name, Language, Description, Author, etc.).
-pub fn property<S: Into<String>>(_name: S) -> ZomeApiResult<String> {
-    Err(ZomeApiError::FunctionNotImplemented)
+pub fn property<S: Into<String>>(name: S) -> ZomeApiResult<JsonString> {
+	let properties: Value = serde_json::from_str(&PROPERTIES.to_string())
+		.map_err(|_| ZomeApiError::from("DNA Properties could not be parsed as JSON".to_string()))?;
+		
+	properties.get(name.into())
+		.map(|value| JsonString::from(value.clone()))
+		.ok_or(ZomeApiError::from("field does not exist in DNA properties".to_string()))
 }

--- a/wasm_utils/src/api_serialization/zome_api_globals.rs
+++ b/wasm_utils/src/api_serialization/zome_api_globals.rs
@@ -13,4 +13,5 @@ pub struct ZomeApiGlobals {
     pub agent_latest_hash: HashString,
     pub public_token: Address,
     pub cap_request: CapabilityRequest,
+    pub properties: JsonString,
 }


### PR DESCRIPTION
## PR summary

This makes the DNA properties field accessible either as a JsonString through the PROPERTIES static or via the `hdk::property(name)` HDK function.

Adds app spec test illustrating how it works 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
