### PR TITLE
Reset caller's conductor api after adding bridge dynamically

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -18,4 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Adding bridges dynamically via an admin interface works now without rebooting the conductor. [#1476](https://github.com/holochain/holochain-rust/pull/1476) 
+
 ### Security

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -37,6 +37,7 @@ use std::{
 };
 
 use conductor::passphrase_manager::{PassphraseManager, PassphraseServiceCmd};
+use config::AgentConfiguration;
 use holochain_net::{
     ipc::spawn::{ipc_spawn, SpawnResult},
     p2p_config::P2pConfig,
@@ -44,7 +45,6 @@ use holochain_net::{
 use interface::{ConductorApiBuilder, InstanceMap, Interface};
 use signal_wrapper::SignalWrapper;
 use static_file_server::StaticServer;
-use config::AgentConfiguration;
 
 lazy_static! {
     /// This is a global and mutable Conductor singleton.
@@ -605,7 +605,11 @@ impl Conductor {
             })
     }
 
-    pub fn build_conductor_api(&mut self, instance_id: String, config: &Configuration) -> Result<IoHandler, HolochainError> {
+    pub fn build_conductor_api(
+        &mut self,
+        instance_id: String,
+        config: &Configuration,
+    ) -> Result<IoHandler, HolochainError> {
         let instance_config = config.instance_by_id(&instance_id)?;
         let agent_id = instance_config.agent.clone();
         let agent_config = config.agent_by_id(&agent_id)?;
@@ -647,16 +651,19 @@ impl Conductor {
                     the bridge API"#,
             );
 
-            api_builder = api_builder
-                .with_named_instance(bridge.handle.clone(), callee_instance.clone());
-            api_builder = api_builder
-                .with_named_instance_config(bridge.handle.clone(), callee_config);
+            api_builder =
+                api_builder.with_named_instance(bridge.handle.clone(), callee_instance.clone());
+            api_builder =
+                api_builder.with_named_instance_config(bridge.handle.clone(), callee_config);
         }
 
         Ok(api_builder.spawn())
     }
 
-    pub fn agent_config_to_id(&mut self, agent_config: &AgentConfiguration) -> Result<AgentId,HolochainError> {
+    pub fn agent_config_to_id(
+        &mut self,
+        agent_config: &AgentConfiguration,
+    ) -> Result<AgentId, HolochainError> {
         Ok(if let Some(true) = agent_config.holo_remote_key {
             // !!!!!!!!!!!!!!!!!!!!!!!
             // Holo closed-alpha hack:

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -44,6 +44,7 @@ use holochain_net::{
 use interface::{ConductorApiBuilder, InstanceMap, Interface};
 use signal_wrapper::SignalWrapper;
 use static_file_server::StaticServer;
+use config::AgentConfiguration;
 
 lazy_static! {
     /// This is a global and mutable Conductor singleton.
@@ -458,7 +459,7 @@ impl Conductor {
 
         for id in config.instance_ids_sorted_by_bridge_dependencies()? {
             let instance = self
-                .instantiate_from_config(&id, &config)
+                .instantiate_from_config(&id, Some(&config))
                 .map_err(|error| {
                     format!(
                         "Error while trying to create instance \"{}\": {}",
@@ -504,8 +505,10 @@ impl Conductor {
     pub fn instantiate_from_config(
         &mut self,
         id: &String,
-        config: &Configuration,
+        maybe_config: Option<&Configuration>,
     ) -> Result<Holochain, String> {
+        let self_config = self.config.clone();
+        let config = maybe_config.unwrap_or(&self_config);
         let _ = config.check_consistency()?;
 
         config
@@ -517,16 +520,7 @@ impl Conductor {
 
                 // Agent:
                 let agent_config = config.agent_by_id(&instance_config.agent).unwrap();
-                let agent_id = if let Some(true) = agent_config.holo_remote_key {
-                    // !!!!!!!!!!!!!!!!!!!!!!!
-                    // Holo closed-alpha hack:
-                    // !!!!!!!!!!!!!!!!!!!!!!!
-                    AgentId::new(&agent_config.name, agent_config.public_address)
-                } else {
-                    let keybundle_arc = self.get_keybundle_for_agent(&instance_config.agent)?;
-                    let keybundle = keybundle_arc.lock().unwrap();
-                    AgentId::new(&agent_config.name, keybundle.get_id())
-                };
+                let agent_id = self.agent_config_to_id(&agent_config)?;
 
                 context_builder = context_builder.with_agent(agent_id.clone());
 
@@ -568,50 +562,8 @@ impl Conductor {
                 }
 
                 // Conductor API
-                let mut api_builder = ConductorApiBuilder::new();
-                // Signing callback:
-                if let Some(true) = agent_config.holo_remote_key {
-                    // !!!!!!!!!!!!!!!!!!!!!!!
-                    // Holo closed-alpha hack:
-                    // !!!!!!!!!!!!!!!!!!!!!!!
-                    api_builder = api_builder.with_outsource_signing_callback(
-                        agent_id.clone(),
-                        self.config
-                            .signing_service_uri
-                            .clone()
-                            .expect("holo_remote_key needs signing_service_uri set"),
-                    );
-                } else {
-                    api_builder = api_builder.with_agent_signature_callback(
-                        self.get_keybundle_for_agent(&instance_config.agent)?,
-                    );
-
-                    let keystore = self
-                        .get_keystore_for_agent(&instance_config.agent)
-                        .map_err(|err| format!("{}", err))?;
-                    api_builder = api_builder.with_agent_keystore_functions(keystore);
-                }
-
-                // Bridges:
-                let id = instance_config.id.clone();
-                for bridge in config.bridge_dependencies(id.clone()) {
-                    assert_eq!(bridge.caller_id, id.clone());
-                    let callee_config = config
-                        .instance_by_id(&bridge.callee_id)
-                        .expect("config.check_consistency()? jumps out if config is broken");
-                    let callee_instance = self.instances.get(&bridge.callee_id).expect(
-                        r#"
-                    We have to create instances ordered by bridge dependencies such that we
-                    can expect the callee to be present here because we need it to create
-                    the bridge API"#,
-                    );
-
-                    api_builder = api_builder
-                        .with_named_instance(bridge.handle.clone(), callee_instance.clone());
-                    api_builder = api_builder
-                        .with_named_instance_config(bridge.handle.clone(), callee_config);
-                }
-                context_builder = context_builder.with_conductor_api(api_builder.spawn());
+                let api = self.build_conductor_api(instance_config.id, config)?;
+                context_builder = context_builder.with_conductor_api(api);
 
                 // Spawn context
                 let context = context_builder.spawn();
@@ -651,6 +603,70 @@ impl Conductor {
                         Holochain::new(dna, context).map_err(|hc_err| hc_err.to_string())
                     })
             })
+    }
+
+    pub fn build_conductor_api(&mut self, instance_id: String, config: &Configuration) -> Result<IoHandler, HolochainError> {
+        let instance_config = config.instance_by_id(&instance_id)?;
+        let agent_id = instance_config.agent.clone();
+        let agent_config = config.agent_by_id(&agent_id)?;
+        let mut api_builder = ConductorApiBuilder::new();
+        // Signing callback:
+        if let Some(true) = agent_config.holo_remote_key {
+            // !!!!!!!!!!!!!!!!!!!!!!!
+            // Holo closed-alpha hack:
+            // !!!!!!!!!!!!!!!!!!!!!!!
+            api_builder = api_builder.with_outsource_signing_callback(
+                self.agent_config_to_id(&agent_config)?,
+                self.config
+                    .signing_service_uri
+                    .clone()
+                    .expect("holo_remote_key needs signing_service_uri set"),
+            );
+        } else {
+            api_builder = api_builder.with_agent_signature_callback(
+                self.get_keybundle_for_agent(&instance_config.agent)?,
+            );
+
+            let keystore = self
+                .get_keystore_for_agent(&instance_config.agent)
+                .map_err(|err| format!("{}", err))?;
+            api_builder = api_builder.with_agent_keystore_functions(keystore);
+        }
+
+        // Bridges:
+        let id = instance_config.id.clone();
+        for bridge in config.bridge_dependencies(id.clone()) {
+            assert_eq!(bridge.caller_id, id.clone());
+            let callee_config = config
+                .instance_by_id(&bridge.callee_id)
+                .expect("config.check_consistency()? jumps out if config is broken");
+            let callee_instance = self.instances.get(&bridge.callee_id).expect(
+                r#"
+                    We have to create instances ordered by bridge dependencies such that we
+                    can expect the callee to be present here because we need it to create
+                    the bridge API"#,
+            );
+
+            api_builder = api_builder
+                .with_named_instance(bridge.handle.clone(), callee_instance.clone());
+            api_builder = api_builder
+                .with_named_instance_config(bridge.handle.clone(), callee_config);
+        }
+
+        Ok(api_builder.spawn())
+    }
+
+    pub fn agent_config_to_id(&mut self, agent_config: &AgentConfiguration) -> Result<AgentId,HolochainError> {
+        Ok(if let Some(true) = agent_config.holo_remote_key {
+            // !!!!!!!!!!!!!!!!!!!!!!!
+            // Holo closed-alpha hack:
+            // !!!!!!!!!!!!!!!!!!!!!!!
+            AgentId::new(&agent_config.name, agent_config.public_address.clone())
+        } else {
+            let keybundle_arc = self.get_keybundle_for_agent(&agent_config.id)?;
+            let keybundle = keybundle_arc.lock().unwrap();
+            AgentId::new(&agent_config.name, keybundle.get_id())
+        })
     }
 
     /// Checks if the key for the given agent can be loaded or was already loaded.

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -103,6 +103,7 @@ use holochain_core_types::{
     json::JsonString,
 };
 use std::sync::Arc;
+use jsonrpc_core::IoHandler;
 
 /// contains a Holochain application instance
 pub struct Holochain {
@@ -220,6 +221,10 @@ impl Holochain {
 
     pub fn context(&self) -> &Arc<Context> {
         &self.context
+    }
+
+    pub fn set_conductor_api(&mut self, api: IoHandler) {
+        self.context.conductor_api.reset(api);
     }
 }
 

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -102,8 +102,8 @@ use holochain_core_types::{
     error::HolochainError,
     json::JsonString,
 };
-use std::sync::Arc;
 use jsonrpc_core::IoHandler;
+use std::sync::Arc;
 
 /// contains a Holochain application instance
 pub struct Holochain {

--- a/core/src/conductor_api.rs
+++ b/core/src/conductor_api.rs
@@ -40,6 +40,10 @@ impl ConductorApi {
     pub fn get(&self) -> &Arc<RwLock<IoHandler>> {
         &self.0
     }
+
+    pub fn reset(&self, api: IoHandler) {
+        *self.0.write().unwrap() = api;
+    }
 }
 
 impl PartialEq for ConductorApi {


### PR DESCRIPTION
## PR summary

These changes make bridging work in the case of a purely dynamically created config, as needed for the Rust-conductor based testing framework.

Before it was impossible to have bridges working if they were not configured in the config file during start-up. The reason was that bridges are called through a conductor API that is exposed to the caller instance. These conductor APIs were only created on boot-up.

This PR breaks that code out into a separate function that also gets called when a bridge is added through an admin interface after the conductor finished booting.

closes #1419 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
