### PR TITLE
WIP - Expose validation of agent system entry

### DIFF
--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -38,6 +38,8 @@ define_zome! {
         Ok(())
     }
 
+    agent_validation: || { Ok(()) }
+
     receive: |from, msg_json| {
         blog::handle_receive(from, JsonString::from_json(&msg_json))
     }

--- a/app_spec/zomes/converse/code/src/lib.rs
+++ b/app_spec/zomes/converse/code/src/lib.rs
@@ -57,6 +57,8 @@ define_zome! {
         }
     }
 
+    agent_validation: || { Ok(()) }
+
     functions: [
         sign_message: {
             inputs: |key_id: String, message: String|,

--- a/app_spec/zomes/summer/code/src/lib.rs
+++ b/app_spec/zomes/summer/code/src/lib.rs
@@ -20,6 +20,8 @@ define_zome! {
         Ok(())
     }
 
+    agent_validation: || { Ok(()) }
+
     functions: [
         sum: {
             inputs: |num1: u32, num2: u32|,

--- a/conductor_api/test-bridge-caller/src/lib.rs
+++ b/conductor_api/test-bridge-caller/src/lib.rs
@@ -22,6 +22,8 @@ define_zome! {
         Ok(())
     }
 
+    agent_validation: || { Ok(()) }
+
     functions: [
         call_bridge: {
             inputs: | |,

--- a/core/src/nucleus/actions/wasm-test/src/lib.rs
+++ b/core/src/nucleus/actions/wasm-test/src/lib.rs
@@ -164,6 +164,8 @@ define_zome! {
         Ok(())
     }
 
+    agent_validation: || { Ok(()) }
+
     functions: [
         test_fn: {
             inputs: | |,

--- a/core/src/nucleus/validation/agent_entry.rs
+++ b/core/src/nucleus/validation/agent_entry.rs
@@ -1,49 +1,40 @@
 use crate::{
     context::Context,
     nucleus::{
-        // actions::{
-            // get_entry::get_entry_from_dht, run_validation_callback::run_validation_callback,
-        // },
+        actions::{
+            run_validation_callback::run_validation_callback,
+        },
         validation::{
-            // entry_to_validation_data, ValidationError,
-            ValidationResult},
-        // CallbackFnCall,
+            ValidationResult
+        },
+        CallbackFnCall,
     },
 };
 use holochain_core_types::{
-    // cas::content::{Address, AddressableContent},
-    entry::{
-        // entry_type::AppEntryType, 
-        Entry},
+    entry::Entry,
+    json::JsonString,
+    cas::content::AddressableContent,
     validation::ValidationData,
 };
-// use holochain_wasm_utils::api_serialization::validation::EntryValidationArgs;
 use std::sync::Arc;
+use futures::future;
+use futures_util::future::FutureExt;
 
 pub async fn validate_agent_entry(
-    _entry: Entry,
+    entry: Entry,
     _validation_data: ValidationData,
-    _context: &Arc<Context>,
+    context: &Arc<Context>,
 ) -> ValidationResult {
+    let dna = context.get_dna().expect("Callback called without DNA set!");
+
+    let _results = await!(future::join_all(
+        dna.zomes
+        .iter()
+        .map(|(zome_name, _)| {
+            let call = CallbackFnCall::new(&zome_name, "__hdk_validate_agent_entry", JsonString::empty_object());
+            run_validation_callback(entry.address(), call, &context).boxed()
+        })
+    ));
+
     Ok(())
-    // let dna = context.get_dna().expect("Callback called without DNA set!");
-
-    // let zome_name = dna
-    //     .get_zome_name_for_app_entry_type(&app_entry_type)
-    //     .ok_or(ValidationError::NotImplemented)?;
-    // if let Some(expected_link_update) = link.clone() {
-    //     get_entry_from_dht(&context.clone(), &expected_link_update).map_err(|_| {
-    //         ValidationError::UnresolvedDependencies(vec![expected_link_update.clone()])
-    //     })?;
-    // };
-
-    // let params = EntryValidationArgs {
-    //     validation_data: entry_to_validation_data(context.clone(), &entry, link, validation_data)
-    //         .map_err(|_| {
-    //         ValidationError::Fail("Could not get entry validation".to_string())
-    //     })?,
-    // };
-    // let call = CallbackFnCall::new(&zome_name, "__hdk_validate_app_entry", params);
-
-    // await!(run_validation_callback(entry.address(), call, &context))
 }

--- a/core/src/nucleus/validation/agent_entry.rs
+++ b/core/src/nucleus/validation/agent_entry.rs
@@ -1,0 +1,49 @@
+use crate::{
+    context::Context,
+    nucleus::{
+        // actions::{
+            // get_entry::get_entry_from_dht, run_validation_callback::run_validation_callback,
+        // },
+        validation::{
+            // entry_to_validation_data, ValidationError,
+            ValidationResult},
+        // CallbackFnCall,
+    },
+};
+use holochain_core_types::{
+    // cas::content::{Address, AddressableContent},
+    entry::{
+        // entry_type::AppEntryType, 
+        Entry},
+    validation::ValidationData,
+};
+// use holochain_wasm_utils::api_serialization::validation::EntryValidationArgs;
+use std::sync::Arc;
+
+pub async fn validate_agent_entry(
+    _entry: Entry,
+    _validation_data: ValidationData,
+    _context: &Arc<Context>,
+) -> ValidationResult {
+    Ok(())
+    // let dna = context.get_dna().expect("Callback called without DNA set!");
+
+    // let zome_name = dna
+    //     .get_zome_name_for_app_entry_type(&app_entry_type)
+    //     .ok_or(ValidationError::NotImplemented)?;
+    // if let Some(expected_link_update) = link.clone() {
+    //     get_entry_from_dht(&context.clone(), &expected_link_update).map_err(|_| {
+    //         ValidationError::UnresolvedDependencies(vec![expected_link_update.clone()])
+    //     })?;
+    // };
+
+    // let params = EntryValidationArgs {
+    //     validation_data: entry_to_validation_data(context.clone(), &entry, link, validation_data)
+    //         .map_err(|_| {
+    //         ValidationError::Fail("Could not get entry validation".to_string())
+    //     })?,
+    // };
+    // let call = CallbackFnCall::new(&zome_name, "__hdk_validate_app_entry", params);
+
+    // await!(run_validation_callback(entry.address(), call, &context))
+}

--- a/core/src/nucleus/validation/agent_entry.rs
+++ b/core/src/nucleus/validation/agent_entry.rs
@@ -1,24 +1,17 @@
 use crate::{
     context::Context,
     nucleus::{
-        actions::{
-            run_validation_callback::run_validation_callback,
-        },
-        validation::{
-            ValidationResult
-        },
+        actions::run_validation_callback::run_validation_callback,
+        validation::{ValidationError, ValidationResult},
         CallbackFnCall,
     },
 };
-use holochain_core_types::{
-    entry::Entry,
-    json::JsonString,
-    cas::content::AddressableContent,
-    validation::ValidationData,
-};
-use std::sync::Arc;
 use futures::future;
 use futures_util::future::FutureExt;
+use holochain_core_types::{
+    cas::content::AddressableContent, entry::Entry, json::JsonString, validation::ValidationData,
+};
+use std::sync::Arc;
 
 pub async fn validate_agent_entry(
     entry: Entry,
@@ -27,14 +20,30 @@ pub async fn validate_agent_entry(
 ) -> ValidationResult {
     let dna = context.get_dna().expect("Callback called without DNA set!");
 
-    let _results = await!(future::join_all(
-        dna.zomes
-        .iter()
-        .map(|(zome_name, _)| {
-            let call = CallbackFnCall::new(&zome_name, "__hdk_validate_agent_entry", JsonString::empty_object());
-            run_validation_callback(entry.address(), call, &context).boxed()
-        })
-    ));
+    let results = await!(future::join_all(dna.zomes.iter().map(|(zome_name, _)| {
+        let call = CallbackFnCall::new(
+            &zome_name,
+            "__hdk_validate_agent_entry",
+            JsonString::empty_object(),
+        );
+        // Need to return a boxed future for it to work with join_all
+        // https://users.rust-lang.org/t/the-trait-unpin-is-not-implemented-for-genfuture-error-when-using-join-all/23612/2
+        run_validation_callback(entry.address(), call, &context).boxed()
+    })));
 
-    Ok(())
+    let errors: Vec<ValidationError> = results
+        .iter()
+        .filter_map(|r| match r {
+            Ok(_) => None,
+            Err(e) => Some(e.to_owned()),
+        })
+        .collect();
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(ValidationError::Error(
+            "Failed to validate agent ID on a zome".into(),
+        ))
+    }
 }

--- a/core/src/nucleus/validation/mod.rs
+++ b/core/src/nucleus/validation/mod.rs
@@ -10,8 +10,8 @@ use holochain_core_types::{
 
 use std::sync::Arc;
 
-mod app_entry;
 mod agent_entry;
+mod app_entry;
 mod header_address;
 mod link_entry;
 mod provenances;

--- a/core/src/nucleus/validation/mod.rs
+++ b/core/src/nucleus/validation/mod.rs
@@ -11,6 +11,7 @@ use holochain_core_types::{
 use std::sync::Arc;
 
 mod app_entry;
+mod agent_entry;
 mod header_address;
 mod link_entry;
 mod provenances;
@@ -116,13 +117,12 @@ pub async fn validate_entry(
         // a grant should always be private, so it should always pass
         EntryType::CapTokenGrant => Ok(()),
 
-        // TODO: actually check agent against app specific membrane validation rule
-        // like for instance: validate_agent_id(
-        //                      entry.clone(),
-        //                      validation_data,
-        //                      context,
-        //                    )?
-        EntryType::AgentId => Ok(()),
+        // Runs the AgentId entry callbacks for each zome
+        EntryType::AgentId => await!(agent_entry::validate_agent_entry(
+            entry.clone(),
+            validation_data,
+            context,
+        )),
 
         _ => Err(ValidationError::NotImplemented),
     }

--- a/hdk-rust/src/api/call.rs
+++ b/hdk-rust/src/api/call.rs
@@ -90,6 +90,8 @@ use holochain_wasm_utils::api_serialization::ZomeFnCallArgs;
 ///     genesis: || {
 ///         Ok(())
 ///     }
+///     
+///     agent_validation: || { Ok(()) }
 ///
 ///     functions: [
 ///             sum: {
@@ -202,6 +204,8 @@ use holochain_wasm_utils::api_serialization::ZomeFnCallArgs;
 ///     genesis: || {
 ///         Ok(())
 ///     }
+///     
+///     agent_validation: || { Ok(()) }
 ///
 ///     functions: [
 ///             check_sum: {

--- a/hdk-rust/src/api/send.rs
+++ b/hdk-rust/src/api/send.rs
@@ -91,6 +91,8 @@ use holochain_wasm_utils::api_serialization::send::{SendArgs, SendOptions};
 ///    entries: []
 ///
 ///    genesis: || { Ok(()) }
+///    
+///     agent_validation: || { Ok(()) }
 ///
 ///    receive: |from, payload| {
 ///        // if you want to serialize data as json to pass, use the json! serde macro

--- a/hdk-rust/src/macros.rs
+++ b/hdk-rust/src/macros.rs
@@ -178,6 +178,8 @@ macro_rules! load_string {
 ///     genesis: || {
 ///         Ok(())
 ///     }
+///     
+///     agent_validation: || { Ok(()) }
 ///
 ///     receive: |from, payload| {
 ///       // just return what was received, but modified
@@ -213,6 +215,10 @@ macro_rules! define_zome {
 
         genesis : || {
             $genesis_expr:expr
+        }
+
+        agent_validation: || {
+            $agent_validation_expr:expr
         }
 
         $(
@@ -265,6 +271,34 @@ macro_rules! define_zome {
 
             fn execute() -> Result<(), String> {
                 $genesis_expr
+            }
+
+            match execute() {
+                Ok(_) => hdk::holochain_core_types::error::RibosomeEncodedValue::Success.into(),
+                Err(e) => $crate::holochain_wasm_utils::memory::ribosome::return_code_for_allocation_result(
+                    $crate::global_fns::write_json(
+                        $crate::holochain_wasm_utils::holochain_core_types::json::RawString::from(e)
+                    )
+                ).into(),
+            }
+        }
+
+        #[no_mangle]
+        pub extern "C" fn __hdk_validate_agent_entry(encoded_allocation_of_input: hdk::holochain_core_types::error::RibosomeEncodingBits) -> hdk::holochain_core_types::error::RibosomeEncodingBits {
+            let maybe_allocation = $crate::holochain_wasm_utils::memory::allocation::WasmAllocation::try_from_ribosome_encoding(encoded_allocation_of_input);
+            let allocation = match maybe_allocation {
+                Ok(allocation) => allocation,
+                Err(allocation_error) => return hdk::holochain_core_types::error::RibosomeEncodedValue::from(allocation_error).into(),
+            };
+            let init = $crate::global_fns::init_global_memory(allocation);
+            if init.is_err() {
+                return $crate::holochain_wasm_utils::memory::ribosome::return_code_for_allocation_result(
+                    init
+                ).into();
+            }
+
+            fn execute() -> Result<(), String> {
+                $agent_validation_expr
             }
 
             match execute() {

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -94,13 +94,6 @@ pub extern "C" fn __hdk_get_validation_package_for_entry_type(
 }
 
 #[no_mangle]
-pub extern "C" fn __hdk_validate_agent_entry(
-    _encoded_allocation_of_input: RibosomeEncodingBits,
-) -> RibosomeEncodingBits {
-    RibosomeEncodedValue::Success.into()
-}
-
-#[no_mangle]
 pub extern "C" fn __hdk_validate_app_entry(
     encoded_allocation_of_input: RibosomeEncodingBits,
 ) -> RibosomeEncodingBits {

--- a/hdk-rust/src/meta.rs
+++ b/hdk-rust/src/meta.rs
@@ -94,6 +94,13 @@ pub extern "C" fn __hdk_get_validation_package_for_entry_type(
 }
 
 #[no_mangle]
+pub extern "C" fn __hdk_validate_agent_entry(
+    _encoded_allocation_of_input: RibosomeEncodingBits,
+) -> RibosomeEncodingBits {
+    RibosomeEncodedValue::Success.into()
+}
+
+#[no_mangle]
 pub extern "C" fn __hdk_validate_app_entry(
     encoded_allocation_of_input: RibosomeEncodingBits,
 ) -> RibosomeEncodingBits {

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -562,6 +562,8 @@ define_zome! {
 
     genesis: || { Ok(()) }
 
+    agent_validation: || { Ok(()) }
+
     receive: |_from, payload| {
         {
             let entry = Entry::App(


### PR DESCRIPTION
## PR summary

As genesis is being largely replaced by the init function we need another way to enforce membranes. As per @zippy 's suggestion we have decided to do this by adding a validation callback on the second chain entry, the Agent system entry.

This validation will be run by all agents every time a new agent joins the network this allowing them to maintain a membrane.

Currently this callback does not take any parameters. Need to discuss what it should take. Also there are no comprehensive tests in place at this stage
