### PR TITLE
JsonString [de]serialisation for Option types

### DIFF
--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -30,7 +30,7 @@ holochain_core_types_derive = { path = "../core_types_derive" }
 lib3h_crypto_api = "=0.0.1-alpha1"
 uuid = { version = "=0.7.1", features = ["v4"] }
 regex = "=1.1.2"
-shrinkwraprs = "0.2.1"
+shrinkwraprs = "=0.2.1"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils"}

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -30,6 +30,7 @@ holochain_core_types_derive = { path = "../core_types_derive" }
 lib3h_crypto_api = "=0.0.1-alpha1"
 uuid = { version = "=0.7.1", features = ["v4"] }
 regex = "=1.1.2"
+shrinkwraprs = "0.2.1"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils"}

--- a/core_types/src/cas/content.rs
+++ b/core_types/src/cas/content.rs
@@ -4,15 +4,11 @@
 //! A test suite for AddressableContent is also implemented here.
 
 use crate::{
-    cas::storage::ContentAddressableStorage,
-    error::HolochainError,
-    hash::HashString,
-    json::{JsonString},
+    cas::storage::ContentAddressableStorage, error::HolochainError, hash::HashString,
+    json::JsonString,
 };
 use multihash::Hash;
-use std::{
-    fmt::{Debug, Write},
-};
+use std::fmt::{Debug, Write};
 
 /// an Address for some Content
 /// ideally would be the Content but pragmatically must be Address

--- a/core_types/src/cas/content.rs
+++ b/core_types/src/cas/content.rs
@@ -7,11 +7,10 @@ use crate::{
     cas::storage::ContentAddressableStorage,
     error::HolochainError,
     hash::HashString,
-    json::{default_to_json, default_try_from_json, JsonString},
+    json::{JsonString},
 };
 use multihash::Hash;
 use std::{
-    convert::TryFrom,
     fmt::{Debug, Write},
 };
 
@@ -19,19 +18,6 @@ use std::{
 /// ideally would be the Content but pragmatically must be Address
 /// consider what would happen if we had multi GB addresses...
 pub type Address = HashString;
-
-impl From<Option<Address>> for JsonString {
-    fn from(maybe_address: Option<Address>) -> Self {
-        default_to_json(maybe_address)
-    }
-}
-
-impl TryFrom<JsonString> for Option<Address> {
-    type Error = HolochainError;
-    fn try_from(j: JsonString) -> Result<Self, Self::Error> {
-        default_try_from_json(j)
-    }
-}
 
 /// the Content is a JsonString
 /// this is the only way to be confident in persisting all Rust types across all backends

--- a/core_types/src/entry/mod.rs
+++ b/core_types/src/entry/mod.rs
@@ -19,7 +19,7 @@ use crud_status::CrudStatus;
 use dna::Dna;
 use entry::entry_type::{test_app_entry_type, test_app_entry_type_b, AppEntryType, EntryType};
 use error::{HcResult, HolochainError};
-use json::{default_to_json, default_try_from_json, JsonString, RawString};
+use json::{JsonString, RawString};
 use link::{link_data::LinkData, link_list::LinkList};
 use multihash::Hash;
 use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serializer};
