### PR TITLE
WIP: Cluster test proving that gossip works

### DIFF
--- a/app_spec/cluster_test/index.js
+++ b/app_spec/cluster_test/index.js
@@ -6,7 +6,7 @@ process.on('unhandledRejection', error => {
 })
 
 const bugTest = async () => {
-  const dnaPath = path.join(__dirname, '..', 'dist/app_spec.dna.json')
+  const dnaPath = path.join(__dirname, 'holochain-basic-chat.dna.json')
   const instanceId = 'test-1'
 
   // start with two
@@ -23,17 +23,14 @@ const bugTest = async () => {
 
   let enteringShutdown = false
 
-  let blogPostAddress
   let thirdConductor
 
   // wait a maximum of 5 seconds for
   // all the expected signals to arrive
   // otherwise consider it a timed out failure
   setTimeout(async () => {
-    const result = await thirdConductor.callZome(instanceId, 'blog', 'get_post')({
-      post_address: blogPostAddress
-    })
-    console.log('get_post_result2', result)
+    const result = await thirdConductor.callZome(instanceId, 'chat', 'get_all_public_streams')({})
+    console.log('get_all_public_streams_result2', result)
 
     if (!enteringShutdown) {
       enteringShutdown = true
@@ -42,7 +39,7 @@ const bugTest = async () => {
         process.exit(1) // failure status code
       })
     }
-  }, 30000)
+  }, 120000)
 
   const proceedWithThirdNode = async () => {
     // shut down the FIRST conductor
@@ -54,15 +51,12 @@ const bugTest = async () => {
 
     thirdConductor.onSignal(async signal => {
       if (signal.action_type === "Hold") {
-        console.log('new HOLD!', signal)
+        console.log('new HOLD!', signal.data.entry.App)
       }
     })
 
-    console.log('post_address', blogPostAddress)
-    const result = await thirdConductor.callZome(instanceId, 'blog', 'get_post')({
-      post_address: blogPostAddress
-    })
-    console.log('get_post_result', result)
+    const result = await thirdConductor.callZome(instanceId, 'chat', 'get_all_public_streams')({})
+    console.log('get_all_public_streams_result', result)
   }
 
   let countHolding = 0
@@ -78,11 +72,12 @@ const bugTest = async () => {
   // calling this will trigger a flurry of actions/signals
   // including the Hold actions related to the Commits this function
   // invokes
-  const result = await cluster.conductors[0].callZome(instanceId, 'blog', 'create_post')({
-    content: 'hi',
-    in_reply_to: null,
+  const result = await cluster.conductors[0].callZome(instanceId, 'chat', 'create_stream')({
+    name: 'streamname',
+    description: '',
+    initial_members: []
   })
-  blogPostAddress = JSON.parse(result).Ok
+  console.log('result123', result)
 }
 
 bugTest()

--- a/app_spec/cluster_test/index.js
+++ b/app_spec/cluster_test/index.js
@@ -63,7 +63,8 @@ const bugTest = async () => {
   cluster.conductors[1].onSignal(async signal => {
     if (signal.action_type === "Hold") {
       countHolding++
-      if (countHolding === 2) {
+      console.log('old HOLD [',countHolding,']',signal.data)
+      if (countHolding === 5) {
         proceedWithThirdNode()
       }
     }

--- a/app_spec/cluster_test/index.js
+++ b/app_spec/cluster_test/index.js
@@ -5,77 +5,84 @@ process.on('unhandledRejection', error => {
   console.log('unhandledRejection', error.message);
 })
 
-const scenarioTest = async (numConductors = 2, debugging = false) => {
+const bugTest = async () => {
   const dnaPath = path.join(__dirname, '..', 'dist/app_spec.dna.json')
   const instanceId = 'test-1'
 
-  // just creates the instance
-  const cluster = new ConductorCluster(numConductors, { debugging })
+  // start with two
+  const cluster = new ConductorCluster(2, { debugging: true, adminPortStart: 3000, instancePortStart: 4000 })
+
+  const createDnaInstance = (conductor) => conductor.createDnaInstance(instanceId, dnaPath)
+
   // spawns the conductors and connects
   // to their newly opened websocket connections
   await cluster.initialize()
   // install the DNA and create an instance
   // with the test agent already in each Conductor
-  await cluster.batch(conductor => conductor.createDnaInstance(instanceId, dnaPath))
+  await cluster.batch(createDnaInstance)
 
   let enteringShutdown = false
+
+  let blogPostAddress
+  let thirdConductor
 
   // wait a maximum of 5 seconds for
   // all the expected signals to arrive
   // otherwise consider it a timed out failure
   setTimeout(async () => {
+    const result = await thirdConductor.callZome(instanceId, 'blog', 'get_post')({
+      post_address: blogPostAddress
+    })
+    console.log('get_post_result2', result)
+
     if (!enteringShutdown) {
       enteringShutdown = true
-      console.log('after 10 seconds, all nodes should be holding all entries and all links')
-      console.log(`There are only ${countHolding} after 5 seconds.`)
-      // done this way because cluster.shutdown() was causing
-      // errors on CircleCI
-      if (process.env.CI) {
+      console.log('after 30 seconds, third node should be holding all entries and all links from first node')
+      cluster.shutdown().finally(() => {
         process.exit(1) // failure status code
-      } else {
-        cluster.shutdown().finally(() => {
-          process.exit(1) // failure status code
-        })
-      }
+      })
     }
-  }, 10000)
+  }, 30000)
+
+  const proceedWithThirdNode = async () => {
+    // shut down the FIRST conductor
+    await cluster.conductors[0].shutdown()
+    // add a new conductor
+    thirdConductor = await cluster.addConductor()
+    // set up that conductor with the same DNA
+    await createDnaInstance(thirdConductor)
+
+    thirdConductor.onSignal(async signal => {
+      if (signal.action_type === "Hold") {
+        console.log('new HOLD!', signal)
+      }
+    })
+
+    console.log('post_address', blogPostAddress)
+    const result = await thirdConductor.callZome(instanceId, 'blog', 'get_post')({
+      post_address: blogPostAddress
+    })
+    console.log('get_post_result', result)
+  }
 
   let countHolding = 0
-  cluster.batch(conductor => conductor.onSignal(async signal => {
+  cluster.conductors[1].onSignal(async signal => {
     if (signal.action_type === "Hold") {
       countHolding++
-      console.log("Nodes holding so far:" + countHolding)
-    }
-    // 2 Holds for each nodes ... one for the App entry and one for a LinkAdd entry
-    if (countHolding === numConductors * 2 && !enteringShutdown) {
-      enteringShutdown = true
-      console.log('All nodes are successfully HOLDing all entries they should be.')
-
-      // done this way because cluster.shutdown() was causing
-      // errors on CircleCI
-      if (process.env.CI) {
-        process.exit() // success status code
-      } else {
-        cluster.shutdown().finally(() => {
-          process.exit() // success status code
-        })
+      if (countHolding === 2) {
+        proceedWithThirdNode()
       }
     }
-  }))
+  })
 
   // calling this will trigger a flurry of actions/signals
   // including the Hold actions related to the Commits this function
   // invokes
-  cluster.conductors[0].callZome(instanceId, 'blog', 'create_post')({
+  const result = await cluster.conductors[0].callZome(instanceId, 'blog', 'create_post')({
     content: 'hi',
     in_reply_to: null,
   })
+  blogPostAddress = JSON.parse(result).Ok
 }
 
-// first argument is the number of nodes to run
-const optionalNumber = process.argv[2]
-
-// second argument is whether to show debugging logs or not
-const optionalDebugging = process.argv[3]
-
-scenarioTest(optionalNumber, optionalDebugging)
+bugTest()

--- a/app_spec/cluster_test/index.js
+++ b/app_spec/cluster_test/index.js
@@ -5,15 +5,24 @@ process.on('unhandledRejection', error => {
   console.log('unhandledRejection', error.message);
 })
 
+const waitForHoldSignals = (count, cb) => {
+  let countHolding = 0
+  return (signal) => {
+    console.log('signal', signal.action_type, signal.data.header && signal.data.header.entry_type)
+    if (signal.action_type === "Hold" && signal.data.header.entry_type !== 'AgentId') {
+      countHolding++
+      if (countHolding === count) cb()
+    }
+  }
+}
+
 const bugTest = async () => {
   const dnaPath = path.join(__dirname, 'holochain-basic-chat.dna.json')
   const instanceId = 'test-1'
 
   // start with two
   const cluster = new ConductorCluster(2, { debugging: true, adminPortStart: 3000, instancePortStart: 4000 })
-
   const createDnaInstance = (conductor) => conductor.createDnaInstance(instanceId, dnaPath)
-
   // spawns the conductors and connects
   // to their newly opened websocket connections
   await cluster.initialize()
@@ -23,62 +32,58 @@ const bugTest = async () => {
 
   let enteringShutdown = false
 
-  let thirdConductor
-
   // wait a maximum of 5 seconds for
   // all the expected signals to arrive
   // otherwise consider it a timed out failure
   setTimeout(async () => {
-    const result = await thirdConductor.callZome(instanceId, 'chat', 'get_all_public_streams')({})
-    console.log('get_all_public_streams_result2', result)
-
     if (!enteringShutdown) {
       enteringShutdown = true
-      console.log('after 30 seconds, third node should be holding all entries and all links from first node')
       cluster.shutdown().finally(() => {
         process.exit(1) // failure status code
       })
     }
   }, 120000)
 
+  const proceedWithFourthNode = async () => {
+    // shut down the SECOND conductor
+    await cluster.conductors[1].shutdown()
+    // add a new conductor
+    const fourthConductor = await cluster.addConductor()
+    // set up that conductor with the same DNA
+    await createDnaInstance(fourthConductor)
+
+    fourthConductor.onSignal(waitForHoldSignals(10, () => {
+      console.log('got dare')
+    }))
+  }
+
   const proceedWithThirdNode = async () => {
     // shut down the FIRST conductor
     await cluster.conductors[0].shutdown()
     // add a new conductor
-    thirdConductor = await cluster.addConductor()
+    const thirdConductor = await cluster.addConductor()
     // set up that conductor with the same DNA
     await createDnaInstance(thirdConductor)
 
-    thirdConductor.onSignal(async signal => {
-      if (signal.action_type === "Hold") {
-        console.log('new HOLD!', signal.data)
-      }
+    thirdConductor.onSignal(waitForHoldSignals(10, proceedWithFourthNode))
+    thirdConductor.callZome(instanceId, 'chat', 'create_stream')({
+      name: 'streamtwo',
+      description: '',
+      initial_members: []
     })
-
-    const result = await thirdConductor.callZome(instanceId, 'chat', 'get_all_public_streams')({})
-    console.log('get_all_public_streams_result', result)
   }
 
-  let countHolding = 0
-  cluster.conductors[1].onSignal(async signal => {
-    if (signal.action_type === "Hold") {
-      countHolding++
-      console.log('old HOLD [',countHolding,']',signal.data)
-      if (countHolding === 5) {
-        proceedWithThirdNode()
-      }
-    }
-  })
+  // in node 2, wait for holding of all relevant entries
+  cluster.conductors[1].onSignal(waitForHoldSignals(5, proceedWithThirdNode))
 
   // calling this will trigger a flurry of actions/signals
   // including the Hold actions related to the Commits this function
   // invokes
-  const result = await cluster.conductors[0].callZome(instanceId, 'chat', 'create_stream')({
+  await cluster.conductors[0].callZome(instanceId, 'chat', 'create_stream')({
     name: 'streamname',
     description: '',
     initial_members: []
   })
-  console.log('result123', result)
 }
 
 bugTest()

--- a/app_spec/cluster_test/index.js
+++ b/app_spec/cluster_test/index.js
@@ -51,7 +51,7 @@ const bugTest = async () => {
 
     thirdConductor.onSignal(async signal => {
       if (signal.action_type === "Hold") {
-        console.log('new HOLD!', signal.data.entry.App)
+        console.log('new HOLD!', signal.data)
       }
     })
 

--- a/app_spec/zomes/blog/code/src/post.rs
+++ b/app_spec/zomes/blog/code/src/post.rs
@@ -54,7 +54,7 @@ pub fn definition() -> ValidatingEntryType {
         sharing: Sharing::Public,
 
         validation_package: || {
-            hdk::ValidationPackageDefinition::ChainFull
+            hdk::ValidationPackageDefinition::Entry
         },
 
         validation: |validation_data: hdk::EntryValidationData<Post>| {

--- a/core/src/network/handler/mod.rs
+++ b/core/src/network/handler/mod.rs
@@ -14,11 +14,16 @@ use crate::{
 use holochain_net::connection::{json_protocol::JsonProtocol, net_connection::NetHandler};
 use holochain_persistence_api::hash::HashString;
 
-use crate::network::{direct_message::DirectMessage, entry_aspect::EntryAspect};
+use crate::network::{
+    direct_message::DirectMessage,
+    entry_aspect::EntryAspect,
+    query::{NetworkQuery, NetworkQueryResult},
+};
 use holochain_json_api::json::JsonString;
-use holochain_net::connection::json_protocol::{MessageData, StoreEntryAspectData, QueryEntryData, QueryEntryResultData};
+use holochain_net::connection::json_protocol::{
+    MessageData, QueryEntryData, QueryEntryResultData, StoreEntryAspectData,
+};
 use std::{convert::TryFrom, sync::Arc};
-use crate::network::query::{NetworkQuery, NetworkQueryResult};
 
 // FIXME: Temporary hack to ignore messages incorrectly sent to us by the networking
 // module that aren't really meant for us
@@ -113,7 +118,8 @@ QueryEntryData {{
 
 // See comment on fn format_store_data() - same reason for this function.
 fn format_query_entry_result_data(data: &QueryEntryResultData) -> String {
-    let query_result_json = JsonString::from_json(&String::from_utf8(data.query_result.clone()).unwrap());
+    let query_result_json =
+        JsonString::from_json(&String::from_utf8(data.query_result.clone()).unwrap());
     let query_result = NetworkQueryResult::try_from(query_result_json).unwrap();
     format!(
         r#"

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -141,7 +141,7 @@ pub fn find_link_definition_by_type(
                             entry_type_name: entry_type_name.to_string(),
                             direction: LinkDirection::To,
                             link_type: link_type.clone(),
-                        })
+                        });
                     }
                 }
 
@@ -152,13 +152,14 @@ pub fn find_link_definition_by_type(
                             entry_type_name: entry_type_name.to_string(),
                             direction: LinkDirection::From,
                             link_type: link_type.clone(),
-                        })
+                        });
                     }
                 }
             }
-
         }
     }
 
-    Err(HolochainError::ErrorGeneric(String::from("Unknown entry type")))
+    Err(HolochainError::ErrorGeneric(String::from(
+        "Unknown entry type",
+    )))
 }

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -125,3 +125,40 @@ pub fn find_link_definition_in_dna(
         "Unknown entry type",
     )))
 }
+
+pub fn find_link_definition_by_type(
+    link_type: &String,
+    context: &Arc<Context>,
+) -> Result<LinkDefinitionPath, HolochainError> {
+    let dna = context.get_dna().expect("No DNA found?!");
+    for (zome_name, zome) in dna.zomes.iter() {
+        for (entry_type, entry_type_def) in zome.entry_types.iter() {
+            if let EntryType::App(entry_type_name) = entry_type.clone() {
+                for link in entry_type_def.links_to.iter() {
+                    if link.link_type == *link_type {
+                        return Ok(LinkDefinitionPath {
+                            zome_name: zome_name.clone(),
+                            entry_type_name: entry_type_name.to_string(),
+                            direction: LinkDirection::To,
+                            link_type: link_type.clone(),
+                        })
+                    }
+                }
+
+                for link in entry_type_def.linked_from.iter() {
+                    if link.link_type == *link_type {
+                        return Ok(LinkDefinitionPath {
+                            zome_name: zome_name.clone(),
+                            entry_type_name: entry_type_name.to_string(),
+                            direction: LinkDirection::From,
+                            link_type: link_type.clone(),
+                        })
+                    }
+                }
+            }
+
+        }
+    }
+
+    Err(HolochainError::ErrorGeneric(String::from("Unknown entry type")))
+}

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -54,10 +54,8 @@ pub fn get_validation_package_definition(
                 }
             };
 
-            let link_definition_path = links_utils::find_link_definition_by_type(
-                link_add.link().link_type(),
-                &context,
-            )?;
+            let link_definition_path =
+                links_utils::find_link_definition_by_type(link_add.link().link_type(), &context)?;
 
             let params = LinkValidationPackageArgs {
                 entry_type: link_definition_path.entry_type_name,

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -53,12 +53,9 @@ pub fn get_validation_package_definition(
                     ));
                 }
             };
-            let (base, target) = links_utils::get_link_entries(link_add.link(), &context)?;
 
-            let link_definition_path = links_utils::find_link_definition_in_dna(
-                &base.entry_type(),
+            let link_definition_path = links_utils::find_link_definition_by_type(
                 link_add.link().link_type(),
-                &target.entry_type(),
                 &context,
             )?;
 
@@ -88,12 +85,9 @@ pub fn get_validation_package_definition(
                     ));
                 }
             };
