### PR TITLE
Release 0.0.17-alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.17-alpha2] - 2019-05-27
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.0.17-alpha1] - 2019-05-27
 
 ### Added

--- a/app_spec/zomes/blog/code/Cargo.toml
+++ b/app_spec/zomes/blog/code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/app_spec/zomes/summer/code/Cargo.toml
+++ b/app_spec/zomes/summer/code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "benchmarks"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/cas_implementations/Cargo.toml
+++ b/cas_implementations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cas_implementations"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/cli/README.md
+++ b/cli/README.md
@@ -39,7 +39,7 @@ $ cargo install hc --force --git https://github.com/holochain/holochain-rust.git
 
 To install the latest released version of the Holochain conductor, run the following command in a terminal
 ```shell
-$ cargo install hc --force --git https://github.com/holochain/holochain-rust.git --tag v0.0.17-alpha1
+$ cargo install hc --force --git https://github.com/holochain/holochain-rust.git --tag v0.0.17-alpha2
 ```
 
 The command line tools are now available in your command line using the `hc` command.

--- a/cli/src/cli/js-tests-scaffold/package.json
+++ b/cli/src/cli/js-tests-scaffold/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@holochain/holochain-nodejs": "0.4.16-alpha1",
+    "@holochain/holochain-nodejs": "0.4.16-alpha2",
     "json3": "*",
     "tape": "^4.9.1"
   }

