### PR TITLE
Unresolved Dependencies during validation should not log as error

### DIFF
--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -66,20 +66,27 @@ pub async fn hold_entry_workflow<'a>(
         &context
     ))
     .map_err(|err| {
-        context.log(format!(
-            "err/workflow/hold_entry: {} is NOT valid! {:?}",
-            entry_with_header.entry.address(),
-            err,
-        ));
         if let ValidationError::UnresolvedDependencies(dependencies) = &err {
+            context.log(format!(
+                "debug/workflow/hold_entry: {} could not be validated due to unresolved dependencies and will be tried later. List of missing dependencies: {:?}",
+                entry_with_header.entry.address(),
+                dependencies,
+            ));
             add_pending_validation(
                 entry_with_header.to_owned(),
                 dependencies.clone(),
                 ValidatingWorkflow::HoldEntry,
                 &context,
             );
+            HolochainError::ValidationPending
+        } else {
+            context.log(format!(
+                "info/workflow/hold_entry: Entry {} is NOT valid! Validation error: {:?}",
+                entry_with_header.entry.address(),
+                err,
+            ));
+            HolochainError::from(err)
         }
-        HolochainError::ValidationPending
     })?;
 
     context.log(format!(

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -80,16 +80,24 @@ pub async fn hold_link_workflow<'a>(
         &context
     ))
     .map_err(|err| {
-        context.log(format!("debug/workflow/hold_link: invalid! {:?}", err));
         if let ValidationError::UnresolvedDependencies(dependencies) = &err {
+            context.log(format!("debug/workflow/hold_link: Link could not be validated due to unresolved dependencies and will be tried later. List of missing dependencies: {:?}", dependencies));
             add_pending_validation(
                 entry_with_header.to_owned(),
                 dependencies.clone(),
                 ValidatingWorkflow::HoldLink,
                 &context,
             );
+            HolochainError::ValidationPending
+        } else {
+            context.log(format!(
+                "info/workflow/hold_link: Link {:?} is NOT valid! Validation error: {:?}",
+                entry_with_header.entry,
+                err,
+            ));
+            HolochainError::from(err)
         }
-        HolochainError::ValidationPending
+
     })?;
     context.log(format!("debug/workflow/hold_link: is valid!"));
 


### PR DESCRIPTION
## PR summary

Fixes https://github.com/holochain/holochain-rust/issues/1452

When an entry or link can't be validated because of missing dependencies, that is not an error but a normal and recoverable situation. The log messages was misleading.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
