### PR TITLE
fix PATH for local bin in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ with pkgs;
      # https://github.com/rust-lang/rustup.rs/issues/994
      export CARGO_HOME=`pwd`/.cargo
      export CARGO_INSTALL_ROOT=`pwd`/.cargo
-     export PATH="$PATH:$CARGO_INSTALL_ROOT/bin"
+     export PATH="$CARGO_INSTALL_ROOT/bin:$PATH"
 
      export HC_TARGET_PREFIX=~/nix-holochain/
      export NIX_LDFLAGS="${darwin.ld-flags}$NIX_LDFLAGS"

--- a/holonix/cli/src/uninstall.nix
+++ b/holonix/cli/src/uninstall.nix
@@ -5,8 +5,8 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-   echo "dropping hc binary from home directory"
-   rm -f ~/.cargo/bin/hc
+   echo "dropping hc binary from cargo home directory"
+   rm -f $CARGO_HOME/bin/hc
   '';
 in
 script

--- a/holonix/conductor/rust/src/uninstall.nix
+++ b/holonix/conductor/rust/src/uninstall.nix
@@ -5,8 +5,8 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-   echo "dropping holochain binary from home directory"
-   rm -f ~/.cargo/bin/holochain
+   echo "dropping holochain binary from cargo home directory"
+   rm -f $CARGO_HOME/bin/holochain
   '';
 in
 script


### PR DESCRIPTION
## PR summary

puts the local bin in front of the rest of the path so that installing locally works

point the uninstall scripts to use the cargo home so that uninstalling locally works

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