@@ -74,19 +74,6 @@ pub enum Entry {
     ChainMigrate(ChainMigrate),
     CapTokenClaim(CapTokenClaim),
     CapTokenGrant(CapTokenGrant),
-}
-
-impl From<Option<Entry>> for JsonString {
-    fn from(maybe_entry: Option<Entry>) -> Self {
-        default_to_json(maybe_entry)
-    }
-}
-
-impl TryFrom<JsonString> for Option<Entry> {
-    type Error = HolochainError;
-    fn try_from(j: JsonString) -> Result<Self, Self::Error> {
-        default_try_from_json(j)
-    }
 }
 
 impl Entry {

--- a/core_types/src/json.rs
+++ b/core_types/src/json.rs
@@ -267,7 +267,7 @@ impl Display for JsonString {
 // ## Conversions from Option types ##
 
 // Options are a special case for several reasons. Firstly they are handled
-// in a special way be serde:
+// in a special way by serde:
 
 //     "Users tend to have different expectations around the Option enum compared to other enums.
 //     Serde JSON will serialize Option::None as null and Option::Some as just the contained value."

--- a/core_types/src/json.rs
+++ b/core_types/src/json.rs
@@ -264,6 +264,64 @@ impl Display for JsonString {
     }
 }
 
+// ## Conversions from Option types ##
+
+// Options are a special case for several reasons. Firstly they are handled
+// in a special way be serde:
+
+//     "Users tend to have different expectations around the Option enum compared to other enums.
+//     Serde JSON will serialize Option::None as null and Option::Some as just the contained value."
+
+// The other issue is that option implements generic From<T> so you can do calls like
+// `let s: Option<&str> = "hi".into()`
+// To get around this we need an intermediate type and a conversion that understands null
+
+#[derive(Shrinkwrap, Deserialize)]
+pub struct JsonStringOption<T>(Option<T>);
+
+impl<T> JsonStringOption<T> {
+    pub fn to_option(self) -> Option<T> {
+        self.0
+    }
+}
+
+impl<T> TryInto<JsonStringOption<T>> for JsonString
+where
+    T: Into<JsonString> + DeserializeOwned,
+{
+    type Error = HolochainError;
+    fn try_into(self) -> Result<JsonStringOption<T>, Self::Error> {
+        let o: Option<T> = default_try_from_json(self)?;
+        Ok(JsonStringOption(o))
+    }
+}
+
+impl TryInto<JsonStringOption<String>> for JsonString
+{
+    type Error = HolochainError;
+    fn try_into(self) -> Result<JsonStringOption<String>, Self::Error> {
+        let o: Option<String> = default_try_from_json(self)?;
+        Ok(JsonStringOption(o))
+    }
+}
+
+// conversions from options to JsonString
+
+impl<T> From<Option<T>> for JsonString
+where T: Debug + Serialize + Into<JsonString>
+{
+    fn from(o: Option<T>) -> JsonString {
+        default_to_json(o)
+    }
+}
+
+impl From<Option<String>> for JsonString
+{
+    fn from(o: Option<String>) -> JsonString {
+        default_to_json(o)
+    }
+}
+
 /// if all you want to do is implement the default behaviour then use #[derive(DefaultJson)]
 /// should only be used with From<S> for JsonString
 /// i.e. when failure should be impossible so an expect is ok
@@ -370,7 +428,7 @@ impl TryFrom<JsonString> for RawString {
 pub mod tests {
     use crate::{
         error::HolochainError,
-        json::{JsonString, RawString},
+        json::{JsonString, RawString, JsonStringOption},
     };
     use serde_json;
     use std::convert::{TryFrom, TryInto};
@@ -520,5 +578,36 @@ pub mod tests {
             .expect("Could not convert json string to result type");
 
         assert_eq!(r.unwrap(), String::from("string-content"),);
+    }
+
+    #[test]
+    fn options_are_converted_to_null_or_value_respectively() {
+        let o: Option<u32> = None;
+        let j: JsonString = o.into();
+        assert_eq!(j, JsonString::from_json("null"));
+    
+        let o: Option<u32> = Some(10);
+        let j: JsonString = o.into();
+        assert_eq!(j, JsonString::from_json("10"));
+
+        let o: Option<String> = Some("test".to_string());
+        let j: JsonString = o.into();
+        assert_eq!(j, JsonString::from_json("\"test\""));
+    }
+
+    #[test]
+    fn json_string_to_option() {
+        let j = JsonString::from("10");
+        let o: JsonStringOption<u32> = j.try_into().expect("failed conversion from JsonString");
+        assert_eq!(o.to_option(), Some(10));
+
+        let j = JsonString::from("null");
+        let o: JsonStringOption<u32> = j.try_into().expect("failed conversion from JsonString");
+        assert_eq!(o.to_option(), None);
+
+        // tricky!
+        let j = JsonString::from("\"null\"");
+        let o: JsonStringOption<String> = j.try_into().expect("failed conversion from JsonString");
+        assert_eq!(o.to_option(), Some("null".to_string()));
     }
 }

--- a/core_types/src/lib.rs
+++ b/core_types/src/lib.rs
@@ -35,6 +35,8 @@ extern crate maplit;
 extern crate hcid;
 extern crate uuid;
 extern crate wasmi;
+#[macro_use]
+extern crate shrinkwraprs;
 
 pub mod cas;
 pub mod chain_header;


### PR DESCRIPTION
## PR summary

Well this ended up turning into a much bigger problem that I thought. A few reasons why this is tricky:

Firstly Options are handled in a special way by serde:
>Users tend to have different expectations around the Option enum compared to other enums. Serde JSON will serialize Option::None as null and Option::Some as just the contained value."
This first one didn't make much difference but something to keep in mind.

The real problem is that option implements generic From<T> so you can do calls like
 `let s: Option<&str> = "hi".into()`
To get around this we need to go through an intermediate type JsonStringOption. This shrinkwraps Option and implements Into<Option> so the subsequent conversion is easy but it would be better if we didn't have to. 

If anyone has any other ideas let me know.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
