### PR TITLE
reinstate check-artifacts for core

### DIFF
--- a/release/github/default.nix
+++ b/release/github/default.nix
@@ -6,10 +6,15 @@ let
   github = config;
   release = release;
  };
+
+ check-artifacts = pkgs.callPackage ./nix/check-artifacts.nix {
+  release = release;
+ };
 in
 {
  config = config;
  buildInputs = [
   merge
+  check-artifacts
  ];
 }

--- a/release/github/nix/check-artifacts.nix
+++ b/release/github/nix/check-artifacts.nix
@@ -1,0 +1,32 @@
+{ pkgs, release }:
+let
+
+  name = "hc-release-github-check-artifacts";
+
+  script = pkgs.writeShellScriptBin name
+  ''
+  echo
+  echo "Checking core artifacts"
+  echo
+
+  echo
+  echo "checking ${release.tag}"
+  echo
+
+  core_binaries=( "cli" "conductor" )
+  core_platforms=( "apple-darwin" "pc-windows-gnu" "pc-windows-msvc" "unknown-linux-gnu" )
+
+  for binary in "''${core_binaries[@]}"; do for platform in "''${core_platforms[@]}"; do file="$binary-${release.tag}-x86_64-$platform.tar.gz"
+    url="https://github.com/holochain/holochain-rust/releases/download/${release.tag}/$file"
+    echo
+    echo "pinging $file for release $release..."
+    if curl -Is "$url" | grep -q "HTTP/1.1 302 Found"
+     then echo "FOUND ✔"
+     else echo "NOT FOUND ⨯"
+    fi
+    echo
+   done
+  done
+  '';
+in
+script


### PR DESCRIPTION
## PR summary

brings artifact checking back to core in a simplified form

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
