### PR TITLE
`LifecycleError` for closed channels, to prevent Futures from locking up

### DIFF
--- a/app_spec/test/package.json
+++ b/app_spec/test/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {},
   "dependencies": {
-    "@holochain/diorama": "^0.1.0-rc11",
+    "@holochain/diorama": "^0.1.0-rc12",
     "faucet": "0.0.1",
     "json3": "*",
     "sleep": "^5.2.3",

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -240,6 +240,10 @@ impl ConductorAdmin for Conductor {
         }
         self.instances.remove(id).map(|instance| {
             instance.write().unwrap().kill();
+            println!(
+                "@REFCOUNT@ : Number of references at time of drop is {}",
+                Arc::strong_count(&instance)
+            );
         });
 
         notify(format!("Removed instance \"{}\".", id));

--- a/core/src/action.rs
+++ b/core/src/action.rs
@@ -220,6 +220,9 @@ pub enum Action {
 
     /// Clear an entry from the pending validation list
     RemovePendingValidation((Address, ValidatingWorkflow)),
+
+    /// No-op, used to check if an action channel is still open
+    Ping,
 }
 
 /// function signature for action handler functions

--- a/core/src/agent/actions/commit.rs
+++ b/core/src/agent/actions/commit.rs
@@ -45,6 +45,9 @@ impl Future for CommitFuture {
     type Output = Result<Address, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("CommitFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/dht/actions/add_link.rs
+++ b/core/src/dht/actions/add_link.rs
@@ -37,6 +37,9 @@ impl Future for AddLinkFuture {
     type Output = Result<(), HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("AddLinkFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/dht/actions/hold.rs
+++ b/core/src/dht/actions/hold.rs
@@ -33,6 +33,9 @@ impl Future for HoldEntryFuture {
     type Output = Result<Address, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("HoldEntryFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/dht/actions/remove_entry.rs
+++ b/core/src/dht/actions/remove_entry.rs
@@ -38,6 +38,9 @@ impl Future for RemoveEntryFuture {
     type Output = Result<(), HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("RemoveEntryFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/dht/actions/remove_link.rs
+++ b/core/src/dht/actions/remove_link.rs
@@ -39,6 +39,9 @@ impl Future for RemoveLinkFuture {
     type Output = Result<(), HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("RemoveLinkFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/dht/actions/update_entry.rs
+++ b/core/src/dht/actions/update_entry.rs
@@ -38,6 +38,9 @@ impl Future for UpdateEntryFuture {
     type Output = Result<Address, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("UpdateEntryFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -182,7 +182,7 @@ impl Instance {
             let mut state_observers: Vec<Observer> = Vec::new();
             while !kill_receiver.try_recv().is_ok() {
                 if let Ok(action_wrapper) = rx_action.recv_timeout(Duration::from_secs(1)) {
-                    // Ping can happen often, and should be
+                    // Ping can happen often, and should be as lightweight as possible
                     if *action_wrapper.action() != Action::Ping {
                         state_observers = sync_self.process_action(
                             &action_wrapper,
@@ -194,7 +194,7 @@ impl Instance {
                     }
                 }
             }
-            println!("STOPPING ACTION LOOP");
+            sub_context.log("info/action: STOPPING ACTION LOOP");
         });
     }
 

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -13,6 +13,7 @@ use holochain_core_types::cas::content::Address;
 use holochain_core_types::{
     dna::Dna,
     error::{HcResult, HolochainError},
+    ugly::lax_send_sync,
 };
 use std::{
     sync::{
@@ -348,9 +349,7 @@ pub fn dispatch_action_and_wait(context: Arc<Context>, action_wrapper: ActionWra
 ///
 /// Panics if the channels passed are disconnected.
 pub fn dispatch_action(action_channel: &SyncSender<ActionWrapper>, action_wrapper: ActionWrapper) {
-    action_channel
-        .send(action_wrapper)
-        .expect(DISPATCH_WITHOUT_CHANNELS);
+    lax_send_sync(action_channel.clone(), action_wrapper, "dispatch_action");
 }
 
 #[cfg(test)]

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -194,7 +194,7 @@ impl Instance {
                     }
                 }
             }
-            sub_context.log("info/action: STOPPING ACTION LOOP");
+            println!("info/action: STOPPING ACTION LOOP");
         });
     }
 

--- a/core/src/network/actions/custom_send.rs
+++ b/core/src/network/actions/custom_send.rs
@@ -55,6 +55,9 @@ impl Future for SendResponseFuture {
     type Output = Result<String, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("SendResponseFuture") {
+            return Poll::Ready(Err(err));
+        }
         let state = self.context.state().unwrap().network();
         if let Err(error) = state.initialized() {
             return Poll::Ready(Err(HolochainError::ErrorGeneric(error.to_string())));

--- a/core/src/network/actions/get_entry.rs
+++ b/core/src/network/actions/get_entry.rs
@@ -55,6 +55,9 @@ impl Future for GetEntryFuture {
     type Output = HcResult<Option<EntryWithMetaAndHeader>>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("GetEntryFuture") {
+            return Poll::Ready(Err(err));
+        }
         if let Err(error) = self
             .context
             .state()

--- a/core/src/network/actions/get_links.rs
+++ b/core/src/network/actions/get_links.rs
@@ -55,6 +55,9 @@ impl Future for GetLinksFuture {
     type Output = HcResult<Vec<Address>>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("GetLinksFuture") {
+            return Poll::Ready(Err(err));
+        }
         let state = self.context.state().unwrap().network();
         if let Err(error) = state.initialized() {
             return Poll::Ready(Err(error));

--- a/core/src/network/actions/get_validation_package.rs
+++ b/core/src/network/actions/get_validation_package.rs
@@ -44,6 +44,12 @@ impl Future for GetValidationPackageFuture {
     type Output = HcResult<Option<ValidationPackage>>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self
+            .context
+            .action_channel_error("GetValidationPackageFuture")
+        {
+            return Poll::Ready(Err(err));
+        }
         let state = self.context.state().unwrap().network();
         if let Err(error) = state.initialized() {
             return Poll::Ready(Err(error));

--- a/core/src/network/actions/initialize_network.rs
+++ b/core/src/network/actions/initialize_network.rs
@@ -64,6 +64,9 @@ impl Future for InitNetworkFuture {
     type Output = HcResult<()>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("InitializeNetworkFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/network/actions/publish.rs
+++ b/core/src/network/actions/publish.rs
@@ -36,6 +36,9 @@ impl Future for PublishFuture {
     type Output = HcResult<Address>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("PublishFuture") {
+            return Poll::Ready(Err(err));
+        }
         let state = self.context.state().unwrap().network();
         if let Err(error) = state.initialized() {
             return Poll::Ready(Err(error));

--- a/core/src/network/mod.rs
+++ b/core/src/network/mod.rs
@@ -37,9 +37,9 @@ pub mod tests {
         let netname = Some("get_entry_roundtrip");
         let mut dna = create_test_dna_with_wat("test_zome", None);
         dna.uuid = netname.unwrap().to_string();
-        let (_, context1) =
+        let (_instance1, context1) =
             test_instance_and_context_by_name(dna.clone(), "alice1", netname).unwrap();
-        let (_, context2) =
+        let (_instance2, context2) =
             test_instance_and_context_by_name(dna.clone(), "bob1", netname).unwrap();
 
         // Create Entry & metadata
@@ -91,9 +91,9 @@ pub mod tests {
         let netname = Some("get_entry_results_roundtrip");
         let mut dna = create_test_dna_with_wat("test_zome", None);
         dna.uuid = netname.unwrap().to_string();
-        let (_, context1) =
+        let (_instance1, context1) =
             test_instance_and_context_by_name(dna.clone(), "alex", netname).unwrap();
-        let (_, context2) =
+        let (_instance2, context2) =
             test_instance_and_context_by_name(dna.clone(), "billy", netname).unwrap();
 
         // Create Entry & crud-status metadata, and store it.
@@ -134,8 +134,9 @@ pub mod tests {
         let netname = Some("get_non_existant_entry");
         let mut dna = create_test_dna_with_wat("test_zome", None);
         dna.uuid = netname.unwrap().to_string();
-        let (_, _) = test_instance_and_context_by_name(dna.clone(), "alice2", netname).unwrap();
-        let (_, context2) =
+        let (_instance1, _) =
+            test_instance_and_context_by_name(dna.clone(), "alice2", netname).unwrap();
+        let (_instance2, context2) =
             test_instance_and_context_by_name(dna.clone(), "bob2", netname).unwrap();
 
         let entry = test_entry();
@@ -159,7 +160,7 @@ pub mod tests {
         let netname = Some("get_when_alone");
         let mut dna = create_test_dna_with_wat("test_zome", None);
         dna.uuid = netname.unwrap().to_string();
-        let (_, context1) =
+        let (_instance1, context1) =
             test_instance_and_context_by_name(dna.clone(), "bob3", netname).unwrap();
 
         // Create Entry
@@ -187,6 +188,7 @@ pub mod tests {
             CrudStatus::Live
         );
     }
+
     #[test]
     fn get_validation_package_roundtrip() {
         let netname = Some("get_validation_package_roundtrip");
@@ -194,7 +196,7 @@ pub mod tests {
         let mut dna = create_test_dna_with_wat("test_zome", Some(wat));
         dna.uuid = netname.unwrap().to_string();
 
-        let (_, context1) =
+        let (_instance1, context1) =
             test_instance_and_context_by_name(dna.clone(), "alice1", netname).unwrap();
 
         let entry = test_entry();
@@ -207,11 +209,11 @@ pub mod tests {
             .get_most_recent_header_for_entry(&entry)
             .expect("There must be a header in the author's source chain after commit");
 
-        let (_, context2) =
+        let (_instance2, context2) =
             test_instance_and_context_by_name(dna.clone(), "bob1", netname).unwrap();
         let result = context2.block_on(get_validation_package(header.clone(), &context2));
 
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "actual result: {:?}", result);
         let maybe_validation_package = result.unwrap();
         assert!(maybe_validation_package.is_some());
         let validation_package = maybe_validation_package.unwrap();
@@ -226,9 +228,9 @@ pub mod tests {
         let wat = &test_wat_always_valid();
         let mut dna = create_test_dna_with_wat("test_zome", Some(wat));
         dna.uuid = netname.unwrap().to_string();
-        let (_, context1) =
+        let (_instance1, context1) =
             test_instance_and_context_by_name(dna.clone(), "alex2", netname).unwrap();
-        let (_, context2) =
+        let (_instance2, context2) =
             test_instance_and_context_by_name(dna.clone(), "billy2", netname).unwrap();
 
         let mut entry_addresses: Vec<Address> = Vec::new();

--- a/core/src/nucleus/actions/build_validation_package.rs
+++ b/core/src/nucleus/actions/build_validation_package.rs
@@ -154,7 +154,7 @@ pub async fn build_validation_package<'a>(
                     id,
                     maybe_validation_package,
                 ))),
-                "action channel to be open in reducer",
+                "build_validation_package",
             );
         });
     }
@@ -201,6 +201,9 @@ impl Future for ValidationPackageFuture {
     type Output = Result<ValidationPackage, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("ValidationPackageFuture") {
+            return Poll::Ready(Err(err));
+        }
         if let Some(ref error) = self.error {
             return Poll::Ready(Err(error.clone()));
         }

--- a/core/src/nucleus/actions/build_validation_package.rs
+++ b/core/src/nucleus/actions/build_validation_package.rs
@@ -16,6 +16,7 @@ use holochain_core_types::{
     entry::{entry_type::EntryType, Entry},
     error::HolochainError,
     signature::Provenance,
+    ugly::lax_send_sync,
     validation::{ValidationPackage, ValidationPackageDefinition::*},
 };
 use snowflake;
@@ -147,13 +148,14 @@ pub async fn build_validation_package<'a>(
                     })
                 });
 
-            context
-                .action_channel()
-                .send(ActionWrapper::new(Action::ReturnValidationPackage((
+            lax_send_sync(
+                context.action_channel().clone(),
+                ActionWrapper::new(Action::ReturnValidationPackage((
                     id,
                     maybe_validation_package,
-                ))))
-                .expect("action channel to be open in reducer");
+                ))),
+                "action channel to be open in reducer",
+            );
         });
     }
 

--- a/core/src/nucleus/actions/call_zome_function.rs
+++ b/core/src/nucleus/actions/call_zome_function.rs
@@ -17,6 +17,7 @@ use holochain_core_types::{
     error::HolochainError,
     json::JsonString,
     signature::{Provenance, Signature},
+    ugly::lax_send_sync,
 };
 use holochain_dpki::utils::Verify;
 
@@ -102,12 +103,11 @@ pub async fn call_zome_function(
         let response = ExecuteZomeFnResponse::new(zome_call_clone, call_result);
         // Send ReturnZomeFunctionResult Action
         context_clone.log("debug/actions/call_zome_fn: sending ReturnZomeFunctionResult action.");
-        context_clone
-            .action_channel()
-            .send(ActionWrapper::new(Action::ReturnZomeFunctionResult(
-                response,
-            )))
-            .expect("action channel to be open in reducer");
+        lax_send_sync(
+            context_clone.action_channel().clone(),
+            ActionWrapper::new(Action::ReturnZomeFunctionResult(response)),
+            "call_zome_function",
+        );
         context_clone.log("debug/actions/call_zome_fn: sent ReturnZomeFunctionResult action.");
     });
 

--- a/core/src/nucleus/actions/call_zome_function.rs
+++ b/core/src/nucleus/actions/call_zome_function.rs
@@ -290,6 +290,9 @@ impl Future for CallResultFuture {
     type Output = Result<JsonString, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("CallResultFuture") {
+            return Poll::Ready(Err(err));
+        }
         // With our own executor implementation in Context::block_on we actually
         // wouldn't need the waker since this executor is attached to the redux loop
         // and re-polls after every State mutation.
@@ -381,7 +384,7 @@ pub mod tests {
     #[test]
     fn test_get_grant() {
         let dna = test_dna();
-        let (_, context) =
+        let (_instance, context) =
             test_instance_and_context(dna, None).expect("Could not initialize test instance");
 
         let mut cap_functions = CapFunctions::new();

--- a/core/src/nucleus/actions/initialize.rs
+++ b/core/src/nucleus/actions/initialize.rs
@@ -221,6 +221,9 @@ impl Future for InitializationFuture {
     type Output = Result<NucleusStatus, HolochainError>;
 
     fn poll(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
+        if let Some(err) = self.context.action_channel_error("InitializationFuture") {
+            return Poll::Ready(Err(err));
+        }
         //
         // TODO: connect the waker to state updates for performance reasons
         // See: https://github.com/holochain/holochain-rust/issues/314

--- a/core/src/nucleus/mod.rs
+++ b/core/src/nucleus/mod.rs
@@ -261,7 +261,7 @@ pub mod tests {
     fn test_call_zome_function() {
         let _netname = Some("test_call_zome_function");
         let dna = test_utils::create_test_dna_with_wat("test_zome", None);
-        //let (_, context) =
+        //let (_instance, context) =
         //    test_instance_and_context(dna, None).expect("Could not initialize test instance");
         //let context = instance.initialize_context(test_context("janet", netname));
         let test_setup = setup_test(dna, "test_call_zome_function");
@@ -303,7 +303,7 @@ pub mod tests {
     /// tests that calling a valid zome with invalid function returns the correct error
     fn call_ribosome_wrong_function() {
         let dna = test_utils::create_test_dna_with_wat("test_zome", None);
-        let (_, context) =
+        let (_instance, context) =
             test_instance_and_context(dna, None).expect("Could not initialize test instance");
 
         // Create zome function call:
@@ -323,7 +323,7 @@ pub mod tests {
     /// tests that calling the wrong zome/capability returns the correct errors
     fn call_wrong_zome_function() {
         let dna = test_utils::create_test_dna_with_wat("test_zome", None);
-        let (_, context) =
+        let (_instance, context) =
             test_instance_and_context(dna, None).expect("Could not initialize test instance");
 
         // Create bad zome function call

--- a/core/src/nucleus/ribosome/api/get_links.rs
+++ b/core/src/nucleus/ribosome/api/get_links.rs
@@ -38,6 +38,7 @@ pub fn invoke_get_links(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiRes
 
 #[cfg(test)]
 pub mod tests {
+    use crate::instance::Instance;
     use std::sync::Arc;
     use test_utils;
 
@@ -92,7 +93,7 @@ pub mod tests {
         entry_addresses
     }
 
-    fn initialize_context(netname: &str) -> Arc<Context> {
+    fn initialize_context(netname: &str) -> (Instance, Arc<Context>) {
         let wasm = test_zome_api_function_wasm(ZomeApiFunction::GetLinks.as_str());
         let dna = test_utils::create_test_dna_with_wasm(&test_zome_name(), wasm.clone());
 
@@ -100,7 +101,8 @@ pub mod tests {
         let instance = test_instance(dna, netname).expect("Could not create test instance");
 
         let (context, _) = test_context_and_logger("joan", netname);
-        instance.initialize_context(context)
+        let arc_context = instance.initialize_context(context);
+        (instance, arc_context)
     }
 
     fn add_links(initialized_context: Arc<Context>, links: Vec<Link>) {
@@ -129,7 +131,7 @@ pub mod tests {
     #[test]
     fn returns_list_of_links() {
         // setup the instance and links
-        let initialized_context = initialize_context("returns_list_of_links");
+        let (_instance, initialized_context) = initialize_context("returns_list_of_links");
         let entry_addresses = add_test_entries(initialized_context.clone());
         let links = vec![
             Link::new(
@@ -177,7 +179,7 @@ pub mod tests {
 
     #[test]
     fn get_links_with_non_existent_type_returns_nothing() {
-        let initialized_context =
+        let (_instance, initialized_context) =
             initialize_context("get_links_with_non_existent_type_returns_nothing");
         let entry_addresses = add_test_entries(initialized_context.clone());
         let links = vec![
@@ -214,7 +216,7 @@ pub mod tests {
 
     #[test]
     fn get_links_with_non_existent_tag_returns_nothing() {
-        let initialized_context =
+        let (_instance, initialized_context) =
             initialize_context("get_links_with_non_existent_tag_returns_nothing");
         let entry_addresses = add_test_entries(initialized_context.clone());
         let links = vec![
@@ -252,7 +254,8 @@ pub mod tests {
     #[test]
     fn can_get_all_links_of_any_tag_or_type() {
         // setup the instance and links
-        let initialized_context = initialize_context("can_get_all_links_of_any_tag_or_type");
+        let (_instance, initialized_context) =
+            initialize_context("can_get_all_links_of_any_tag_or_type");
         let entry_addresses = add_test_entries(initialized_context.clone());
         let links = vec![
             Link::new(
@@ -294,7 +297,7 @@ pub mod tests {
 
     #[test]
     fn get_links_with_exact_tag_match_returns_only_that_link() {
-        let initialized_context =
+        let (_instance, initialized_context) =
             initialize_context("get_links_with_exact_tag_match_returns_only_that");
         let entry_addresses = add_test_entries(initialized_context.clone());
         let links = vec![
@@ -330,7 +333,8 @@ pub mod tests {
 
     #[test]
     fn test_with_same_target_and_tag_dedup() {
-        let initialized_context = initialize_context("test_with_same_target_and_tag_dedup");
+        let (_instance, initialized_context) =
+            initialize_context("test_with_same_target_and_tag_dedup");
         let entry_addresses = add_test_entries(initialized_context.clone());
         // links have same tag, same base and same tag. Are the same
         let links = vec![
@@ -365,7 +369,7 @@ pub mod tests {
 
     #[test]
     fn test_with_same_target_different_tag_dont_dedup() {
-        let initialized_context =
+        let (_instance, initialized_context) =
             initialize_context("test_with_same_target_different_tag_dont_dedup");
         let entry_addresses = add_test_entries(initialized_context.clone());
         // same target and type, different tag

--- a/core/src/nucleus/ribosome/api/link_entries.rs
+++ b/core/src/nucleus/ribosome/api/link_entries.rs
@@ -138,7 +138,8 @@ pub mod tests {
 
     #[test]
     fn returns_ok_if_base_is_present() {
-        let (_, context) = create_test_instance_with_name(Some("returns_ok_if_base_present"));
+        let (_instance, context) =
+            create_test_instance_with_name(Some("returns_ok_if_base_present"));
 
         context
             .block_on(commit_entry(test_entry(), None, &context))
@@ -161,7 +162,7 @@ pub mod tests {
 
     #[test]
     fn errors_with_wrong_type() {
-        let (_, context) = create_test_instance();
+        let (_instance, context) = create_test_instance();
 
         context
             .block_on(commit_entry(test_entry(), None, &context))
@@ -181,7 +182,7 @@ pub mod tests {
 
     #[test]
     fn works_with_linked_from_defined_link() {
-        let (_, context) = create_test_instance();
+        let (_instance, context) = create_test_instance();
 
         context
             .block_on(commit_entry(test_entry(), None, &context))
@@ -209,7 +210,7 @@ pub mod tests {
 
     #[test]
     fn test_different_tags_produces_different_hashes() {
-        let (_, context) = create_test_instance();
+        let (_instance, context) = create_test_instance();
 
         context
             .block_on(commit_entry(test_entry(), None, &context))

--- a/core/src/nucleus/ribosome/api/mod.rs
+++ b/core/src/nucleus/ribosome/api/mod.rs
@@ -352,7 +352,7 @@ pub mod tests {
         let wasm = test_zome_api_function_wasm(canonical_name);
         let dna = test_utils::create_test_dna_with_wasm(&test_zome_name(), wasm.clone());
 
-        let (_, context) =
+        let (_instance, context) =
             test_instance_and_context(dna, None).expect("Could not create test instance");
 
         let call_result = test_zome_api_function_call(context.clone(), args_bytes);

--- a/core/src/nucleus/validation/mod.rs
+++ b/core/src/nucleus/validation/mod.rs
@@ -35,7 +35,7 @@ pub enum ValidationError {
     NotImplemented,
 
     /// An error occurred that is out of the scope of validation (no state?, I/O errors..)
-    Error(String),
+    Error(HolochainError),
 }
 
 /// Result of validating an entry.
@@ -53,7 +53,7 @@ impl From<ValidationError> for HolochainError {
             ValidationError::NotImplemented => {
                 HolochainError::NotImplemented("Validation not implemented".to_string())
             }
-            ValidationError::Error(e) => HolochainError::ErrorGeneric(e),
+            ValidationError::Error(e) => e,
         }
     }
 }

--- a/core_types/src/error/mod.rs
+++ b/core_types/src/error/mod.rs
@@ -104,6 +104,7 @@ pub enum HolochainError {
     ConfigError(String),
     Timeout,
     InitializationFailed(String),
+    LifecycleError(String),
     DnaHashMismatch(HashString, HashString),
 }
 
@@ -137,6 +138,7 @@ impl fmt::Display for HolochainError {
             ConfigError(err_msg) => write!(f, "{}", err_msg),
             Timeout => write!(f, "timeout"),
             InitializationFailed(err_msg) => write!(f, "{}", err_msg),
+            LifecycleError(err_msg) => write!(f, "{}", err_msg),
             DnaHashMismatch(hash1, hash2) => write!(
                 f,
                 "Provided DNA hash does not match actual DNA hash! {} != {}",

--- a/core_types/src/error/ribosome_error.rs
+++ b/core_types/src/error/ribosome_error.rs
@@ -202,6 +202,7 @@ impl From<HolochainError> for RibosomeErrorCode {
             HolochainError::ConfigError(_) => RibosomeErrorCode::Unspecified,
             HolochainError::Timeout => RibosomeErrorCode::Unspecified,
             HolochainError::InitializationFailed(_) => RibosomeErrorCode::Unspecified,
+            HolochainError::LifecycleError(_) => RibosomeErrorCode::Unspecified,
             HolochainError::DnaHashMismatch(_, _) => RibosomeErrorCode::Unspecified,
         }
     }

--- a/core_types/src/lib.rs
+++ b/core_types/src/lib.rs
@@ -53,6 +53,7 @@ pub mod json;
 pub mod link;
 pub mod signature;
 pub mod time;
+pub mod ugly;
 pub mod validation;
 
 pub const GIT_HASH: &str = env!(

--- a/core_types/src/ugly.rs
+++ b/core_types/src/ugly.rs
@@ -1,0 +1,23 @@
+use std::fmt::Debug;
+
+use std::sync::mpsc::{Sender, SyncSender};
+
+pub fn lax_send<T: Clone + Debug>(tx: Sender<T>, val: T, failure_reason: &str) -> bool {
+    match tx.send(val.clone()) {
+        Ok(()) => true,
+        Err(_) => {
+            println!("[MEMLEAK] {} {:?}", failure_reason, val);
+            false
+        }
+    }
+}
+
+pub fn lax_send_sync<T: Clone + Debug>(tx: SyncSender<T>, val: T, failure_reason: &str) -> bool {
+    match tx.send(val.clone()) {
+        Ok(()) => true,
+        Err(_) => {
+            println!("[MEMLEAK] {} {:?}", failure_reason, val);
+            false
+        }
+    }
+}

--- a/core_types/src/ugly.rs
+++ b/core_types/src/ugly.rs
@@ -2,21 +2,21 @@ use std::fmt::Debug;
 
 use std::sync::mpsc::{Sender, SyncSender};
 
-pub fn lax_send<T: Clone + Debug>(tx: Sender<T>, val: T, failure_reason: &str) -> bool {
+pub fn lax_send<T: Clone + Debug>(tx: Sender<T>, val: T, _failure_reason: &str) -> bool {
     match tx.send(val.clone()) {
         Ok(()) => true,
         Err(_) => {
-            println!("[MEMLEAK] {} {:?}", failure_reason, val);
+            // println!("[lax_send]\n{}\n{:?}\n", _failure_reason, val);
             false
         }
     }
 }
 
-pub fn lax_send_sync<T: Clone + Debug>(tx: SyncSender<T>, val: T, failure_reason: &str) -> bool {
+pub fn lax_send_sync<T: Clone + Debug>(tx: SyncSender<T>, val: T, _failure_reason: &str) -> bool {
     match tx.send(val.clone()) {
         Ok(()) => true,
         Err(_) => {
-            println!("[MEMLEAK] {} {:?}", failure_reason, val);
+            // println!("[lax_send_sync]\n{}\n{:?}\n", _failure_reason, val);
             false
         }
     }

--- a/nodejs_conductor/native/src/js_test_conductor.rs
+++ b/nodejs_conductor/native/src/js_test_conductor.rs
@@ -160,7 +160,7 @@ declare_types! {
                     .expect(&format!("No instance with id: {}", instance_id));
                 let mut instance = instance_arc.write().unwrap();
                 let cap = {
-                    let context = instance.context();
+                    let context = instance.context().expect("Instance context not initialized");
                     let token = context.get_public_token().unwrap();
                     make_cap_request_for_call(
                         context.clone(),
@@ -224,7 +224,8 @@ declare_types! {
                 let instance = tc.conductor.instances().get(&instance_id)
                     .expect(&format!("No instance with id: {}", instance_id))
                     .read().unwrap();
-                let out = instance.context().state().ok_or("No state?".to_string())
+                let context = instance.context().expect("instance not initialized");
+                let out = context.state().ok_or("No state?".to_string())
                     .and_then(|state| state
                         .agent().get_agent_address()
                         .map_err(|e| e.to_string()));
@@ -252,7 +253,8 @@ declare_types! {
                 let instance = tc.conductor.instances().get(&instance_id)
                     .expect(&format!("No instance with id: {}", instance_id))
                     .read().unwrap();
-                let out = instance.context().state().ok_or("No state?".to_string())
+                let context = instance.context().expect("instance not initialized.");
+                let out = context.state().ok_or("No state?".to_string())
                     .and_then(|state| state
                         .nucleus()
                         .dna


### PR DESCRIPTION
## PR summary

Based on #1494. This fixes the hanging tests, as well as adding a new type of error which will prevent further hangs.

Add a `HolochainError::LifecycleError`, for use when invariants around lifecycle dependencies are unmet, e.g. when a component `send`s on a closed action channel because the instance has shut down. 

We have many Futures which dispatch actions on one thread and then wait on another thread for the action to be reduced before resolving. If the action was never dispatched, then the future will hang forever. To solve this, we check if the action channel is still open on every Poll, and if not raise a `LifecycleError`.

This alone wasn't necessary to make the tests in #1494 stop hanging, but it helped diagnose the problem, and seems useful. What really made the tests stop hanging is to bind the Instance created in various `create_test_instance` type functions to an actual value, rather than throwing it away, causing it to immediately be dropped and hence its action channel killed.

## testing/benchmarking notes

Let's make sure that the extra `Ping` actions don't clog up the works. They should be very light-weight. May have to increase the Future polling interval if not.

## followups

Ø

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [X] this is not a code change, or doesn't effect anyone outside holochain core development