--- a/cli/src/cli/scaffold/rust.rs
+++ b/cli/src/cli/scaffold/rust.rs
@@ -34,7 +34,7 @@ fn generate_cargo_toml(name: &str, contents: &str) -> DefaultResult<String> {
     let version_default = if maybe_version.is_some() {
         maybe_version.unwrap()
     } else {
-        String::from("tag = \"v0.0.17-alpha1\"")
+        String::from("tag = \"v0.0.17-alpha2\"")
     };
     let maybe_package = config.get("package");
 

--- a/cli/src/cli/scaffold/rust/lib.rs
+++ b/cli/src/cli/scaffold/rust/lib.rs
@@ -21,7 +21,7 @@ use hdk::holochain_core_types::{
     validation::EntryValidationData
 };
 
-// see https://developer.holochain.org/api/0.0.17-alpha1/hdk/ for info on using the hdk library
+// see https://developer.holochain.org/api/0.0.17-alpha2/hdk/ for info on using the hdk library
 
 // This is a sample zome that defines an entry type "MyEntry" that can be committed to the
 // agent's chain via the exposed function create_my_entry

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_common"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/conductor/README.md
+++ b/conductor/README.md
@@ -29,7 +29,7 @@ $ cargo install holochain --force --git https://github.com/holochain/holochain-r
 
 To install the latest released version of the Holochain conductor, run the following command in a terminal
 ```shell
-$ cargo install holochain --force --git https://github.com/holochain/holochain-rust.git --tag v0.0.17-alpha1
+$ cargo install holochain --force --git https://github.com/holochain/holochain-rust.git --tag v0.0.17-alpha2
 ```
 
 The Conductor should then be available from your command line using the `holochain` command.

--- a/conductor_api/Cargo.toml
+++ b/conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/conductor_api/test-bridge-caller/Cargo.toml
+++ b/conductor_api/test-bridge-caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-bridge-caller"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/conductor_api/wasm-test/Cargo.toml
+++ b/conductor_api/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_api_wasm"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_core"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/core/src/nucleus/actions/wasm-test/Cargo.toml
+++ b/core/src/nucleus/actions/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nucleus-actions-tests"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/core_api_c_binding/Cargo.toml
+++ b/core_api_c_binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_core_api_c_binding"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_core_types"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 build = "build.rs"
 

--- a/core_types_derive/Cargo.toml
+++ b/core_types_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_core_types_derive"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/dna_c_binding/Cargo.toml
+++ b/dna_c_binding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_dna_c_binding"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/dpki/Cargo.toml
+++ b/dpki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_dpki"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/hdk-rust/Cargo.toml
+++ b/hdk-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/hdk-rust/wasm-test/Cargo.toml
+++ b/hdk-rust/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-globals"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]

--- a/holonix/release/config.nix
+++ b/holonix/release/config.nix
@@ -3,22 +3,22 @@ let
 
     # the commit from `develop` branch that the release is targetting
     # the final release(s) will differ from this due to changelog updates etc.
-    commit = "c065bbdbc4af29ac7f837efb1531a6011b60f86d";
+    commit = "ae0c88e3c183eb55220009cfb75056c415ac852d";
 
     # current documentation for the release process
     process-url = "https://hackmd.io/oWIM8H4UQQSdJMaAW4uaMg";
 
     core = {
      version = {
-      previous = "0.0.16-alpha1";
-      current = "0.0.17-alpha1";
+      previous = "0.0.17-alpha1";
+      current = "0.0.17-alpha2";
      };
     };
 
     node-conductor = {
      version = {
-      previous = "0.4.15-alpha1";
-      current = "0.4.16-alpha1";
+      previous = "0.4.16-alpha1";
+      current = "0.4.16-alpha2";
      };
     };
 

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_net"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/nodejs_conductor/native/Cargo.toml
+++ b/nodejs_conductor/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain-node"
-version = "0.4.16-alpha1"
+version = "0.4.16-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 license = "MIT"
 build = "build.rs"

--- a/nodejs_conductor/package.json
+++ b/nodejs_conductor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/holochain-nodejs",
-  "version": "0.4.16-alpha1",
+  "version": "0.4.16-alpha2",
   "description": "Nodejs Holochain Conductor primarily for test execution",
   "repository": {
     "type": "git",

--- a/nodejs_waiter/Cargo.toml
+++ b/nodejs_waiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_node_test_waiter"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/sodium/Cargo.toml
+++ b/sodium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sodium"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["neonphog <neonphog@gmail.com>","zo-el<zo@el.org>"]
 edition = "2018"
 

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_bin"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_utils"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/wasm_utils/Cargo.toml
+++ b/wasm_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_utils"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/wasm_utils/wasm-test/integration-test/Cargo.toml
+++ b/wasm_utils/wasm-test/integration-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-integration-test"
-version = "0.0.17-alpha1"
+version = "0.0.17-alpha2"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]


### PR DESCRIPTION
current release process: https://hackmd.io/oWIM8H4UQQSdJMaAW4uaMg

## Preparation

First checkout `develop` and `git pull` to ensure you are up to date locally.
Then run `nix-shell --run hc-release-prepare`

- [x] develop is green
- [x] correct dev pulse commit + version + url hash
- [x] correct core version
- [x] correct node conductor
- [x] correct release process url

## PR into master

- [ ] reviewed and updated CHANGELOG
- [ ] release PR merged into `master`

## Build and deploy release artifacts

- [ ] release cut from `master` with `hc-release-deploy`
- [ ] core release tag + linux/mac/windows artifacts on github
  - travis build: {{ build url }}
  - artifacts: https://github.com/holochain/holochain-rust/releases/tag/v0.0.17-alpha2
- [ ] node release tag + linux/mac/windows artifacts on github
  - travis build: {{ build url }}
  - artifacts: https://github.com/holochain/holochain-rust/releases/tag/holochain-nodejs-v0.4.16-alpha2
- [ ] all release artifacts found by `hc-release-github-check-artifacts`
- [ ] npmjs deploy with `hc-release-npm-deploy` then `hc-release-npm-check-version`
- [ ] `unknown` release assets renamed to `ubuntu`

## PR into develop

- [ ] `hc-release-github-merge-back`
- [ ] `develop` PR changelog cleaned up
  - [ ] no new items from `develop` under recently released changelog header
- [ ] merge `develop` PR

## Finalise

- [ ] dev pulse is live on medium
- [ ] `hc-release-pulse-sync`