### PR TITLE
Fix dangling core_types_derive reference

### DIFF
--- a/cli/src/cli/scaffold/rust-proc-macro/Cargo.template.toml
+++ b/cli/src/cli/scaffold/rust-proc-macro/Cargo.template.toml
@@ -11,7 +11,7 @@ serde_derive = "=1.0.89"
 hdk = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
 hdk-proc-macros = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
 holochain_wasm_utils = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
-holochain_core_types_derive = { git = "https://github.com/holochain/holochain-rust", <<VERSION>> }
+holochain_json_derive = { version = "0.0.1-alpah2" }
 
 [lib]
 path = "src/lib.rs"

--- a/cli/src/cli/scaffold/rust-proc-macro/lib.rs
+++ b/cli/src/cli/scaffold/rust-proc-macro/lib.rs
@@ -7,19 +7,26 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 #[macro_use]
-extern crate holochain_core_types_derive;
+extern crate holochain_json_derive;
 
 use hdk::{
     entry_definition::ValidatingEntryType,
     error::ZomeApiResult,
 };
 use hdk::holochain_core_types::{
-    cas::content::Address,
     entry::Entry,
     dna::entry_types::Sharing,
-    error::HolochainError,
-    json::JsonString,
 };
+
+use hdk::holochain_json_api::{
+    json::JsonsString,
+    error::JsonError
+};
+
+use hdk::holochain_persistence_api::{
+    cas::content::Adddress
+};
+
 use hdk_proc_macros::zome;
 
 // see https://developer.holochain.org/api/0.0.18-alpha1/hdk/ for info on using the hdk library
@@ -53,7 +60,7 @@ mod my_zome {
                 Ok(())
             }
         )
-    }   
+    }
 
     #[zome_fn("hc_public")]
     fn create_my_entry(entry: MyEntry) -> ZomeApiResult<Address> {

--- a/hdk-proc-macros/wasm-test/Cargo.toml
+++ b/hdk-proc-macros/wasm-test/Cargo.toml
@@ -19,4 +19,4 @@ hdk = { path = "../../hdk-rust" }
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
-holochain_core_types_derive = { path = "../../core_types_derive" }
+holochain_json_derive = { version = "=0.0.1-alpha2" ]


### PR DESCRIPTION
## PR summary

This PR addresses some unmodified references to `core_types_derive` and related imports in rust code as should have been done by #1505 .

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