-            let (base, target) = links_utils::get_link_entries(link_remove.link(), &context)?;
 
-            let link_definition_path = links_utils::find_link_definition_in_dna(
-                &base.entry_type(),
+            let link_definition_path = links_utils::find_link_definition_by_type(
                 link_remove.link().link_type(),
-                &target.entry_type(),
                 &context,
             )?;
 

--- a/hc_cluster_test/conductor_cluster.ts
+++ b/hc_cluster_test/conductor_cluster.ts
@@ -2,7 +2,15 @@ import spawnConductors from './spawn_conductors'
 import ConductorHandle from './conductor_handle'
 
 interface ClusterOptions {
-  debugging: boolean
+  debugging: boolean,
+  adminPortStart: number,
+  instancePortStart: number
+}
+
+const defaultOptions: ClusterOptions = {
+  debugging: false,
+  adminPortStart: 3000,
+  instancePortStart: 4000
 }
 
 export default class ConductorCluster {
@@ -10,16 +18,28 @@ export default class ConductorCluster {
   options: ClusterOptions
   conductors: Array<ConductorHandle>
 
-  constructor(numConductors: number, options: ClusterOptions = { debugging: false }) {
+  constructor(numConductors: number, options = defaultOptions) {
     this.numConductors = numConductors
     this.options = options
   }
 
   async initialize() {
-    const conductorsArray = await spawnConductors(this.numConductors, this.options.debugging)
+    const { debugging, adminPortStart, instancePortStart } = this.options
+    const conductorsArray = await spawnConductors(this.numConductors, debugging, adminPortStart, instancePortStart)
     console.log('spawnConductors completed')
     this.conductors = conductorsArray.map(conductorInfo => new ConductorHandle(conductorInfo))
     return this.batch(conductor => conductor.initialize())
+  }
+
+  async addConductor() {
+    const { debugging, adminPortStart, instancePortStart } = this.options
+    const indexStart = this.conductors.length
+    const conductorArray = await spawnConductors(1, debugging, adminPortStart, instancePortStart, indexStart)
+    const conductorInfo = conductorArray[0]
+    const conductor = new ConductorHandle(conductorInfo)
+    this.conductors.push(conductor)
+    await conductor.initialize()
+    return conductor
   }
 
   batch(fn: (conductor: ConductorHandle) => any) {


### PR DESCRIPTION
## PR summary

This adds a 3rd node to cluster test that only gets started after the 1st node is shutdown, leaving the 2nd to gossip entries from the 1st to the 3rd.

Switches app-spec to holochain-basic-chat for that. (@Connoropolous, should we switch back?)

This includes one change to core that simplifies validation of links which is necessary for this to work, and was the blocker for messages getting successfully gossiped in HCB: in order to get the validation package definition for links, we need to know the link type. Before we added back link type alongside link tags, we had to infer the link type by looking at the entry types of base and target. With the explicit link type we could now simplify this so that we have a chance to create the validation package of link locally without running DHT gets on the link's base and target first. But, this is the first time we assume that link type names are unique across the whole DNA (which makes sense and is something we might want to add checks for).

This change to the link validation packages is all in [this commit](https://github.com/holochain/holochain-rust/commit/2debdb8a51f868083000d2fbc08606ee0dfada9f).
## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
