### PR TITLE
cleanup of wrong crate names in docs

### DIFF
--- a/core_types/src/lib.rs
+++ b/core_types/src/lib.rs
@@ -3,10 +3,6 @@
 //! The reason for having this crate is to have a minimal but
 //! complete set of types that are used in most other Holochain
 //! crates, but that don't include Holochain itself.
-//!
-//! Note: This is already quite big. Maybe break the CAS and EAV traits
-//! out into their separate crate as well since those are generic and not
-//! necessarily bound to Holochain.
 #![feature(try_from)]
 #![feature(try_trait)]
 #![feature(never_type)]

--- a/doc/holochain_101/src/first_steps.md
+++ b/doc/holochain_101/src/first_steps.md
@@ -123,7 +123,7 @@ extern crate hdk;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
-extern crate lib3h_persistence_derive;
+extern crate holochain_persistence_derive;
 use hdk::{
     error::ZomeApiResult,
     holochain_core_types::{
@@ -288,7 +288,7 @@ extern crate hdk;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
-extern crate lib3h_persistence_derive;
+extern crate holochain_persistence_derive;
 
 use hdk::{
     error::ZomeApiResult,

--- a/doc/holochain_101/src/json_string.md
+++ b/doc/holochain_101/src/json_string.md
@@ -342,7 +342,7 @@ important edge cases that we need to cover with additional techniques/tooling.
 `JsonString::from_json(&str)` requires the `&str` passed to it is already a
 serialized JSON value. We may add the option to validate this for debug builds at runtime in the future.
 
-Previously `JsonString` implemented the `From<String>` trait but this was removed. Strings are a special case as they may either contain serialized json or be used as a JSON string primitive. `JsonString::from_json` makes it explicit that you mean the former. 
+Previously `JsonString` implemented the `From<String>` trait but this was removed. Strings are a special case as they may either contain serialized json or be used as a JSON string primitive. `JsonString::from_json` makes it explicit that you mean the former.
 
 We can use `serde_json::to_string` and `json!` to create JSON data that we can
 then wrap in `JsonString`.
@@ -520,7 +520,7 @@ impl TryFrom<JsonString> for MyType {
 #### Automatic derive
 
 The standard boilerplate has been implemented as a derive macro in the
-`lib3h_persistence_derive` crate.
+`holochain_persistence_derive` crate.
 
 Simply `#[derive(DefaultJson)]` to add the above boilerplate plus some extra
 conveniences (e.g. for references) to your type.
@@ -532,7 +532,7 @@ conveniences (e.g. for references) to your type.
 - `MyType` implements `Serialize`, `Deserialize` and `Debug` from serde/std
 
 ```rust
-use lib3h_persistence_api::json::JsonString;
+use holochain_persistence_api::json::JsonString;
 use holochain_core_types::error::HolochainError;
 
 #[derive(Serialize, Deserialize, Debug, DefaultJson)]

--- a/doc/holochain_101/src/zome/entry_type_definitions.md
+++ b/doc/holochain_101/src/zome/entry_type_definitions.md
@@ -119,7 +119,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
-extern crate lib3h_persistence_derive;
+extern crate holochain_persistence_derive;
 
 #[derive(Serialize, Deserialize, Debug, DefaultJson,Clone)]
 struct Post {
@@ -152,7 +152,7 @@ Every struct used as a `native_type` reference should include all 4 derives, as 
 #[derive(Serialize, Deserialize, Debug, DefaultJson)]
 ```
 
-`Serialize` and `Deserialize` come from `serde_derive`, and `DefaultJson` comes from `lib3h_persistence_derive`.
+`Serialize` and `Deserialize` come from `serde_derive`, and `DefaultJson` comes from `holochain_persistence_derive`.
 
 Then there is the struct itself. This is the real type definition, because it defines the schema. It is simply a list of property names, the 'keys', and the types of values expected, which should be set to one of the primitive types of the language. This will tell `serde` how to parse JSON string inputs into the type. Note that conversion from JSON strings into the struct type can easily fail, in particular if the proper keys are not present on the input.
 


### PR DESCRIPTION
## PR summary
tiny fixes 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
