### PR TITLE
Diorama scaffold tests

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Crud Status` information to link data in get_links as well as query through `LinkStatusRequest` [#1337](https://github.com/holochain/holochain-rust/pull/1337)
 
 ### Changed
+- The barebones tests produced by `hc init` now use the Diorama testing framework rather than holochain-nodejs [#1532](https://github.com/holochain/holochain-rust/pull/1532)
 
 ### Deprecated
 

--- a/cli/src/cli/js-tests-scaffold/index.js
+++ b/cli/src/cli/js-tests-scaffold/index.js
@@ -22,11 +22,11 @@ const diorama = new Diorama({
   middleware: backwardCompatibilityMiddleware,
 })
 
-diorama.registerScenario.runTape("description of example test", async (s, t, { alice }) => {
+diorama.registerScenario("description of example test", async (s, t, { alice }) => {
   // Make a call to a Zome function
   // indicating the function, and passing it an input
-  const addr = alice.call("my_zome", "create_my_entry", {"entry" : {"content":"sample content"}})
-  const result = alice.call("my_zome", "get_my_entry", {"address": addr.Ok})
+  const addr = await alice.call("my_zome", "create_my_entry", {"entry" : {"content":"sample content"}})
+  const result = await alice.call("my_zome", "get_my_entry", {"address": addr.Ok})
 
   // check for equality of the actual and expected results
   t.deepEqual(result, { Ok: { App: [ 'my_entry', '{"content":"sample content"}' ] } })

--- a/cli/src/cli/js-tests-scaffold/package.json
+++ b/cli/src/cli/js-tests-scaffold/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {},
   "dependencies": {
-    "@holochain/diorama": "^0.1.1",
+    "@holochain/diorama": "^0.1.2",
     "faucet": "0.0.1",
     "json3": "*",
     "sleep": "^5.2.3",

--- a/cli/src/cli/js-tests-scaffold/package.json
+++ b/cli/src/cli/js-tests-scaffold/package.json
@@ -1,7 +1,10 @@
 {
+  "devDependencies": {},
   "dependencies": {
-    "@holochain/holochain-nodejs": "0.4.18-alpha1",
+    "@holochain/diorama": "^0.1.1",
+    "faucet": "0.0.1",
     "json3": "*",
+    "sleep": "^5.2.3",
     "tape": "^4.9.1"
   }
 }

--- a/cli/src/cli/scaffold/rust/lib.rs
+++ b/cli/src/cli/scaffold/rust/lib.rs
@@ -18,7 +18,6 @@ use hdk::holochain_core_types::{
     dna::entry_types::Sharing,
     error::HolochainError,
     json::JsonString,
-    validation::EntryValidationData
 };
 
 // see https://developer.holochain.org/api/0.0.20-alpha3/hdk/ for info on using the hdk library


### PR DESCRIPTION
## PR summary

Another little one. Changes the test skeleton produced by `hc init` to use diorama.js instead of holochain-nodejs.

Running
```
hc init test_dna
cd test_dna/zomes && hc generate my_zome && cd ..
hc test
```
results in tests running and passing using diorama.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
