### PR TITLE
(tiny) Fix bug in get_links_and_load

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -366,6 +366,30 @@ scenario2.runTape('delete_post', async (t, { alice, bob }) => {
   t.equal(bob_agent_posts_expect_empty.Ok.links.length, 0);
 })
 
+scenario1.runTape('get_links_and_load with a delete_post', async (t, { alice }) => {
+
+  //create post
+  const alice_create_post_result = await alice.callSync("blog", "create_post",
+    { "content": "Posty", "in_reply_to": "" }
+  )
+
+  const alice_get_post_result1 = await alice.callSync("blog", "my_posts_with_load",
+    { "tag": null }
+  )
+
+  t.ok(alice_get_post_result1.Ok)
+  t.equal(alice_get_post_result1.Ok.length, 1);
+
+  //remove link by alicce
+  await alice.callSync("blog", "delete_post", { "content": "Posty", "in_reply_to": "" })
+
+  const alice_get_post_result2 = await alice.callSync("blog", "my_posts_with_load",
+    { "tag": null }
+  )
+  t.ok(alice_get_post_result2.Ok)
+  t.equal(alice_get_post_result2.Ok.length, 0);
+})
+
 scenario2.runTape('delete_entry_post', async (t, { alice, bob }) => {
   const content = "Hello Holo world 321"
   const in_reply_to = null

--- a/app_spec/zomes/blog/code/src/blog.rs
+++ b/app_spec/zomes/blog/code/src/blog.rs
@@ -403,6 +403,10 @@ pub fn handle_my_posts(tag: Option<String>) -> ZomeApiResult<GetLinksResult> {
     hdk::get_links(&AGENT_ADDRESS, Some("authored_posts".into()), tag)
 }
 
+pub fn handle_my_posts_with_load(tag: Option<String>) -> ZomeApiResult<Vec<Post>> {
+    hdk::utils::get_links_and_load_type(&AGENT_ADDRESS, Some("authored_posts".into()), tag)
+}
+
 pub fn handle_my_memos() -> ZomeApiResult<Vec<Address>> {
     hdk::query("memo".into(), 0, 0)
 }

--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -200,6 +200,12 @@ define_zome! {
             handler: blog::handle_my_posts
         }
 
+        my_posts_with_load: {
+            inputs: |tag: Option<String>|,
+            outputs: |post_hashes: ZomeApiResult<Vec<post::Post>>|,
+            handler: blog::handle_my_posts_with_load
+        }
+
         my_memos: {
             inputs: | |,
             outputs: |memo_hashes: ZomeApiResult<Vec<Address>>|,
@@ -251,6 +257,6 @@ define_zome! {
     ]
 
     traits: {
-        hc_public [show_env, get_test_properties, check_sum, ping, get_sources, post_address, create_post, create_tagged_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged]
+        hc_public [show_env, get_test_properties, check_sum, ping, get_sources, post_address, create_post, create_tagged_post, create_post_countersigned, delete_post, delete_entry_post, update_post, posts_by_agent, get_post, my_posts, my_posts_with_load, memo_address, get_memo, my_memos, create_memo, my_posts_as_committed, my_posts_immediate_timeout, recommend_post, my_recommended_posts,get_initial_post, get_history_post, get_post_with_options, get_post_with_options_latest, authored_posts_with_sources, create_post_with_agent, request_post_grant, get_grants, commit_post_claim, create_post_with_claim, get_post_bridged]
     }
 }

--- a/app_spec_proc_macro/zomes/blog/code/src/blog.rs
+++ b/app_spec_proc_macro/zomes/blog/code/src/blog.rs
@@ -403,6 +403,10 @@ pub fn handle_my_posts(tag: Option<String>) -> ZomeApiResult<GetLinksResult> {
     hdk::get_links(&AGENT_ADDRESS, Some("authored_posts".into()), tag)
 }
 
+pub fn handle_my_posts_with_load(tag: Option<String>) -> ZomeApiResult<Vec<Post>> {
+    hdk::utils::get_links_and_load_type(&AGENT_ADDRESS, Some("authored_posts".into()), tag)
+}
+
 pub fn handle_my_memos() -> ZomeApiResult<Vec<Address>> {
     hdk::query("memo".into(), 0, 0)
 }

--- a/app_spec_proc_macro/zomes/blog/code/src/lib.rs
+++ b/app_spec_proc_macro/zomes/blog/code/src/lib.rs
@@ -161,6 +161,11 @@ pub mod blog {
     }
 
     #[zome_fn("hc_public")]
+    pub fn my_posts_with_load(tag: Option<String>) -> ZomeApiResult<Vec<post::Post>> {
+        blog::handle_my_posts_with_load(tag)
+    }
+
+    #[zome_fn("hc_public")]
     pub fn my_memos() -> ZomeApiResult<Vec<Address>> {
         blog::handle_my_memos()
     }

--- a/hdk-rust/src/api/get_links.rs
+++ b/hdk-rust/src/api/get_links.rs
@@ -3,7 +3,7 @@ use api::get_entry::get_entry_result;
 use error::{ZomeApiError, ZomeApiResult};
 use holochain_core_types::{cas::content::Address, entry::Entry, hash::HashString};
 use holochain_wasm_utils::api_serialization::{
-    get_entry::{GetEntryOptions, GetEntryResult, GetEntryResultType},
+    get_entry::{GetEntryOptions, GetEntryResult, GetEntryResultItem, GetEntryResultType},
     get_links::{GetLinksArgs, GetLinksOptions, GetLinksResult},
 };
 
@@ -110,8 +110,9 @@ pub fn get_links_and_load(
     .map(|get_result| {
         let get_type = get_result?.result;
         match get_type {
-            GetEntryResultType::Single(elem) => Ok(elem.entry.unwrap().to_owned()),
-            GetEntryResultType::All(_) => Err(ZomeApiError::Internal("Invalid response. get_links_result returned all entries when latest was requested".to_string()))
+            GetEntryResultType::Single(GetEntryResultItem{entry: Some(entry), ..}) => Ok(entry),
+            GetEntryResultType::Single(GetEntryResultItem{entry: None, ..}) => Err(ZomeApiError::Internal("Entry is None so most likely has been marked as deleted".to_string())),
+            GetEntryResultType::All(_) => Err(ZomeApiError::Internal("Invalid response. get_links_result returned all entries when latest was requested".to_string())),
         }
     })
     .collect();


### PR DESCRIPTION
## PR summary

Calling get_links_and_load when one of the linked entries had been deleted caused it to error. This has been fixed and an app spec test added to show it working after entry deletion.

Probably a rewrite of the get_links* variants is needed soon but this is a bugfix for the mean time

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
