### PR TITLE
Add some diagnostic context in instances of BadCallError

### DIFF
--- a/core/src/nucleus/ribosome/runtime.rs
+++ b/core/src/nucleus/ribosome/runtime.rs
@@ -44,10 +44,10 @@ pub enum WasmCallData {
 }
 
 #[derive(Debug)]
-struct BadCallError();
+struct BadCallError(String);
 impl fmt::Display for BadCallError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Bad calling context")
+        write!(f, "Bad calling context: {}", self.0)
     }
 }
 
@@ -68,6 +68,22 @@ impl WasmCallData {
             WasmCallData::CallbackCall(data) => data.call.fn_name.clone(),
             WasmCallData::DirectCall(name, _) => name.to_string(),
         }
+    }
+}
+
+impl fmt::Display for WasmCallData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "fn_name: {} ({})", self.fn_name(), match self {
+            WasmCallData::ZomeCall(_data) => "ZomeCall",
+            WasmCallData::CallbackCall(_data) => "CallbackCall",
+            WasmCallData::DirectCall(_name, _) => "DirectCall",
+        })
+    }
+}
+
+impl fmt::Debug for WasmCallData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "WasmCallData({})", self)
     }
 }
 
@@ -94,14 +110,14 @@ impl Runtime {
     pub fn zome_call_data(&self) -> Result<ZomeCallData, Trap> {
         match &self.data {
             WasmCallData::ZomeCall(ref data) => Ok(data.clone()),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError())))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("zome_call_data: {:?}", &self.data)))))),
         }
     }
 
     pub fn callback_call_data(&self) -> Result<CallbackCallData, Trap> {
         match &self.data {
             WasmCallData::CallbackCall(ref data) => Ok(data.clone()),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError())))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("callback_call_data: {:?}", &self.data)))))),
         }
     }
 
@@ -119,7 +135,7 @@ impl Runtime {
                 fn_name: data.call.fn_name.clone(),
                 parameters: data.call.parameters.clone(),
             }),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError())))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("call_data: {:?}", &self.data)))))),
         }
     }
 
@@ -127,7 +143,7 @@ impl Runtime {
         match &self.data {
             WasmCallData::ZomeCall(ref data) => Ok(data.context.clone()),
             WasmCallData::CallbackCall(ref data) => Ok(data.context.clone()),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError())))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("context data: {:?}", &self.data)))))),
         }
     }
 

--- a/core/src/nucleus/ribosome/runtime.rs
+++ b/core/src/nucleus/ribosome/runtime.rs
@@ -73,11 +73,16 @@ impl WasmCallData {
 
 impl fmt::Display for WasmCallData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "fn_name: {} ({})", self.fn_name(), match self {
-            WasmCallData::ZomeCall(_data) => "ZomeCall",
-            WasmCallData::CallbackCall(_data) => "CallbackCall",
-            WasmCallData::DirectCall(_name, _) => "DirectCall",
-        })
+        write!(
+            f,
+            "fn_name: {} ({})",
+            self.fn_name(),
+            match self {
+                WasmCallData::ZomeCall(_data) => "ZomeCall",
+                WasmCallData::CallbackCall(_data) => "CallbackCall",
+                WasmCallData::DirectCall(_name, _) => "DirectCall",
+            }
+        )
     }
 }
 
@@ -110,14 +115,20 @@ impl Runtime {
     pub fn zome_call_data(&self) -> Result<ZomeCallData, Trap> {
         match &self.data {
             WasmCallData::ZomeCall(ref data) => Ok(data.clone()),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("zome_call_data: {:?}", &self.data)))))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!(
+                "zome_call_data: {:?}",
+                &self.data
+            )))))),
         }
     }
 
     pub fn callback_call_data(&self) -> Result<CallbackCallData, Trap> {
         match &self.data {
             WasmCallData::CallbackCall(ref data) => Ok(data.clone()),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("callback_call_data: {:?}", &self.data)))))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!(
+                "callback_call_data: {:?}",
+                &self.data
+            )))))),
         }
     }
 
@@ -135,7 +146,10 @@ impl Runtime {
                 fn_name: data.call.fn_name.clone(),
                 parameters: data.call.parameters.clone(),
             }),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("call_data: {:?}", &self.data)))))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!(
+                "call_data: {:?}",
+                &self.data
+            )))))),
         }
     }
 
@@ -143,7 +157,10 @@ impl Runtime {
         match &self.data {
             WasmCallData::ZomeCall(ref data) => Ok(data.context.clone()),
             WasmCallData::CallbackCall(ref data) => Ok(data.context.clone()),
-            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!("context data: {:?}", &self.data)))))),
+            _ => Err(Trap::new(TrapKind::Host(Box::new(BadCallError(format!(
+                "context data: {:?}",
+                &self.data
+            )))))),
         }
     }
 


### PR DESCRIPTION
## PR summary

Just provide some context to help diagnose BadCallError failures.  

In general, if an ...Error can be produced from a variety of locations, some kind of diagnostic context is required -- otherwise, we only have the fact that an ...Error occurred, but no idea of *why* it occurred, so we can correct the issue.

This (probably poorly implemented) change gives us at least an idea of what function was being called, and in which context the BadCallError was fired.  It results in errors like this being returned from the failing Zome calls:

```
{"Err":{"Internal":"{\"kind\":{\"ErrorGeneric\":\"WASM invocation failed: Trap: Trap { kind: Host(BadCallError(\\\"zome_call_data: WasmCallData(fn_name: __hdk_validate_app_entry (CallbackCall))\\\")) }\"},\"file\":\"/Users/perry/src/holochain-rust/core/src/nucleus/ribosome/runtime.rs\",\"line\\
":\"208\"}"}}
```

Still not very helpful in diagnosing what's going wrong that is causing the Zome call to fail, but its a start...

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
