### PR TITLE
updated old version numbers that got missed by release process

### DIFF
--- a/app_spec_proc_macro/zomes/blog/code/Cargo.toml
+++ b/app_spec_proc_macro/zomes/blog/code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code"
-version = "0.0.12-alpha1"
+version = "0.0.18-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/app_spec_proc_macro/zomes/converse/code/Cargo.toml
+++ b/app_spec_proc_macro/zomes/converse/code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "converse"
-version = "0.0.12-alpha1"
+version = "0.0.18-alpha1"
 authors = ["Julian Laubstein <contact@julianlaubstein.de>"]
 edition = "2018"
 

--- a/app_spec_proc_macro/zomes/summer/code/Cargo.toml
+++ b/app_spec_proc_macro/zomes/summer/code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code"
-version = "0.0.12-alpha1"
+version = "0.0.18-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]

--- a/doc/holochain_101/src/alpha_migrate.md
+++ b/doc/holochain_101/src/alpha_migrate.md
@@ -65,7 +65,7 @@ entry!(
 
 The callback `validation`, replaces `validateCommit` and all the rest from holochain-proto. However, validation still happens at various times in the lifecycle of an entry, so if the validation is to operate differently between initial `commit` to the chain, `update`, or `remove`, then that logic must be written into this single validation function. To determine which context validation is being called within, you can check in a property of the second parameter of the callback, which in the example above is called `validation_data`.
 
-For this, you can use the Rust `match` operator, and check against the `validation_data.action`. It will be one of an enum that can be seen in detail [in the API reference](/api/0.0.7-alpha/hdk/enum.EntryAction.html).
+For this, you can use the Rust `match` operator, and check against the `validation_data.action`. It will be one of an enum that can be seen in detail [in the API reference](/api/0.0.18-alpha1/hdk/enum.EntryAction.html).
 
 
 

--- a/doc/holochain_101/src/first_steps.md
+++ b/doc/holochain_101/src/first_steps.md
@@ -517,4 +517,4 @@ Pro tip: [Pipe the output to tap-spec](https://github.com/scottcorgan/tap-spec) 
 
 And there we have it! A simple Zome created with Holochain using the Rust HDK.
 
-The [complete working version of this project is available on github](https://github.com/willemolding/holochain-rust-todo). This builds under the 0.0.18-alpha1 release but as the API and HDK are changing it will likely fail under newer releases.
+The [complete working version of this project is available on github](https://github.com/willemolding/holochain-rust-todo). This builds under the 0.0.9-alpha release but as the API and HDK are changing it will likely fail under newer releases.

--- a/doc/holochain_101/src/first_steps.md
+++ b/doc/holochain_101/src/first_steps.md
@@ -1,7 +1,7 @@
 # First steps writing Holochain hApps with Rust
 
 ___
-This tutorial builds for the 0.0.9-alpha release but as the API and HDK are changing it will likely fail under newer releases.
+This tutorial builds for the 0.0.18-alpha1 release but as the API and HDK are changing it will likely fail under newer releases.
 ___
 
 Holochain hApps are made of compiled WebAssembly that encodes the rules of the hApp, the data it can store and how users will interact with it. This means that [any language that can compile to WebAssembly](https://github.com/appcypher/awesome-wasm-langs) can one day be used for Holochain.
@@ -62,27 +62,27 @@ The project structure should now be as follows:
  │  └── lib.rs
  └── zome.json
 ```
- 
+
 ## Writing the lists zome
-The Rust HDK makes use of Rust macros to reduce the need for boilerplate code. The most important of which is the [`define_zome!`](https://developer.holochain.org/api/0.0.9-alpha/hdk/macro.define_zome.html) macro. Every zome must use this to define the structure of the zome, what entries it contains, which functions it exposes and what to do on first start-up (genesis).
+The Rust HDK makes use of Rust macros to reduce the need for boilerplate code. The most important of which is the [`define_zome!`](https://developer.holochain.org/api/0.0.18-alpha1/hdk/macro.define_zome.html) macro. Every zome must use this to define the structure of the zome, what entries it contains, which functions it exposes and what to do on first start-up (genesis).
 
 Open up `lib.rs` and replace its contents with the following:
 
 ```rust
 #[macro_use]
 extern crate hdk;
- 
+
 define_zome! {
     entries: [
     ]
- 
+
     genesis: || {
         Ok(())
     }
- 
+
     functions: [
     ]
- 
+
     traits: {
     }
 }
@@ -302,7 +302,7 @@ use hdk::{
     }
 };
 
- 
+
 define_zome! {
     entries: [
         entry!(
@@ -334,11 +334,11 @@ define_zome! {
             }
         )
     ]
- 
+
     genesis: || {
         Ok(())
     }
- 
+
 	functions: [
         create_list: {
             inputs: |list: List|,
@@ -517,4 +517,4 @@ Pro tip: [Pipe the output to tap-spec](https://github.com/scottcorgan/tap-spec) 
 
 And there we have it! A simple Zome created with Holochain using the Rust HDK.
 
-The [complete working version of this project is available on github](https://github.com/willemolding/holochain-rust-todo). This builds under the 0.0.9-alpha release but as the API and HDK are changing it will likely fail under newer releases.
+The [complete working version of this project is available on github](https://github.com/willemolding/holochain-rust-todo). This builds under the 0.0.18-alpha1 release but as the API and HDK are changing it will likely fail under newer releases.

--- a/doc/holochain_101/src/zome/api_functions.md
+++ b/doc/holochain_101/src/zome/api_functions.md
@@ -56,7 +56,7 @@ Canonical name: `entry_address`
 
 Returns the address that a given entry will hash into. Often used for reconstructing an address for a "base" when calling [get_links](#get-links).
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.entry_address.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.entry_address.html)
 
 ### Debug
 
@@ -64,7 +64,7 @@ Canonical name: `debug`
 
 Debug sends the passed arguments to the log that was given to the Holochain instance and returns `None`.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.debug.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.debug.html)
 
 ### Call
 
@@ -72,7 +72,7 @@ Canonical name: `call`
 
 Enables making function calls to an exposed function from another app instance via bridging, or simply another Zome within the same instance.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.call.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.call.html)
 
 ### Sign
 
@@ -97,7 +97,7 @@ Canonical name: `commit_entry`
 
 Attempts to commit an entry to your local source chain. The entry will have to pass the defined validation rules for that entry type. If the entry type is defined as public, it will also publish the entry to the DHT. Returns either an address of the committed entry as a string, or an error.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.commit_entry.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.commit_entry.html)
 
 ### Update Entry
 
@@ -105,7 +105,7 @@ Canonical name: `update_entry`
 
 Commit an entry to your local source chain that "updates" a previous entry, meaning when getting the previous entry, the updated entry will be returned. update_entry sets the previous entry's status metadata to Modified and adds the updated entry's address in the previous entry's metadata. The updated entry will hold the previous entry's address in its header, which will be used by validation routes.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.update_entry.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.update_entry.html)
 
 ### Update Agent
 
@@ -121,7 +121,7 @@ Enables an entry, referred to by its address, to be marked in the chain as 'dele
 which indicates the deleted status of the old one. This will changes which types of results that entry would then show up in,
 according to its new 'deleted' status. It can still be retrieved, but only if specifically asked for. This function also returns the Hash of the deletion entry on completion
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.remove_entry.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.remove_entry.html)
 
 ### Get Entry
 
@@ -137,10 +137,10 @@ Entry lookup is done in the following order:
 Caller can request additional metadata on the entry such as type or sources
 (hashes of the agents that committed the entry).
 
-- [View get_entry in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_entry.html)
-- [View get_entry_initial in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_entry_initial.html)
-- [View get_entry_history in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_entry_history.html)
-- [View get_entry_result in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_entry_result.html)
+- [View get_entry in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_entry.html)
+- [View get_entry_initial in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_entry_initial.html)
+- [View get_entry_history in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_entry_history.html)
+- [View get_entry_result in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_entry_result.html)
 
 
 ### Get Links
@@ -149,10 +149,10 @@ Canonical name: `get_links`
 
 Consumes three values, the first of which is the address of an entry, base, the remaining two are Optional types for the `link_type` and `tag`. Passing `Some("string")` will return only links that match the type/tag exactly. Passing `None` for either of those params will return all links regardless of the type/tag. Returns a list of addresses of other entries which matched as being linked by the given link type. Links are created in the first place using the Zome API function [link_entries](#link-entries). Once you have the addresses, there is a good likelihood that you will wish to call [get_entry](#get-entry) for each of them.
 
-- [View get_links in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_links.html)
-- [View get_links_and_load in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_links_and_load.html)
-- [View get_links_result in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_links_result.html)
-- [View get_links_with_options in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.get_links_with_options.html)
+- [View get_links in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_links.html)
+- [View get_links_and_load in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_links_and_load.html)
+- [View get_links_result in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_links_result.html)
+- [View get_links_with_options in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.get_links_with_options.html)
 
 
 ### Link Entries
@@ -161,7 +161,7 @@ Canonical name: `link_entries`
 
 Consumes four values, two of which are the addresses of entries, and two of which are strings that determine which `link_type` to use and a `tag` string that should be added to the link. The `link_type` must exactly match a type defined in an `entry!` macro. The tag can be any arbitrary string. Later, lists of entries can be looked up by using `get_links` and optionally filtered based on their type or tag. Entries can only be looked up in the direction from the `base`, which is the first argument, to the `target`, which is the second. This function returns a hash for the LinkAdd entry on completion.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.link_entries.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.link_entries.html)
 
 ### Query
 
@@ -169,7 +169,7 @@ Canonical name: `query`
 
 Returns a list of addresses of entries from your local source chain, that match a given entry type name, or a vector of names. You can optionally limit the number of results, and you can use "glob" patterns such as "prefix/*" to specify the entry type names desired.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.query.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.query.html)
 
 ### Send
 
@@ -177,7 +177,7 @@ Canonical name: `send`
 
 Sends a node-to-node message to the given agent. This works in conjunction with the receive callback, which is where the response behaviour to receiving a message should be defined. This function returns the result from the receive callback on the other side.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.send.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.send.html)
 
 ### Grant Capability
 
@@ -185,7 +185,7 @@ Canonical name: `commit_capability_grant`
 
 Creates a capability grant on the local chain for allowing access to zome functions.
 
-[View it in the Rust HDK](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.commit_capability_grant.html)
+[View it in the Rust HDK](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.commit_capability_grant.html)
 
 ### Start Bundle
 

--- a/doc/holochain_101/src/zome/dna_variables.md
+++ b/doc/holochain_101/src/zome/dna_variables.md
@@ -2,7 +2,7 @@
 
 Note: Full reference is available in language-specific API Reference documentation.
 
-For the Rust `hdk`, [see here](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/index.html#structs)
+For the Rust `hdk`, [see here](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/index.html#structs)
 
 | Name        | Purpose           |
 | ------------- |:-------------|

--- a/doc/holochain_101/src/zome/entry_type_definitions.md
+++ b/doc/holochain_101/src/zome/entry_type_definitions.md
@@ -107,7 +107,7 @@ entry!(
 )
 ```
 
-As mentioned above, sharing refers to whether entries of this type are private to their author, or whether they will be gossiped to other peers to hold copies of. The value must be referenced from an [enum in the HDK](/api/0.0.7-alpha/holochain_core_types/dna/entry_types/enum.Sharing.html). Holochain currently supports the first two values in the enum: Public, and Private.
+As mentioned above, sharing refers to whether entries of this type are private to their author, or whether they will be gossiped to other peers to hold copies of. The value must be referenced from an [enum in the HDK](/api/0.0.18-alpha1/holochain_core_types/dna/entry_types/enum.Sharing.html). Holochain currently supports the first two values in the enum: Public, and Private.
 
 ---
 
@@ -174,7 +174,7 @@ entry!(
 
 At the moment, what `validation_package` is will not be covered in great detail. In short, for a peer to perform validation of an entry from another peer, varying degrees of metadata from the original author of the entry might be needed. `validation_package` refers to the carrier for that extra metadata.
 
-Looking at the above code, there is a required import from the HDK needed for use in `validation_package`, and that's the enum `ValidationPackageDefinition`. The value of `validation_package` is a function that takes no arguments. It will be called as a callback by Holochain. The result should be a value from the `ValidationPackageDefinition` enum, whose values can be [seen here](https://developer.holochain.org/api/0.0.7-alpha/hdk/enum.ValidationPackageDefinition.html). In the example, and as the most basic option, simply use `Entry`, which means no extra metadata beyond the entry itself is needed.
+Looking at the above code, there is a required import from the HDK needed for use in `validation_package`, and that's the enum `ValidationPackageDefinition`. The value of `validation_package` is a function that takes no arguments. It will be called as a callback by Holochain. The result should be a value from the `ValidationPackageDefinition` enum, whose values can be [seen here](https://developer.holochain.org/api/0.0.18-alpha1/hdk/enum.ValidationPackageDefinition.html). In the example, and as the most basic option, simply use `Entry`, which means no extra metadata beyond the entry itself is needed.
 
 Further reading is [here](./entry_validation.md).
 
@@ -236,7 +236,7 @@ define_zome! {
             name: "post",
             description: "A blog post entry which has an author",
             sharing: Sharing::Public,
-   
+
             validation_package: || {
                 ValidationPackageDefinition::Entry
             },
@@ -292,7 +292,7 @@ define_zome! {
 
 Use of this technique can help you write clean, modular code.
 
-If you want to look closely at a complete example of the use of `entry!` in a Zome, check out the [API reference](https://developer.holochain.org/api/0.0.7-alpha/hdk/macro.entry.html), or the ["app-spec" example app](https://github.com/holochain/holochain-rust/blob/v0.0.4/app_spec/zomes/blog/code/src/post.rs).
+If you want to look closely at a complete example of the use of `entry!` in a Zome, check out the [API reference](https://developer.holochain.org/api/0.0.18-alpha1/hdk/macro.entry.html), or the ["app-spec" example app](https://github.com/holochain/holochain-rust/blob/v0.0.4/app_spec/zomes/blog/code/src/post.rs).
 
 #### Summary
 This is still a pretty minimal Zome, since it doesn't have any functions yet, and the most basic `genesis` behaviour, so read on to learn about how to work with those aspects of `define_zome!`.

--- a/doc/holochain_101/src/zome/intro_to_hdk.md
+++ b/doc/holochain_101/src/zome/intro_to_hdk.md
@@ -36,7 +36,7 @@ Once Holochain stabilizes beyond the 0.0.x version numbers, it will be published
 
 If you wanted to lock the HDK at a specific version, you could adjust the HDK dependency like this:
 ```toml
-hdk = { git = "https://github.com/holochain/holochain-rust", tag = "v0.0.7-alpha" }
+hdk = { git = "https://github.com/holochain/holochain-rust", tag = "v0.0.18-alpha1" }
 ```
 
 #### Use of the HDK in Rust code

--- a/doc/holochain_101/src/zome/zome_functions.md
+++ b/doc/holochain_101/src/zome/zome_functions.md
@@ -204,9 +204,9 @@ Notice right away how the arguments match perfectly with the `inputs: |...|` sec
 
 The name of the function, `handle_send_message` is the same as the name given as the `handler` in the `define_zome!` function declaration.
 
-Within the function, `handle_send_message` makes use of a Holochain/HDK function that [sends messages directly node-to-node](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/fn.send.html).
+Within the function, `handle_send_message` makes use of a Holochain/HDK function that [sends messages directly node-to-node](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/fn.send.html).
 
-The available functions, their purpose, and how to use them is fully documented elsewhere, in the [API reference](https://developer.holochain.org/api/0.0.7-alpha/hdk/api/index.html#functions) and the [List of API Functions](./api_functions.md).
+The available functions, their purpose, and how to use them is fully documented elsewhere, in the [API reference](https://developer.holochain.org/api/0.0.18-alpha1/hdk/api/index.html#functions) and the [List of API Functions](./api_functions.md).
 
 In the example, `handle_send_message` simply forwards the result of calling `hdk::send` as its' own result.
 

--- a/hdk-proc-macros/Cargo.toml
+++ b/hdk-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk-proc-macros"
-version = "0.0.12-alpha1"
+version = "0.0.18-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 

--- a/hdk-proc-macros/wasm-test/Cargo.toml
+++ b/hdk-proc-macros/wasm-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-proc-macro"
-version = "0.0.12-alpha1"
+version = "0.0.18-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [lib]


### PR DESCRIPTION
## PR summary

It appears that sometimes old version numbers didn't get updated by the release process, probably if stuff was stuck in branches that were worked on over a long time and then merged poorly.

For this PR, I did a manual search for all version numbers from "0.0.7-alpha" to "0.0.17-alpha" and fixed them to be 0.0.18-alpha1 which is what's current at the time of this branch.  Thus this should get merged before next release so the scripts don't miss these updates again!

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
