### PR TITLE
Trace signals conditionally exposed, take 2

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds PROPERTIES static to the HDK which contains a JsonString with the DNA properties object. Also adds a body to the `hdk::properties` stub which allows retrieving fields from the properties object as JsonString. [#1418](https://github.com/holochain/holochain-rust/pull/1418)
 - Conductor now persists its config in the config root (e.g. `home/peter/.config/holochain/conductor` rather than `~/.holochain`) [#1386](https://github.com/holochain/holochain-rust/pull/1386)
 - Default N3H mode as set when spawned by the conductor got set to "REAL". [#1282](https://github.com/holochain/holochain-rust/pull/1282)
+- Internal signals renamed to Trace signals, with ability to opt in or out through `emit_trace_signals` conductor config [#1428](https://github.com/holochain/holochain-rust/pull/1428)
 
 ### Deprecated
 

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -193,7 +193,7 @@ scenario1.runTape('create_tagged_post and retrieve all tags', async (t, { alice 
     tag: "work"
   })
   t.ok(result1.Ok)
-  
+
   const result2 = await alice.callSync("blog", "create_tagged_post", {
     content: "Fly tying, is it for you?",
     tag: "fishing"
@@ -213,7 +213,7 @@ scenario1.runTape('create_tagged_post and retrieve exact tag match', async (t, {
     tag: "work"
   })
   t.ok(result1.Ok)
-  
+
   const result2 = await alice.callSync("blog", "create_tagged_post", {
     content: "Fly tying, is it for you?",
     tag: "fishing"
@@ -233,7 +233,7 @@ scenario1.runTape('tagged link validation', async (t, { alice }) => {
     tag: "muffins"
   })
   t.ok(result1.Err)  // the linking of the entry should fail because `muffins` is the banned tag
-  
+
   const getResult = await alice.callSync("blog", "my_posts", {})
   t.equal(getResult.Ok.links.length, 0)
 })

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -595,6 +595,10 @@ pub mod tests {
         Arc::new(loader)
     }
 
+    pub fn general() -> String {
+        "expose_trace_signals = false".to_string()
+    }
+
     pub fn empty_bridges() -> String {
         "bridges = []".to_string()
     }
@@ -617,6 +621,7 @@ pub mod tests {
 
     pub fn header_block(test_name: &str) -> String {
         let mut toml = empty_bridges();
+        toml = add_line(toml, general());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_bundles());
         toml = add_line(toml, empty_ui_interfaces());
@@ -1111,6 +1116,7 @@ type = 'websocket'"#,
 
         let mut toml = empty_bridges();
         toml = add_line(toml, "dnas = []".to_string());
+        toml = add_line(toml, general());
         toml = add_line(toml, "instances = []".to_string());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_bundles());
@@ -1234,6 +1240,7 @@ type = 'http'"#,
             .expect("Could not read temp config file");
 
         let mut toml = empty_bridges();
+        toml = add_line(toml, general());
         toml = add_line(toml, "interfaces = []".to_string());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_bundles());
@@ -1534,7 +1541,8 @@ type = 'websocket'"#,
         file.read_to_string(&mut config_contents)
             .expect("Could not read temp config file");
 
-        let mut toml = persistence_dir(test_name);
+        let mut toml = general();
+        toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_bundles());
         toml = add_line(toml, empty_ui_interfaces());
 

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -201,12 +201,18 @@ impl Conductor {
                         signal_tx.clone().map(|s| s.send(signal.clone()));
                         let broadcasters = broadcasters.read().unwrap();
                         let interfaces_with_instance: Vec<&InterfaceConfiguration> = match signal {
-                            // Send internal signals only to admin interfaces:
-                            Signal::Trace(_) => config
-                                .interfaces
-                                .iter()
-                                .filter(|interface_config| interface_config.admin)
-                                .collect(),
+                            // Send internal signals only to admin interfaces, if expose_trace_signals is set:
+                            Signal::Trace(_) => {
+                                if config.expose_trace_signals {
+                                    config
+                                        .interfaces
+                                        .iter()
+                                        .filter(|interface_config| interface_config.admin)
+                                        .collect()
+                                } else {
+                                    Vec::new()
+                                }
+                            }
 
                             // Pass through user-defined  signals to the according interfaces
                             // in which the source instance is exposed:

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -202,7 +202,7 @@ impl Conductor {
                         let broadcasters = broadcasters.read().unwrap();
                         let interfaces_with_instance: Vec<&InterfaceConfiguration> = match signal {
                             // Send internal signals only to admin interfaces:
-                            Signal::Internal(_) => config
+                            Signal::Trace(_) => config
                                 .interfaces
                                 .iter()
                                 .filter(|interface_config| interface_config.admin)
@@ -1549,11 +1549,11 @@ pub mod tests {
 
         assert!(received_signals.len() >= 3);
         assert!(received_signals[0]
-            .starts_with("{\"signal\":{\"Internal\":\"SignalZomeFunctionCall(ZomeFnCall {"));
+            .starts_with("{\"signal\":{\"Trace\":\"SignalZomeFunctionCall(ZomeFnCall {"));
         assert!(received_signals[1]
-            .starts_with("{\"signal\":{\"Internal\":\"SignalZomeFunctionCall(ZomeFnCall {"));
+            .starts_with("{\"signal\":{\"Trace\":\"SignalZomeFunctionCall(ZomeFnCall {"));
         assert!(received_signals[2].starts_with(
-            "{\"signal\":{\"Internal\":\"ReturnZomeFunctionResult(ExecuteZomeFnResponse {"
+            "{\"signal\":{\"Trace\":\"ReturnZomeFunctionResult(ExecuteZomeFnResponse {"
         ));
     }
 }

--- a/conductor_api/src/conductor/ui_admin.rs
+++ b/conductor_api/src/conductor/ui_admin.rs
@@ -202,6 +202,7 @@ pub mod tests {
             .expect("Could not read temp config file");
 
         let mut toml = empty_bridges();
+        toml = add_line(toml, general());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_interfaces());
         toml = add_block(toml, agent1());
@@ -250,6 +251,7 @@ root_dir = '.'"#,
             .join("test-bundle-id");
 
         let mut toml = empty_bridges();
+        toml = add_line(toml, general());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_interfaces());
         toml = add_block(toml, agent1());
@@ -356,6 +358,7 @@ id = 'test-bundle-id'"#,
             .expect("Could not read temp config file");
 
         let mut toml = empty_bridges();
+        toml = add_line(toml, general());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_block(toml, agent1());
         toml = add_block(toml, agent2());
@@ -426,6 +429,7 @@ port = 4000"#,
             .expect("Could not read temp config file");
 
         let mut toml = empty_bridges();
+        toml = add_line(toml, general());
         toml = add_line(toml, persistence_dir(test_name));
         toml = add_line(toml, empty_ui_interfaces());
         toml = add_block(toml, agent1());

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -77,6 +77,10 @@ pub struct Configuration {
     /// Optional DPKI configuration if conductor is using a DPKI app to initalize and manage
     /// keys for new instances
     pub dpki: Option<DpkiConfiguration>,
+
+    /// Send Trace signals through interfaces along with other signals
+    #[serde(default)]
+    pub expose_trace_signals: bool,
 }
 
 pub fn default_persistence_dir() -> PathBuf {

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -726,12 +726,12 @@ mod tests {
             let msg_publish = signal_rx
                 .recv_timeout(Duration::from_millis(timeout))
                 .expect("no more signals to receive (outer)");
-            if let Signal::Internal(Action::Publish(address)) = msg_publish {
+            if let Signal::Trace(Action::Publish(address)) = msg_publish {
                 loop {
                     let msg_hold = signal_rx
                         .recv_timeout(Duration::from_millis(timeout))
                         .expect("no more signals to receive (inner)");
-                    if let Signal::Internal(Action::Hold(entry)) = msg_hold {
+                    if let Signal::Trace(Action::Hold(entry)) = msg_hold {
                         assert_eq!(address, entry.address());
                         break 'outer;
                     }

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -229,12 +229,12 @@ impl Instance {
     }
 
     /// Given an `Action` that is being processed, decide whether or not it should be
-    /// emitted as a `Signal::Internal`, and if so, send it
+    /// emitted as a `Signal::Trace`, and if so, send it
     fn maybe_emit_action_signal(&self, context: &Arc<Context>, action: ActionWrapper) {
         if let Some(tx) = context.signal_tx() {
             // @TODO: if needed for performance, could add a filter predicate here
             // to prevent emitting too many unneeded signals
-            let signal = Signal::Internal(action);
+            let signal = Signal::Trace(action);
             tx.send(signal).unwrap_or_else(|e| {
                 context.log(format!(
                     "warn/reduce: Signal channel is closed! No signals can be sent ({:?}).",

--- a/core/src/signal.rs
+++ b/core/src/signal.rs
@@ -7,7 +7,7 @@ use std::thread;
 #[derive(Clone, Debug, Serialize, DefaultJson)]
 #[serde(tag = "signal_type")]
 pub enum Signal {
-    Internal(ActionWrapper),
+    Trace(ActionWrapper),
     User(JsonString),
 }
 

--- a/hdk-rust/wasm-test/src/lib.rs
+++ b/hdk-rust/wasm-test/src/lib.rs
@@ -12,13 +12,15 @@ extern crate holochain_core_types_derive;
 
 use boolinator::Boolinator;
 use hdk::{
+    api::G_MEM_STACK,
     error::{ZomeApiError, ZomeApiResult},
+    global_fns::init_global_memory,
 };
 use holochain_wasm_utils::{
     api_serialization::{
         get_entry::{GetEntryOptions, GetEntryResult},
         get_links::GetLinksResult,
-        query::{ QueryArgsNames, QueryArgsOptions, QueryResult },
+        query::{QueryArgsNames, QueryArgsOptions, QueryResult},
     },
     holochain_core_types::{
         cas::content::{Address, AddressableContent},
@@ -27,24 +29,18 @@ use holochain_wasm_utils::{
             entry_type::{AppEntryType, EntryType},
             AppEntryValue, Entry,
         },
-        error::{
-            HolochainError,
-            RibosomeErrorCode,
-        },
-        json::{JsonString,RawString},
+        error::{HolochainError, RibosomeEncodedValue, RibosomeEncodingBits, RibosomeErrorCode},
+        json::{JsonString, RawString},
+        validation::{EntryValidationData, LinkValidationData},
+    },
+    memory::{
+        allocation::WasmAllocation,
+        ribosome::{load_ribosome_encoded_json, return_code_for_allocation_result},
     },
 };
-use holochain_wasm_utils::holochain_core_types::{validation::{LinkValidationData,EntryValidationData},error::RibosomeEncodingBits};
-use holochain_wasm_utils::memory::ribosome::load_ribosome_encoded_json;
-use holochain_wasm_utils::memory::ribosome::return_code_for_allocation_result;
-use holochain_wasm_utils::memory::allocation::WasmAllocation;
-use hdk::global_fns::init_global_memory;
-use holochain_wasm_utils::holochain_core_types::error::RibosomeEncodedValue;
-use std::convert::TryFrom;
-use std::time::Duration;
-use hdk::api::G_MEM_STACK;
+use std::{convert::TryFrom, time::Duration};
 
-#[derive(Serialize, Deserialize, Debug, DefaultJson,Clone)]
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
 struct TestEntryType {
     stuff: String,
 }
@@ -65,8 +61,9 @@ pub extern "C" fn handle_check_global() -> Address {
 }
 
 #[no_mangle]
-pub extern "C" fn check_commit_entry(encoded_allocation_of_input: RibosomeEncodingBits) -> RibosomeEncodingBits {
-
+pub extern "C" fn check_commit_entry(
+    encoded_allocation_of_input: RibosomeEncodingBits,
+) -> RibosomeEncodingBits {
     let allocation = match WasmAllocation::try_from_ribosome_encoding(encoded_allocation_of_input) {
         Ok(allocation) => allocation,
         Err(allocation_error) => return allocation_error.as_ribosome_encoding(),
@@ -82,8 +79,9 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: RibosomeEncodi
         Ok(entry) => entry,
         Err(hc_err) => {
             hdk::debug(format!("ERROR: {:?}", hc_err.to_string())).ok();
-            return RibosomeEncodedValue::Failure(RibosomeErrorCode::ArgumentDeserializationFailed).into();
-        },
+            return RibosomeEncodedValue::Failure(RibosomeErrorCode::ArgumentDeserializationFailed)
+                .into();
+        }
     };
 
     hdk::debug(format!("Entry: {:?}", entry)).ok();
@@ -100,10 +98,7 @@ pub extern "C" fn check_commit_entry(encoded_allocation_of_input: RibosomeEncodi
         None => return RibosomeEncodedValue::Failure(RibosomeErrorCode::OutOfMemory).into(),
     };
 
-    return_code_for_allocation_result(
-        wasm_stack.write_json(res_obj)
-    ).into()
-
+    return_code_for_allocation_result(wasm_stack.write_json(res_obj)).into()
 }
 
 fn handle_check_commit_entry_macro(entry: Entry) -> ZomeApiResult<Address> {
@@ -169,7 +164,6 @@ fn handle_remove_link() -> ZomeApiResult<()> {
     hdk::commit_entry(&entry_2)?;
     hdk::link_entries(&entry_1.address(), &entry_2.address(), "test", "test-tag")?;
     hdk::remove_link(&entry_1.address(), &entry_2.address(), "test", "test-tag")
-
 }
 
 /// Commit 3 entries
@@ -302,17 +296,27 @@ fn handle_check_query() -> ZomeApiResult<Vec<Address>> {
     }
 
     // Confirm same results via hdk::query_result
-    let addresses = match hdk::query_result(vec!["[%]*","testEntryType"].into(),
-                                            QueryArgsOptions::default()).unwrap() {
+    let addresses = match hdk::query_result(
+        vec!["[%]*", "testEntryType"].into(),
+        QueryArgsOptions::default(),
+    )
+    .unwrap()
+    {
         QueryResult::Addresses(av) => av,
         _ => return err("Unexpected hdk::query_result"),
     };
     if !addresses.len() == 5 {
         return err("System + testEntryType Addresses enum not length 5");
     };
-    let headers = match hdk::query_result(vec!["[%]*","testEntryType"].into(),
-                                          QueryArgsOptions{ headers: true,
-                                                            ..Default::default()}).unwrap() {
+    let headers = match hdk::query_result(
+        vec!["[%]*", "testEntryType"].into(),
+        QueryArgsOptions {
+            headers: true,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    {
         QueryResult::Headers(hv) => hv,
         _ => return err("Unexpected hdk::query_result"),
     };
@@ -420,7 +424,7 @@ fn handle_link_validation(stuff1: String, stuff2: String) -> JsonString {
         &entry1.address(),
         &entry2.address(),
         "longer",
-        "test-tag-longer"
+        "test-tag-longer",
     ))
 }
 

--- a/nodejs_conductor/native/src/config.rs
+++ b/nodejs_conductor/native/src/config.rs
@@ -135,6 +135,7 @@ fn make_config(
         bridges: bridges,
         dpki: dpki,
         logger,
+        expose_trace_signals: true,
         ..Default::default()
     };
     config

--- a/nodejs_conductor/native/src/js_test_conductor.rs
+++ b/nodejs_conductor/native/src/js_test_conductor.rs
@@ -11,19 +11,15 @@ use std::{
 
 use holochain_conductor_api::{
     conductor::Conductor as RustConductor,
-    key_loaders::test_keystore_loader,
     config::{load_configuration, Configuration},
+    key_loaders::test_keystore_loader,
 };
 use holochain_core::{
     action::Action,
-    signal::{signal_channel, Signal, SignalReceiver},
     nucleus::actions::call_zome_function::make_cap_request_for_call,
+    signal::{signal_channel, Signal, SignalReceiver},
 };
-use holochain_core_types::{
-    cas::content::AddressableContent,
-    entry::Entry,
-    json::JsonString,
-};
+use holochain_core_types::{cas::content::AddressableContent, entry::Entry, json::JsonString};
 use holochain_node_test_waiter::waiter::{CallBlockingTask, ControlMsg, MainBackgroundTask};
 
 /// Block until Hold(agent.public_address) is seen for each agent in the conductor.
@@ -36,7 +32,7 @@ fn await_held_agent_ids(config: Configuration, signal_rx: &SignalReceiver) {
         .map(|c| c.public_address.to_string())
         .collect();
     loop {
-        if let Ok(Signal::Internal(aw)) = signal_rx.recv_timeout(Duration::from_millis(10)) {
+        if let Ok(Signal::Trace(aw)) = signal_rx.recv_timeout(Duration::from_millis(10)) {
             let action = aw.action();
             if let Action::Hold(EntryWithHeader {
                 entry: Entry::AgentId(id),

--- a/nodejs_waiter/src/waiter.rs
+++ b/nodejs_waiter/src/waiter.rs
@@ -158,7 +158,7 @@ impl Waiter {
     pub fn process_signal(&mut self, sig: Signal) {
         let num_instances = self.num_instances;
         match sig {
-            Signal::Internal(ref aw) => {
+            Signal::Trace(ref aw) => {
                 let aw = aw.clone();
                 match (self.current_checker(), aw.action().clone()) {
                     // Pair every `SignalZomeFunctionCall` with one `ReturnZomeFunctionResult`
@@ -377,7 +377,7 @@ mod tests {
     use std::sync::mpsc::sync_channel;
 
     fn sig(a: Action) -> Signal {
-        Signal::Internal(ActionWrapper::new(a))
+        Signal::Trace(ActionWrapper::new(a))
     }
 
     fn mk_entry(ty: &'static str, content: &'static str) -> Entry {

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -14,8 +14,7 @@ use holochain_core::{
     logger::{test_logger, TestLogger},
     nucleus::actions::call_zome_function::make_cap_request_for_call,
     signal::Signal,
-}
-;
+};
 use holochain_core_types::{
     cas::content::AddressableContent,
     dna::{
@@ -34,9 +33,9 @@ use holochain_net::p2p_config::P2pConfig;
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap},
     fs::File,
-    path::PathBuf,
     hash::{Hash, Hasher},
     io::prelude::*,
+    path::PathBuf,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -116,7 +115,6 @@ pub fn create_test_dna_with_wasm(zome_name: &str, wasm: Vec<u8>) -> Dna {
         EntryType::App(AppEntryType::from("testEntryTypeC")),
         test_entry_c_def,
     );
-
 
     let mut zome = Zome::new(
         "some zome description",
@@ -290,7 +288,7 @@ where
             .recv_timeout(Duration::from_millis(timeout))
             .map_err(|e| e.to_string())?
         {
-            Signal::Internal(aw) => {
+            Signal::Trace(aw) => {
                 let action = aw.action().clone();
                 if f(&action) {
                     return Ok(action);


### PR DESCRIPTION
## PR summary

Redo of #1378 

* Rename `Signal::Internal` to `Signal::Trace`
* Add `expose_trace_signals` bool to `Configuration`, if false then Trace signals will never be emitted over any interface
* Set `expose_trace_signals` to true for nodejs conductor config

**The first commit is noisy, it's just the sweeping rename to `Trace`. Look at the second commit for the actual filtering logic**

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
