### PR TITLE
Add stress test with 10 agents

### DIFF
--- a/app_spec/test/index.js
+++ b/app_spec/test/index.js
@@ -11,7 +11,7 @@ process.on('unhandledRejection', error => {
 const dnaPath = path.join(__dirname, "../dist/app_spec.dna.json")
 const dna = Diorama.dna(dnaPath, 'app-spec')
 
-const diorama = new Diorama({
+const dioramaMain = new Diorama({
   instances: {
     alice: dna,
     bob: dna,
@@ -25,7 +25,26 @@ const diorama = new Diorama({
   middleware: backwardCompatibilityMiddleware,
 })
 
-require('./regressions')(diorama.registerScenario)
-require('./test')(diorama.registerScenario)
+const numInstances = 10
+const manyInstances = {}
+for (let i = 0; i < numInstances; i++) {
+  manyInstances['Agent ' + i] = dna
+}
 
-diorama.run()
+const dioramaMany = new Diorama({
+  instances: manyInstances,
+  debugLog: true,
+  executor: tapeExecutor(require('tape')),
+})
+
+require('./regressions')(dioramaMain.registerScenario)
+require('./test')(dioramaMain.registerScenario)
+
+require('./many-agent-tests')(dioramaMany.registerScenario)
+
+const run = async () => {
+  await dioramaMain.run()
+  await dioramaMany.run()
+}
+
+run()

--- a/app_spec/test/many-agent-tests.js
+++ b/app_spec/test/many-agent-tests.js
@@ -1,0 +1,28 @@
+module.exports = scenario => {
+
+
+scenario('can run a test with many agents', async (s, t, instanceMap) => {
+  const nodes = Object.values(instanceMap)
+  const anchor = nodes[0]
+
+  t.ok(anchor.agentAddress)
+
+  for (const [name, node] of Object.entries(nodes)) {
+    await node.call('simple', 'create_link', {
+      base: anchor.agentAddress,
+      target: node.agentAddress,
+    })
+  }
+  await s.consistent()
+  const links = await anchor.call('simple', 'get_my_links', {
+    base: anchor.agentAddress,
+  })
+
+  console.log('linx', links.Ok.links)
+
+  t.ok(links.Ok)
+  t.equal(Object.values(links.Ok.links).length, nodes.length)
+})
+
+
+}

--- a/app_spec/zomes/simple/code/src/lib.rs
+++ b/app_spec/zomes/simple/code/src/lib.rs
@@ -10,35 +10,29 @@ extern crate holochain_core_types_derive;
 use hdk::{
     entry_definition::ValidatingEntryType,
     error::ZomeApiResult,
-};
-use hdk::holochain_core_types::{
-    cas::content::Address,
-    dna::entry_types::Sharing,
-    error::HolochainError,
-    json::JsonString,
-    entry::Entry,
-    link::LinkMatch,
-    hash::HashString
+    holochain_core_types::{
+        cas::content::Address, dna::entry_types::Sharing, entry::Entry, error::HolochainError,
+        hash::HashString, json::JsonString, link::LinkMatch,
+    },
 };
 
-use hdk::holochain_wasm_utils::api_serialization::get_links::{GetLinksResult,LinksStatusRequestKind,GetLinksOptions};
-
+use hdk::holochain_wasm_utils::api_serialization::get_links::{
+    GetLinksOptions, GetLinksResult, LinksStatusRequestKind,
+};
 
 // see https://developer.holochain.org/api/0.0.18-alpha1/hdk/ for info on using the hdk library
 
 // This is a sample zome that defines an entry type "MyEntry" that can be committed to the
 // agent's chain via the exposed function create_my_entry
 
-#[derive(Serialize, Deserialize, Debug, DefaultJson,Clone)]
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
 pub struct Simple {
     content: String,
 }
 
-impl Simple 
-{
-    pub fn new(content:String) -> Simple
-    {
-        Simple{content}
+impl Simple {
+    pub fn new(content: String) -> Simple {
+        Simple { content }
     }
 }
 
@@ -46,27 +40,32 @@ fn simple_entry(content: String) -> Entry {
     Entry::App("simple".into(), Simple::new(content).into())
 }
 
-
-pub fn handle_create_my_link(base: Address,target : String) -> ZomeApiResult<()> {
+pub fn handle_create_my_link(base: Address, target: String) -> ZomeApiResult<()> {
     let address = hdk::commit_entry(&simple_entry(target))?;
     hdk::link_entries(&base, &HashString::from(address), "authored_posts", "")?;
     Ok(())
 }
 
-pub fn handle_delete_my_link(base: Address,target : String) -> ZomeApiResult<()> {
+pub fn handle_delete_my_link(base: Address, target: String) -> ZomeApiResult<()> {
     let address = hdk::entry_address(&simple_entry(target))?;
     hdk::remove_link(&base, &HashString::from(address), "authored_posts", "")?;
     Ok(())
 }
 
-
-pub fn handle_get_my_links(agent : Address,status_request:Option<LinksStatusRequestKind>) ->ZomeApiResult<GetLinksResult>
-{
-    let options = GetLinksOptions{
-        status_request : status_request.unwrap_or(LinksStatusRequestKind::All),
+pub fn handle_get_my_links(
+    agent: Address,
+    status_request: Option<LinksStatusRequestKind>,
+) -> ZomeApiResult<GetLinksResult> {
+    let options = GetLinksOptions {
+        status_request: status_request.unwrap_or(LinksStatusRequestKind::All),
         ..GetLinksOptions::default()
     };
-    hdk::get_links_with_options(&agent, LinkMatch::Exactly("authored_posts"), LinkMatch::Any,options)
+    hdk::get_links_with_options(
+        &agent,
+        LinkMatch::Exactly("authored_posts"),
+        LinkMatch::Any,
+        options,
+    )
 }
 
 pub fn definition() -> ValidatingEntryType {
@@ -94,7 +93,7 @@ pub fn definition() -> ValidatingEntryType {
                     Ok(())
                 }
             )]
-        
+
     )
 }
 
@@ -108,7 +107,7 @@ define_zome! {
         Ok(())
     }
 
-  
+
 
     functions: [
 
@@ -133,4 +132,3 @@ define_zome! {
         hc_public [create_link,delete_link,get_my_links]
     }
 }
-


### PR DESCRIPTION
## PR summary

Adds simple Diorama scenario where 10 nodes are created, one is singled out as an anchor, and every node places a link on that anchor. Then the anchor attempts to retrieve all links and verify that there are 10 of them.

This test is flaky. Usually one of the zome function calls simply hangs up and never returns, though I have also seen a case where the zome calls do return, but the hachiko waiter never receives all the signals it needs to proceed.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
