### PR TITLE
Add link for Wasm langs

### DIFF
--- a/doc/holochain_101/src/intro_to_dna_code.md
+++ b/doc/holochain_101/src/intro_to_dna_code.md
@@ -12,7 +12,7 @@ The configuration file should be a JSON file, stored in the Zome folder. The fil
 
 This Zome file is extremely simplistic at this point, and contains only a `description` property, which is a human readable property that describes what the Zome is for.
 
-The only coding language that Holochain knows how to execute is WebAssembly. However, it is unlikely that you'll want to write WebAssembly code by hand. Instead, most people will write their Zomes' code in a language that can compile to WebAssembly, such as Rust or Assemblyscript, and then define a build step in which it is compiled to WebAssembly. There is already a large, and growing, number of languages that compile to WebAssembly.
+The only coding language that Holochain knows how to execute is WebAssembly. However, it is unlikely that you'll want to write WebAssembly code by hand. Instead, most people will write their Zomes' code in [a language that can compile to WebAssembly](https://github.com/appcypher/awesome-wasm-langs), such as Rust or Assemblyscript, and then define a build step in which it is compiled to WebAssembly. There is already a large, and growing, number of languages that compile to WebAssembly.
 
 If this is sounding complex, don't worry. There are tools supplied to make this easy, and you'll be writing in a language that's familiar, or easy to learn.
 


### PR DESCRIPTION
[a language that can compile to WebAssembly](https://github.com/appcypher/awesome-wasm-langs)

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
