### PR TITLE
WIP - HDK standardization

### DIFF
--- a/core_types/src/link/mod.rs
+++ b/core_types/src/link/mod.rs
@@ -72,7 +72,7 @@ pub enum LinkMatch<S: Into<String>> {
     Exactly(S),
     Regex(S),
 }
-
+ 
 impl<S: Into<String>> LinkMatch<S> {
     pub fn to_regex_string(self) -> Result<String, String> {
         let re_string: String = match self {
@@ -85,6 +85,12 @@ impl<S: Into<String>> LinkMatch<S> {
             Ok(_) => Ok(re_string),
             Err(_) => Err("Invalid regex passed to get_links".into()),
         }
+    }
+}
+
+impl From<LinkMatch<&str>> for LinkMatch<String> {
+    fn from(l: LinkMatch<&str>) -> Self {
+        l.into()
     }
 }
 

--- a/hdk-rust/src/api/call.rs
+++ b/hdk-rust/src/api/call.rs
@@ -218,17 +218,17 @@ use holochain_wasm_utils::api_serialization::ZomeFnCallArgs;
 ///
 /// # }
 /// ```
-pub fn call<S: Into<String>>(
-    instance_handle: S,
-    zome_name: S,
-    cap_token: Address,
-    fn_name: S,
-    fn_args: JsonString,
+pub fn call<S1: Into<String>, S2: Into<String>, S3: Into<String>>(
+    instance_handle: S1,
+    zome_name: S2,
+    cap_token: &Address,
+    fn_name: S3,
+    fn_args: &JsonString,
 ) -> ZomeApiResult<JsonString> {
     Dispatch::Call.with_input(ZomeFnCallArgs {
         instance_handle: instance_handle.into(),
         zome_name: zome_name.into(),
-        cap_token,
+        cap_token: cap_token.to_owned(),
         fn_name: fn_name.into(),
         fn_args: String::from(fn_args),
     })

--- a/hdk-rust/src/api/capability.rs
+++ b/hdk-rust/src/api/capability.rs
@@ -11,27 +11,27 @@ use holochain_wasm_utils::api_serialization::capabilities::{
 /// Adds a capability grant to the local chain
 pub fn commit_capability_grant<S: Into<String>>(
     id: S,
-    cap_type: CapabilityType,
-    assignees: Option<Vec<Address>>,
-    functions: CapFunctions,
+    cap_type: &CapabilityType,
+    assignees: Option<&[Address]>,
+    functions: &CapFunctions,
 ) -> ZomeApiResult<Address> {
     Dispatch::CommitCapabilityGrant.with_input(CommitCapabilityGrantArgs {
         id: id.into(),
-        cap_type,
-        assignees,
-        functions,
+        cap_type: cap_type.to_owned(),
+        assignees: assignees.map(|v| Vec::from(v)),
+        functions: functions.to_owned(),
     })
 }
 
 /// Adds a capability claim to the local chain
 pub fn commit_capability_claim<S: Into<String>>(
     id: S,
-    grantor: Address,
-    token: Address,
+    grantor: &Address,
+    token: &Address,
 ) -> ZomeApiResult<Address> {
     Dispatch::CommitCapabilityClaim.with_input(CommitCapabilityClaimArgs {
         id: id.into(),
-        grantor,
-        token,
+        grantor: grantor.to_owned(),
+        token: token.to_owned(),
     })
 }

--- a/hdk-rust/src/api/commit_entry.rs
+++ b/hdk-rust/src/api/commit_entry.rs
@@ -54,7 +54,7 @@ use holochain_wasm_utils::api_serialization::commit_entry::{
 /// # }
 /// ```
 pub fn commit_entry(entry: &Entry) -> ZomeApiResult<Address> {
-    commit_entry_result(entry, CommitEntryOptions::default()).map(|result| result.address())
+    commit_entry_result(entry, &CommitEntryOptions::default()).map(|result| result.address())
 }
 
 /// Attempts to commit an entry to your local source chain. The entry
@@ -65,10 +65,10 @@ pub fn commit_entry(entry: &Entry) -> ZomeApiResult<Address> {
 /// Returns a CommitEntryResult which contains the address of the committed entry.
 pub fn commit_entry_result(
     entry: &Entry,
-    options: CommitEntryOptions,
+    options: &CommitEntryOptions,
 ) -> ZomeApiResult<CommitEntryResult> {
     Dispatch::CommitEntry.with_input(CommitEntryArgs {
         entry: entry.clone(),
-        options,
+        options: options.to_owned(),
     })
 }

--- a/hdk-rust/src/api/get_entry.rs
+++ b/hdk-rust/src/api/get_entry.rs
@@ -32,7 +32,7 @@ use holochain_wasm_utils::api_serialization::get_entry::{
 /// # }
 /// ```
 pub fn get_entry(address: &Address) -> ZomeApiResult<Option<Entry>> {
-    let entry_result = get_entry_result(address, GetEntryOptions::default())?;
+    let entry_result = get_entry_result(address, &GetEntryOptions::default())?;
 
     let entry = if !entry_result.found() {
         None
@@ -48,7 +48,7 @@ pub fn get_entry(address: &Address) -> ZomeApiResult<Option<Entry>> {
 pub fn get_entry_initial(address: &Address) -> ZomeApiResult<Option<Entry>> {
     let entry_result = get_entry_result(
         address,
-        GetEntryOptions::new(StatusRequestKind::Initial, true, false, Default::default()),
+        &GetEntryOptions::new(StatusRequestKind::Initial, true, false, Default::default()),
     )?;
     Ok(entry_result.latest())
 }
@@ -59,7 +59,7 @@ pub fn get_entry_initial(address: &Address) -> ZomeApiResult<Option<Entry>> {
 pub fn get_entry_history(address: &Address) -> ZomeApiResult<Option<EntryHistory>> {
     let entry_result = get_entry_result(
         address,
-        GetEntryOptions::new(StatusRequestKind::All, true, false, Default::default()),
+        &GetEntryOptions::new(StatusRequestKind::All, true, false, Default::default()),
     )?;
     if !entry_result.found() {
         return Ok(None);
@@ -75,10 +75,10 @@ pub fn get_entry_history(address: &Address) -> ZomeApiResult<Option<EntryHistory
 /// The data returned is configurable with the GetEntryOptions argument.
 pub fn get_entry_result(
     address: &Address,
-    options: GetEntryOptions,
+    options: &GetEntryOptions,
 ) -> ZomeApiResult<GetEntryResult> {
     Dispatch::GetEntry.with_input(GetEntryArgs {
         address: address.clone(),
-        options,
+        options: options.to_owned(),
     })
 }

--- a/hdk-rust/src/api/get_links.rs
+++ b/hdk-rust/src/api/get_links.rs
@@ -35,14 +35,14 @@ use holochain_wasm_utils::api_serialization::{
 /// }
 /// # }
 /// ```
-pub fn get_links_with_options<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String>>>(
+pub fn get_links_with_options(
     base: &Address,
-    link_type: T1,
-    tag: T2,
+    link_type: LinkMatch<&str>,
+    tag: LinkMatch<&str>,
     options: &GetLinksOptions,
 ) -> ZomeApiResult<GetLinksResult> {
-    let type_re = link_type.into().to_regex_string()?;
-    let tag_re = tag.into().to_regex_string()?;
+    let type_re = link_type.to_regex_string()?;
+    let tag_re = tag.to_regex_string()?;
 
     Dispatch::GetLinks.with_input(GetLinksArgs {
         entry_address: base.clone(),
@@ -53,10 +53,10 @@ pub fn get_links_with_options<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<St
 }
 
 /// Helper function for get_links. Returns a vector with the default return results.
-pub fn get_links<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String>>>(
+pub fn get_links(
     base: &Address,
-    link_type: T1,
-    tag: T2,
+    link_type: LinkMatch<&str>,
+    tag: LinkMatch<&str>,
 ) -> ZomeApiResult<GetLinksResult> {
     get_links_with_options(
         base,
@@ -87,10 +87,10 @@ pub fn get_links<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String>>>(
 /// }
 /// # }
 /// ```
-pub fn get_links_result<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String>>>(
+pub fn get_links_result(
     base: &Address,
-    link_type: T1,
-    tag: T2,
+    link_type: LinkMatch<&str>,
+    tag: LinkMatch<&str>,
     options: &GetLinksOptions,
     get_entry_options: &GetEntryOptions,
 ) -> ZomeApiResult<Vec<ZomeApiResult<GetEntryResult>>> {
@@ -104,10 +104,10 @@ pub fn get_links_result<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String>>
 }
 
 /// Helper function for get_links. Returns a vector of the entries themselves
-pub fn get_links_and_load<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String>>>(
+pub fn get_links_and_load(
     base: &Address,
-    link_type: T1,
-    tag: T2,
+    link_type: LinkMatch<&str>,
+    tag: LinkMatch<&str>,
 ) -> ZomeApiResult<Vec<ZomeApiResult<Entry>>> {
     let get_links_result = get_links_result(
         base,
@@ -130,19 +130,4 @@ pub fn get_links_and_load<T1: Into<LinkMatch<String>>, T2: Into<LinkMatch<String
     .collect();
 
     Ok(entries)
-}
-
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-    use holochain_core_types::{
-        link::LinkMatch,
-    };
-
-    #[test]
-    fn can_call_with_string_variations() {
-        get_links(&Address::from("x"), LinkMatch::Exactly(""), LinkMatch::Any);
-    }
-
 }

--- a/hdk-rust/src/api/keystore.rs
+++ b/hdk-rust/src/api/keystore.rs
@@ -24,13 +24,13 @@ pub fn keystore_derive_seed<S: Into<String>>(
     src_id: S,
     dst_id: S,
     context: S,
-    index: u64,
+    index: &u64,
 ) -> ZomeApiResult<()> {
     Dispatch::KeystoreDeriveSeed.with_input(KeystoreDeriveSeedArgs {
         src_id: src_id.into(),
         dst_id: dst_id.into(),
         context: context.into(),
-        index,
+        index: index.to_owned(),
     })
 }
 
@@ -39,12 +39,12 @@ pub fn keystore_derive_seed<S: Into<String>>(
 pub fn keystore_derive_key<S: Into<String>>(
     src_id: S,
     dst_id: S,
-    key_type: KeyType,
+    key_type: &KeyType,
 ) -> ZomeApiResult<String> {
     Dispatch::KeystoreDeriveKey.with_input(KeystoreDeriveKeyArgs {
         src_id: src_id.into(),
         dst_id: dst_id.into(),
-        key_type,
+        key_type: key_type.to_owned(),
     })
 }
 

--- a/hdk-rust/src/api/link_entries.rs
+++ b/hdk-rust/src/api/link_entries.rs
@@ -69,11 +69,11 @@ use holochain_wasm_utils::api_serialization::link_entries::LinkEntriesArgs;
 /// }
 /// # }
 /// ```
-pub fn link_entries<S: Into<String>>(
+pub fn link_entries<S1: Into<String>, S2: Into<String>>(
     base: &Address,
     target: &Address,
-    link_type: S,
-    tag: S,
+    link_type: S1,
+    tag: S2,
 ) -> Result<Address, ZomeApiError> {
     Dispatch::LinkEntries.with_input(LinkEntriesArgs {
         base: base.clone(),

--- a/hdk-rust/src/api/query.rs
+++ b/hdk-rust/src/api/query.rs
@@ -66,16 +66,16 @@ use holochain_wasm_utils::api_serialization::{
 /// // }
 /// ```
 pub fn query(
-    entry_type_names: QueryArgsNames,
-    start: usize,
-    limit: usize,
+    entry_type_names: &QueryArgsNames,
+    start: &usize,
+    limit: &usize,
 ) -> ZomeApiResult<Vec<Address>> {
     // The hdk::query API always returns a simple Vec<Address>
     query_result(
         entry_type_names,
-        QueryArgsOptions {
-            start,
-            limit,
+        &QueryArgsOptions {
+            start: start.to_owned(),
+            limit: limit.to_owned(),
             headers: false,
             entries: false,
         },
@@ -87,11 +87,11 @@ pub fn query(
 }
 
 pub fn query_result(
-    entry_type_names: QueryArgsNames,
-    options: QueryArgsOptions,
+    entry_type_names: &QueryArgsNames,
+    options: &QueryArgsOptions,
 ) -> ZomeApiResult<QueryResult> {
     Dispatch::Query.with_input(QueryArgs {
-        entry_type_names,
-        options,
+        entry_type_names: entry_type_names.to_owned(),
+        options: options.to_owned(),
     })
 }

--- a/hdk-rust/src/api/send.rs
+++ b/hdk-rust/src/api/send.rs
@@ -113,10 +113,10 @@ use holochain_wasm_utils::api_serialization::send::{SendArgs, SendOptions};
 ///}
 /// # }
 /// ```
-pub fn send(to_agent: Address, payload: String, timeout: Timeout) -> ZomeApiResult<String> {
+pub fn send<S: Into<String>>(to_agent: &Address, payload: S, timeout: &Timeout) -> ZomeApiResult<String> {
     Dispatch::Send.with_input(SendArgs {
-        to_agent,
-        payload,
-        options: SendOptions(timeout),
+        to_agent: to_agent.to_owned(),
+        payload: payload.into(),
+        options: SendOptions(timeout.to_owned()),
     })
 }

--- a/hdk-rust/src/api/sign.rs
+++ b/hdk-rust/src/api/sign.rs
@@ -58,13 +58,9 @@ pub fn sign<S: Into<String>>(payload: S) -> ZomeApiResult<String> {
 /// }
 /// # }
 /// ```
-pub fn sign_one_time<S: Into<String>>(payloads: Vec<S>) -> ZomeApiResult<SignOneTimeResult> {
-    let mut converted_payloads = Vec::new();
-    for p in payloads {
-        converted_payloads.push(p.into());
-    }
+pub fn sign_one_time<S: Into<String> + Clone>(payloads: &[S]) -> ZomeApiResult<SignOneTimeResult> {
     Dispatch::SignOneTime.with_input(OneTimeSignArgs {
-        payloads: converted_payloads,
+        payloads: Vec::from(payloads).into_iter().map(|s| s.into()).collect(),
     })
 }
 
@@ -90,11 +86,11 @@ pub fn sign_one_time<S: Into<String>>(payloads: Vec<S>) -> ZomeApiResult<SignOne
 /// # }
 /// ```
 pub fn verify_signature<S: Into<String>>(
-    provenance: Provenance,
+    provenance: &Provenance,
     payload: S,
 ) -> ZomeApiResult<bool> {
     Dispatch::VerifySignature.with_input(VerifySignatureArgs {
-        provenance,
+        provenance: provenance.to_owned(),
         payload: payload.into(),
     })
 }

--- a/hdk-rust/src/api/sleep.rs
+++ b/hdk-rust/src/api/sleep.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 ///
 /// # }
 /// ```
-pub fn sleep(duration: Duration) -> ZomeApiResult<()> {
+pub fn sleep(duration: &Duration) -> ZomeApiResult<()> {
     let _: ZomeApiResult<()> = Dispatch::Sleep.with_input(JsonString::from(duration.as_nanos()));
     // internally returns RibosomeEncodedValue::Success which is a zero length allocation
     // return Ok(()) unconditionally instead of the "error" from success

--- a/hdk-rust/src/api/update_remove.rs
+++ b/hdk-rust/src/api/update_remove.rs
@@ -9,10 +9,10 @@ use holochain_wasm_utils::api_serialization::UpdateEntryArgs;
 /// entry's address in the previous entry's metadata.
 /// The updated entry will hold the previous entry's address in its header,
 /// which will be used by validation routes.
-pub fn update_entry(new_entry: Entry, address: &Address) -> ZomeApiResult<Address> {
+pub fn update_entry(new_entry: &Entry, address: &Address) -> ZomeApiResult<Address> {
     Dispatch::UpdateEntry.with_input(UpdateEntryArgs {
-        new_entry,
-        address: address.clone(),
+        new_entry: new_entry.to_owned(),
+        address: address.to_owned(),
     })
 }
 

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -14,10 +14,14 @@ use std::convert::TryFrom;
 /// of a get_links_and_load for a given type. Any entries that either fail to
 /// load or cannot be converted to the type will be dropped.
 ///
-pub fn get_links_and_load_type<R: TryFrom<AppEntryValue>>(
+pub fn get_links_and_load_type<
+    R: TryFrom<AppEntryValue>,
+    T1: Into<LinkMatch<String>>,
+    T2: Into<LinkMatch<String>>,
+>(
     base: &Address,
-    link_type: LinkMatch<&str>,
-    tag: LinkMatch<&str>,
+    link_type: T1,
+    tag: T2,
 ) -> ZomeApiResult<Vec<R>> {
     let link_load_results = hdk::get_links_and_load(base, link_type, tag)?;
 
@@ -48,7 +52,7 @@ pub fn get_links_and_load_type<R: TryFrom<AppEntryValue>>(
 ///
 /// Helper function for loading an entry and converting to a given type
 ///
-pub fn get_as_type<R: TryFrom<AppEntryValue>>(address: Address) -> ZomeApiResult<R> {
+pub fn get_as_type<R: TryFrom<AppEntryValue>>(address: &Address) -> ZomeApiResult<R> {
     let get_result = hdk::get_entry(&address)?;
     let entry =
         get_result.ok_or_else(|| ZomeApiError::Internal("No entry at this address".into()))?;
@@ -66,13 +70,18 @@ pub fn get_as_type<R: TryFrom<AppEntryValue>>(address: Address) -> ZomeApiResult
 
 /// Creates two links:
 /// From A to B, and from B to A, with given link_types.
-pub fn link_entries_bidir<S: Into<String>>(
+pub fn link_entries_bidir<
+    S1: Into<String>,
+    S2: Into<String>,
+    S3: Into<String>,
+    S4: Into<String>,
+>(
     a: &Address,
     b: &Address,
-    link_type_a_b: S,
-    link_type_b_a: S,
-    link_tag_a_b: S,
-    link_tag_b_a: S,
+    link_type_a_b: S1,
+    link_type_b_a: S2,
+    link_tag_a_b: S3,
+    link_tag_b_a: S4,
 ) -> ZomeApiResult<()> {
     hdk::link_entries(a, b, link_type_a_b, link_tag_a_b)?;
     hdk::link_entries(b, a, link_type_b_a, link_tag_b_a)?;
@@ -81,11 +90,14 @@ pub fn link_entries_bidir<S: Into<String>>(
 
 /// Commits the given entry and links it from the base
 /// with the given link_type.
-pub fn commit_and_link<S: Into<String>>(
+pub fn commit_and_link<
+    S1: Into<String>,
+    S2: Into<String>,
+>(
     entry: &Entry,
     base: &Address,
-    link_type: S,
-    tag: S,
+    link_type: S1,
+    tag: S2,
 ) -> ZomeApiResult<Address> {
     let entry_addr = hdk::commit_entry(entry)?;
     hdk::link_entries(base, &entry_addr, link_type, tag)?;

--- a/hdk-rust/src/utils.rs
+++ b/hdk-rust/src/utils.rs
@@ -14,14 +14,10 @@ use std::convert::TryFrom;
 /// of a get_links_and_load for a given type. Any entries that either fail to
 /// load or cannot be converted to the type will be dropped.
 ///
-pub fn get_links_and_load_type<
-    R: TryFrom<AppEntryValue>,
-    T1: Into<LinkMatch<String>>,
-    T2: Into<LinkMatch<String>>,
->(
+pub fn get_links_and_load_type<R: TryFrom<AppEntryValue>>(
     base: &Address,
-    link_type: T1,
-    tag: T2,
+    link_type: LinkMatch<&str>,
+    tag: LinkMatch<&str>,
 ) -> ZomeApiResult<Vec<R>> {
     let link_load_results = hdk::get_links_and_load(base, link_type, tag)?;
 

--- a/wasm_utils/src/api_serialization/query.rs
+++ b/wasm_utils/src/api_serialization/query.rs
@@ -58,7 +58,7 @@ pub struct QueryArgs {
     pub options: QueryArgsOptions,
 }
 
-#[derive(Deserialize, Default, Debug, Serialize, DefaultJson)]
+#[derive(Deserialize, Default, Debug, Serialize, DefaultJson, Clone)]
 pub struct QueryArgsOptions {
     pub start: usize,
     pub limit: usize,


### PR DESCRIPTION
## PR summary

Response to #1499 

The HDK functions were somewhat inconsistent (e.g. functions take ownership or take reference pretty much randomly). This is the start of some proposed changes to the HDK functions. Ideally we should adhere to [this checklist](https://rust-lang-nursery.github.io/api-guidelines/checklist.html)

Only changes to the HDK itself are included for the moment. Once we have fully agreed on the API then I will make the changes to the app spec etc.

TODOs:

- [ ] functions are consistent and always accept references
- [ ] functions don't accept String or Vec but rather use slices (&[<type>]) (or Into<String>) to allow flexibility of calling code
- [ ] Iterators are returned rather than Vecs
- [ ] `get_links_load` variations return the address as well as the entry
