### PR TITLE
Get validation package defs for links only from the link type

### DIFF
--- a/app_spec/zomes/simple/code/src/lib.rs
+++ b/app_spec/zomes/simple/code/src/lib.rs
@@ -54,13 +54,13 @@ fn simple_entry(content: String) -> Entry {
 
 pub fn handle_create_my_link(base: Address,target : String) -> ZomeApiResult<()> {
     let address = hdk::commit_entry(&simple_entry(target))?;
-    hdk::link_entries(&base, &HashString::from(address), "authored_posts", "")?;
+    hdk::link_entries(&base, &HashString::from(address), "authored_simple_posts", "")?;
     Ok(())
 }
 
 pub fn handle_delete_my_link(base: Address,target : String) -> ZomeApiResult<()> {
     let address = hdk::entry_address(&simple_entry(target))?;
-    hdk::remove_link(&base, &HashString::from(address), "authored_posts", "")?;
+    hdk::remove_link(&base, &HashString::from(address), "authored_simple_posts", "")?;
     Ok(())
 }
 
@@ -71,7 +71,7 @@ pub fn handle_get_my_links(agent : Address,status_request:Option<LinksStatusRequ
         status_request : status_request.unwrap_or(LinksStatusRequestKind::All),
         ..GetLinksOptions::default()
     };
-    hdk::get_links_with_options(&agent, LinkMatch::Exactly("authored_posts"), LinkMatch::Any,options)
+    hdk::get_links_with_options(&agent, LinkMatch::Exactly("authored_simple_posts"), LinkMatch::Any,options)
 }
 
 pub fn handle_test_emit_signal(message: String) -> ZomeApiResult<()> {
@@ -99,7 +99,7 @@ pub fn definition() -> ValidatingEntryType {
         links: [
             from!(
                 "%agent_id",
-                link_type: "authored_posts",
+                link_type: "authored_simple_posts",
                 validation_package: || {
                     hdk::ValidationPackageDefinition::ChainFull
                 },

--- a/app_spec_proc_macro/zomes/simple/code/src/lib.rs
+++ b/app_spec_proc_macro/zomes/simple/code/src/lib.rs
@@ -51,7 +51,7 @@ pub mod simple {
         links: [
             from!(
                 "%agent_id",
-                link_type: "authored_posts",
+                link_type: "authored_simple_posts",
                 validation_package: || {
                     hdk::ValidationPackageDefinition::ChainFull
                 },
@@ -104,13 +104,13 @@ pub mod simple {
     pub fn create_link(base: Address,target : String) -> ZomeApiResult<()>
     {
         let address = hdk::commit_entry(&simple_entry(target))?;
-        hdk::link_entries(&base, &address, "authored_posts", "")?;
+        hdk::link_entries(&base, &address, "authored_simple_posts", "")?;
         Ok(())
     }
     #[zome_fn("hc_public")]
     pub fn delete_link(base: Address,target : String) -> ZomeApiResult<()> {
         let address = hdk::entry_address(&simple_entry(target))?;
-        hdk::remove_link(&base, &address, "authored_posts", "")?;
+        hdk::remove_link(&base, &address, "authored_simple_posts", "")?;
         Ok(())
     }
 
@@ -121,7 +121,7 @@ pub mod simple {
             status_request : status_request.unwrap_or(LinksStatusRequestKind::All),
             ..GetLinksOptions::default()
         };
-        hdk::get_links_with_options(&base, LinkMatch::Exactly("authored_posts"), LinkMatch::Any,options)
+        hdk::get_links_with_options(&base, LinkMatch::Exactly("authored_simple_posts"), LinkMatch::Any,options)
     }
 
     #[zome_fn("hc_public")]

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -44,7 +44,7 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
                 }
                 let entry_with_header = EntryWithHeader { entry, header };
                 thread::spawn(move || {
-                    match context.block_on(hold_link_workflow(&entry_with_header, &context.clone()))
+                    match context.block_on(hold_link_workflow(&entry_with_header, context.clone()))
                     {
                         Err(error) => context.log(format!("err/net/dht: {}", error)),
                         _ => (),
@@ -59,7 +59,7 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
                 let entry_with_header = EntryWithHeader { entry, header };
                 thread::spawn(move || {
                     if let Err(error) =
-                        context.block_on(remove_link_workflow(&entry_with_header, &context.clone()))
+                        context.block_on(remove_link_workflow(&entry_with_header, context.clone()))
                     {
                         context.log(format!("err/net/dht: {}", error))
                     }
@@ -71,7 +71,7 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
                 let entry_with_header = EntryWithHeader { entry, header };
                 thread::spawn(move || {
                     if let Err(error) =
-                        context.block_on(hold_update_workflow(entry_with_header, context.clone()))
+                        context.block_on(hold_update_workflow(&entry_with_header, context.clone()))
                     {
                         context.log(format!("err/net/dht: {}", error))
                     }
@@ -94,7 +94,7 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
                 let entry_with_header = EntryWithHeader { entry, header };
                 thread::spawn(move || {
                     if let Err(error) =
-                        context.block_on(hold_remove_workflow(entry_with_header, context.clone()))
+                        context.block_on(hold_remove_workflow(&entry_with_header, context.clone()))
                     {
                         context.log(format!("err/net/handle_store: {}", error))
                     }

--- a/core/src/nucleus/actions/add_pending_validation.rs
+++ b/core/src/nucleus/actions/add_pending_validation.rs
@@ -12,7 +12,7 @@ pub fn add_pending_validation(
     entry_with_header: EntryWithHeader,
     dependencies: Vec<Address>,
     workflow: ValidatingWorkflow,
-    context: &Arc<Context>,
+    context: Arc<Context>,
 ) {
     dispatch_action(
         context.action_channel(),

--- a/core/src/nucleus/ribosome/callback/links_utils.rs
+++ b/core/src/nucleus/ribosome/callback/links_utils.rs
@@ -125,3 +125,40 @@ pub fn find_link_definition_in_dna(
         "Unknown entry type",
     )))
 }
+
+pub fn find_link_definition_by_type(
+    link_type: &String,
+    context: &Arc<Context>,
+) -> Result<LinkDefinitionPath, HolochainError> {
+    let dna = context.get_dna().expect("No DNA found?!");
+    for (zome_name, zome) in dna.zomes.iter() {
+        for (entry_type, entry_type_def) in zome.entry_types.iter() {
+            if let EntryType::App(entry_type_name) = entry_type.clone() {
+                for link in entry_type_def.links_to.iter() {
+                    if link.link_type == *link_type {
+                        return Ok(LinkDefinitionPath {
+                            zome_name: zome_name.clone(),
+                            entry_type_name: entry_type_name.to_string(),
+                            direction: LinkDirection::To,
+                            link_type: link_type.clone(),
+                        })
+                    }
+                }
+
+                for link in entry_type_def.linked_from.iter() {
+                    if link.link_type == *link_type {
+                        return Ok(LinkDefinitionPath {
+                            zome_name: zome_name.clone(),
+                            entry_type_name: entry_type_name.to_string(),
+                            direction: LinkDirection::From,
+                            link_type: link_type.clone(),
+                        })
+                    }
+                }
+            }
+
+        }
+    }
+
+    Err(HolochainError::ErrorGeneric(String::from("Unknown entry type")))
+}

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -54,10 +54,8 @@ pub fn get_validation_package_definition(
                 }
             };
 
-            let link_definition_path = links_utils::find_link_definition_by_type(
-                link_add.link().link_type(),
-                &context,
-            )?;
+            let link_definition_path =
+                links_utils::find_link_definition_by_type(link_add.link().link_type(), &context)?;
 
             let params = LinkValidationPackageArgs {
                 entry_type: link_definition_path.entry_type_name,

--- a/core/src/nucleus/ribosome/callback/validation_package.rs
+++ b/core/src/nucleus/ribosome/callback/validation_package.rs
@@ -53,12 +53,9 @@ pub fn get_validation_package_definition(
                     ));
                 }
             };
-            let (base, target) = links_utils::get_link_entries(link_add.link(), &context)?;
 
-            let link_definition_path = links_utils::find_link_definition_in_dna(
-                &base.entry_type(),
+            let link_definition_path = links_utils::find_link_definition_by_type(
                 link_add.link().link_type(),
-                &target.entry_type(),
                 &context,
             )?;
 
@@ -88,12 +85,9 @@ pub fn get_validation_package_definition(
                     ));
                 }
             };
-            let (base, target) = links_utils::get_link_entries(link_remove.link(), &context)?;
 
-            let link_definition_path = links_utils::find_link_definition_in_dna(
-                &base.entry_type(),
+            let link_definition_path = links_utils::find_link_definition_by_type(
                 link_remove.link().link_type(),
-                &target.entry_type(),
                 &context,
             )?;
 

--- a/core/src/nucleus/validation/link_entry.rs
+++ b/core/src/nucleus/validation/link_entry.rs
@@ -1,4 +1,3 @@
-use boolinator::*;
 use crate::{
     context::Context,
     nucleus::{
@@ -8,6 +7,7 @@ use crate::{
         CallbackFnCall,
     },
 };
+use boolinator::*;
 use holochain_core_types::{
     entry::Entry,
     validation::{LinkValidationData, ValidationData},
@@ -15,7 +15,7 @@ use holochain_core_types::{
 
 use holochain_persistence_api::cas::content::AddressableContent;
 
-use holochain_wasm_utils::api_serialization::validation::{LinkValidationArgs, LinkDirection};
+use holochain_wasm_utils::api_serialization::validation::{LinkDirection, LinkValidationArgs};
 use std::sync::Arc;
 
 pub async fn validate_link_entry(
@@ -50,7 +50,8 @@ pub async fn validate_link_entry(
         .dna()
         .expect("There has to be a DNA in the nucleus when trying to validate entries");
 
-    let entry_def = dna.get_entry_type_def(&link_definition_path.entry_type_name)
+    let entry_def = dna
+        .get_entry_type_def(&link_definition_path.entry_type_name)
         .expect("This is Some === find_link_definition_by_type is correct");
 
     let (base_type, target_type) = if link_definition_path.direction == LinkDirection::To {
@@ -59,14 +60,20 @@ pub async fn validate_link_entry(
             .iter()
             .find(|link| link.link_type == link_definition_path.link_type)
             .expect("This is Some === find_link_definition_by_type is correct");
-        (link_definition_path.entry_type_name.clone(), link_def.target_type.clone())
+        (
+            link_definition_path.entry_type_name.clone(),
+            link_def.target_type.clone(),
+        )
     } else {
         let link_def = entry_def
             .linked_from
             .iter()
             .find(|link| link.link_type == link_definition_path.link_type)
             .expect("This is Some === find_link_definition_by_type is correct");
-        (link_def.base_type.clone(), link_definition_path.entry_type_name.clone())
+        (
+            link_def.base_type.clone(),
+            link_definition_path.entry_type_name.clone(),
+        )
     };
 
     (base.entry_type().to_string() == base_type)
@@ -84,7 +91,6 @@ pub async fn validate_link_entry(
             target_type,
             target.entry_type().to_string(),
         )))?;
-
 
     let validation_data = match entry.clone() {
         Entry::LinkAdd(link) => Ok(LinkValidationData::LinkAdd {

--- a/core/src/nucleus/validation/link_entry.rs
+++ b/core/src/nucleus/validation/link_entry.rs
@@ -33,19 +33,14 @@ pub async fn validate_link_entry(
         }
     };
     let link = link.link().clone();
-    let (base, target) = links_utils::get_link_entries(&link, context).map_err(|_| {
+    let (_base, _target) = links_utils::get_link_entries(&link, context).map_err(|_| {
         ValidationError::UnresolvedDependencies(
             [link.base().clone(), link.target().clone()].to_vec(),
         )
     })?;
 
-    let link_definition_path = links_utils::find_link_definition_in_dna(
-        &base.entry_type(),
-        link.link_type(),
-        &target.entry_type(),
-        context,
-    )
-    .map_err(|_| ValidationError::NotImplemented)?;
+    let link_definition_path = links_utils::find_link_definition_by_type(link.link_type(), context)
+        .map_err(|_| ValidationError::NotImplemented)?;
 
     let validation_data = match entry.clone() {
         Entry::LinkAdd(link) => Ok(LinkValidationData::LinkAdd {

--- a/core/src/nucleus/validation/link_entry.rs
+++ b/core/src/nucleus/validation/link_entry.rs
@@ -1,3 +1,4 @@
+use boolinator::*;
 use crate::{
     context::Context,
     nucleus::{
@@ -14,7 +15,7 @@ use holochain_core_types::{
 
 use holochain_persistence_api::cas::content::AddressableContent;
 
-use holochain_wasm_utils::api_serialization::validation::LinkValidationArgs;
+use holochain_wasm_utils::api_serialization::validation::{LinkValidationArgs, LinkDirection};
 use std::sync::Arc;
 
 pub async fn validate_link_entry(
@@ -33,7 +34,7 @@ pub async fn validate_link_entry(
         }
     };
     let link = link.link().clone();
-    let (_base, _target) = links_utils::get_link_entries(&link, context).map_err(|_| {
+    let (base, target) = links_utils::get_link_entries(&link, context).map_err(|_| {
         ValidationError::UnresolvedDependencies(
             [link.base().clone(), link.target().clone()].to_vec(),
         )
@@ -41,6 +42,49 @@ pub async fn validate_link_entry(
 
     let link_definition_path = links_utils::find_link_definition_by_type(link.link_type(), context)
         .map_err(|_| ValidationError::NotImplemented)?;
+
+    let dna = context
+        .state()
+        .expect("There has to be a state in the context when using it for validation")
+        .nucleus()
+        .dna()
+        .expect("There has to be a DNA in the nucleus when trying to validate entries");
+
+    let entry_def = dna.get_entry_type_def(&link_definition_path.entry_type_name)
+        .expect("This is Some === find_link_definition_by_type is correct");
+
+    let (base_type, target_type) = if link_definition_path.direction == LinkDirection::To {
+        let link_def = entry_def
+            .links_to
+            .iter()
+            .find(|link| link.link_type == link_definition_path.link_type)
+            .expect("This is Some === find_link_definition_by_type is correct");
+        (link_definition_path.entry_type_name.clone(), link_def.target_type.clone())
+    } else {
+        let link_def = entry_def
+            .linked_from
+            .iter()
+            .find(|link| link.link_type == link_definition_path.link_type)
+            .expect("This is Some === find_link_definition_by_type is correct");
+        (link_def.base_type.clone(), link_definition_path.entry_type_name.clone())
+    };
+
+    (base.entry_type().to_string() == base_type)
+        .ok_or(ValidationError::Fail(format!(
+            "Wrong base type for link of type '{}'. Found '{}', but link is defined to link from '{}'s.",
+            link.link_type(),
+            base_type,
+            base.entry_type().to_string(),
+        )))?;
+
+    (target.entry_type().to_string() == target_type)
+        .ok_or(ValidationError::Fail(format!(
+            "Wrong target type for link of type '{}'. Found '{}', but link is defined to link to '{}'s.",
+            link.link_type(),
+            target_type,
+            target.entry_type().to_string(),
+        )))?;
+
 
     let validation_data = match entry.clone() {
         Entry::LinkAdd(link) => Ok(LinkValidationData::LinkAdd {

--- a/core/src/scheduled_jobs/pending_validations.rs
+++ b/core/src/scheduled_jobs/pending_validations.rs
@@ -6,12 +6,13 @@ use crate::{
 };
 use holochain_core_types::error::HolochainError;
 
+use crate::workflows::{
+    hold_entry_remove::hold_remove_workflow, hold_entry_update::hold_update_workflow,
+    remove_link::remove_link_workflow,
+};
 use holochain_json_api::{error::JsonError, json::JsonString};
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
 use std::{fmt, sync::Arc, thread};
-use crate::workflows::hold_entry_update::hold_update_workflow;
-use crate::workflows::remove_link::remove_link_workflow;
-use crate::workflows::hold_entry_remove::hold_remove_workflow;
 
 pub type PendingValidation = Arc<PendingValidationStruct>;
 
@@ -46,9 +47,10 @@ pub struct PendingValidationStruct {
 fn retry_validation(pending: PendingValidation, context: Arc<Context>) {
     thread::spawn(move || {
         let result = match pending.workflow {
-            ValidatingWorkflow::HoldLink => {
-                context.block_on(hold_link_workflow(&pending.entry_with_header, context.clone()))
-            }
+            ValidatingWorkflow::HoldLink => context.block_on(hold_link_workflow(
+                &pending.entry_with_header,
+                context.clone(),
+            )),
             ValidatingWorkflow::HoldEntry => context.block_on(hold_entry_workflow(
                 &pending.entry_with_header,
                 context.clone(),

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -19,8 +19,8 @@ use holochain_persistence_api::cas::content::{Address, AddressableContent};
 
 use holochain_wasm_utils::api_serialization::commit_entry::CommitEntryResult;
 
-use std::{sync::Arc, vec::Vec};
 use crate::nucleus::ribosome::callback::links_utils::get_link_entries;
+use std::{sync::Arc, vec::Vec};
 
 pub async fn author_entry<'a>(
     entry: &'a Entry,

--- a/core/src/workflows/hold_entry.rs
+++ b/core/src/workflows/hold_entry.rs
@@ -34,7 +34,7 @@ pub async fn hold_entry_workflow<'a>(
                 entry_with_header.to_owned(),
                 Vec::new(),
                 ValidatingWorkflow::HoldEntry,
-                &context,
+                context.clone(),
             );
             HolochainError::ValidationPending
         })?;
@@ -46,7 +46,7 @@ pub async fn hold_entry_workflow<'a>(
             entry_with_header.to_owned(),
             Vec::new(),
             ValidatingWorkflow::HoldEntry,
-            &context,
+            context.clone(),
         );
         HolochainError::ValidationPending
     })?;
@@ -76,7 +76,7 @@ pub async fn hold_entry_workflow<'a>(
                 entry_with_header.to_owned(),
                 dependencies.clone(),
                 ValidatingWorkflow::HoldEntry,
-                &context,
+                context.clone(),
             );
             HolochainError::ValidationPending
         } else {

--- a/core/src/workflows/hold_entry_remove.rs
+++ b/core/src/workflows/hold_entry_remove.rs
@@ -12,12 +12,12 @@ use holochain_core_types::{
 use holochain_persistence_api::cas::content::AddressableContent;
 use std::sync::Arc;
 
-pub async fn hold_remove_workflow<'a>(
-    entry_with_header: EntryWithHeader,
+pub async fn hold_remove_workflow(
+    entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
     // 1. Get hold of validation package
-    let maybe_validation_package = await!(validation_package(&entry_with_header, context.clone()))?;
+    let maybe_validation_package = await!(validation_package(entry_with_header, context.clone()))?;
     let validation_package = maybe_validation_package
         .ok_or("Could not get validation package from source".to_string())?;
 

--- a/core/src/workflows/hold_entry_remove.rs
+++ b/core/src/workflows/hold_entry_remove.rs
@@ -3,7 +3,13 @@ use crate::{
     network::entry_with_header::EntryWithHeader, nucleus::validation::validate_entry,
 };
 
-use crate::workflows::validation_package;
+use crate::{
+    nucleus::{
+        actions::add_pending_validation::add_pending_validation, validation::ValidationError,
+    },
+    scheduled_jobs::pending_validations::ValidatingWorkflow,
+    workflows::validation_package,
+};
 use holochain_core_types::{
     entry::Entry,
     error::HolochainError,
@@ -11,9 +17,6 @@ use holochain_core_types::{
 };
 use holochain_persistence_api::cas::content::AddressableContent;
 use std::sync::Arc;
-use crate::nucleus::actions::add_pending_validation::add_pending_validation;
-use crate::scheduled_jobs::pending_validations::ValidatingWorkflow;
-use crate::nucleus::validation::ValidationError;
 
 pub async fn hold_remove_workflow(
     entry_with_header: &EntryWithHeader,
@@ -22,17 +25,17 @@ pub async fn hold_remove_workflow(
     // 1. Get hold of validation package
     let maybe_validation_package = await!(validation_package(entry_with_header, context.clone()))
         .map_err(|err| {
-            let message = "Could not get validation package from source! -> Add to pending...";
-            context.log(format!("debug/workflow/hold_remove: {}", message));
-            context.log(format!("debug/workflow/hold_remove: Error was: {:?}", err));
-            add_pending_validation(
-                entry_with_header.to_owned(),
-                Vec::new(),
-                ValidatingWorkflow::RemoveEntry,
-                context.clone(),
-            );
-            HolochainError::ValidationPending
-        })?;
+        let message = "Could not get validation package from source! -> Add to pending...";
+        context.log(format!("debug/workflow/hold_remove: {}", message));
+        context.log(format!("debug/workflow/hold_remove: Error was: {:?}", err));
+        add_pending_validation(
+            entry_with_header.to_owned(),
+            Vec::new(),
+            ValidatingWorkflow::RemoveEntry,
+            context.clone(),
+        );
+        HolochainError::ValidationPending
+    })?;
     let validation_package = maybe_validation_package
         .ok_or("Could not get validation package from source".to_string())?;
 

--- a/core/src/workflows/hold_entry_remove.rs
+++ b/core/src/workflows/hold_entry_remove.rs
@@ -11,13 +11,28 @@ use holochain_core_types::{
 };
 use holochain_persistence_api::cas::content::AddressableContent;
 use std::sync::Arc;
+use crate::nucleus::actions::add_pending_validation::add_pending_validation;
+use crate::scheduled_jobs::pending_validations::ValidatingWorkflow;
+use crate::nucleus::validation::ValidationError;
 
 pub async fn hold_remove_workflow(
     entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
     // 1. Get hold of validation package
-    let maybe_validation_package = await!(validation_package(entry_with_header, context.clone()))?;
+    let maybe_validation_package = await!(validation_package(entry_with_header, context.clone()))
+        .map_err(|err| {
+            let message = "Could not get validation package from source! -> Add to pending...";
+            context.log(format!("debug/workflow/hold_remove: {}", message));
+            context.log(format!("debug/workflow/hold_remove: Error was: {:?}", err));
+            add_pending_validation(
+                entry_with_header.to_owned(),
+                Vec::new(),
+                ValidatingWorkflow::RemoveEntry,
+                context.clone(),
+            );
+            HolochainError::ValidationPending
+        })?;
     let validation_package = maybe_validation_package
         .ok_or("Could not get validation package from source".to_string())?;
 
@@ -33,7 +48,27 @@ pub async fn hold_remove_workflow(
         None,
         validation_data,
         &context
-    ))?;
+    ))
+    .map_err(|err| {
+        if let ValidationError::UnresolvedDependencies(dependencies) = &err {
+            context.log(format!("debug/workflow/hold_remove: Entry removal could not be validated due to unresolved dependencies and will be tried later. List of missing dependencies: {:?}", dependencies));
+            add_pending_validation(
+                entry_with_header.to_owned(),
+                dependencies.clone(),
+                ValidatingWorkflow::RemoveEntry,
+                context.clone(),
+            );
+            HolochainError::ValidationPending
+        } else {
+            context.log(format!(
+                "info/workflow/hold_remove: Entry removal {:?} is NOT valid! Validation error: {:?}",
+                entry_with_header.entry,
+                err,
+            ));
+            HolochainError::from(err)
+        }
+
+    })?;
 
     let deletion_entry = unwrap_to!(entry_with_header.entry => Entry::Deletion);
 

--- a/core/src/workflows/hold_entry_update.rs
+++ b/core/src/workflows/hold_entry_update.rs
@@ -4,15 +4,18 @@ use crate::{
 };
 use holochain_persistence_api::cas::content::AddressableContent;
 
-use crate::workflows::validation_package;
+use crate::{
+    nucleus::{
+        actions::add_pending_validation::add_pending_validation, validation::ValidationError,
+    },
+    scheduled_jobs::pending_validations::ValidatingWorkflow,
+    workflows::validation_package,
+};
 use holochain_core_types::{
     error::HolochainError,
     validation::{EntryLifecycle, ValidationData},
 };
 use std::sync::Arc;
-use crate::nucleus::actions::add_pending_validation::add_pending_validation;
-use crate::scheduled_jobs::pending_validations::ValidatingWorkflow;
-use crate::nucleus::validation::ValidationError;
 
 pub async fn hold_update_workflow<'a>(
     entry_with_header: &EntryWithHeader,

--- a/core/src/workflows/hold_entry_update.rs
+++ b/core/src/workflows/hold_entry_update.rs
@@ -2,7 +2,7 @@ use crate::{
     context::Context, dht::actions::update_entry::update_entry,
     network::entry_with_header::EntryWithHeader, nucleus::validation::validate_entry,
 };
-use holochain_persistence_api::cas::content::{Address, AddressableContent};
+use holochain_persistence_api::cas::content::AddressableContent;
 
 use crate::workflows::validation_package;
 use holochain_core_types::{
@@ -12,10 +12,10 @@ use holochain_core_types::{
 use std::sync::Arc;
 
 pub async fn hold_update_workflow<'a>(
-    entry_with_header: EntryWithHeader,
+    entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
-) -> Result<Address, HolochainError> {
-    let EntryWithHeader { entry, header } = &entry_with_header;
+) -> Result<(), HolochainError> {
+    let EntryWithHeader { entry, header } = entry_with_header;
 
     // 1. Get hold of validation package
     let maybe_validation_package = await!(validation_package(&entry_with_header, context.clone()))?;
@@ -46,5 +46,7 @@ pub async fn hold_update_workflow<'a>(
         &context.clone(),
         link,
         entry.address().clone()
-    ))
+    ))?;
+
+    Ok(())
 }

--- a/core/src/workflows/hold_link.rs
+++ b/core/src/workflows/hold_link.rs
@@ -17,9 +17,9 @@ use holochain_core_types::{
 };
 use std::sync::Arc;
 
-pub async fn hold_link_workflow<'a>(
-    entry_with_header: &'a EntryWithHeader,
-    context: &'a Arc<Context>,
+pub async fn hold_link_workflow(
+    entry_with_header: &EntryWithHeader,
+    context: Arc<Context>,
 ) -> Result<(), HolochainError> {
     let link_add = match &entry_with_header.entry {
         Entry::LinkAdd(link_add) => link_add,
@@ -43,7 +43,7 @@ pub async fn hold_link_workflow<'a>(
                 entry_with_header.to_owned(),
                 Vec::new(),
                 ValidatingWorkflow::HoldLink,
-                context,
+                context.clone(),
             );
             HolochainError::ValidationPending
         })?;
@@ -54,7 +54,7 @@ pub async fn hold_link_workflow<'a>(
             entry_with_header.to_owned(),
             Vec::new(),
             ValidatingWorkflow::HoldLink,
-            &context,
+            context.clone(),
         );
         HolochainError::ValidationPending
     })?;
@@ -81,7 +81,7 @@ pub async fn hold_link_workflow<'a>(
                 entry_with_header.to_owned(),
                 dependencies.clone(),
                 ValidatingWorkflow::HoldLink,
-                &context,
+                context.clone(),
             );
             HolochainError::ValidationPending
         } else {

--- a/core/src/workflows/remove_link.rs
+++ b/core/src/workflows/remove_link.rs
@@ -3,16 +3,19 @@ use crate::{
     network::entry_with_header::EntryWithHeader, nucleus::validation::validate_entry,
 };
 
-use crate::workflows::validation_package;
+use crate::{
+    nucleus::{
+        actions::add_pending_validation::add_pending_validation, validation::ValidationError,
+    },
+    scheduled_jobs::pending_validations::ValidatingWorkflow,
+    workflows::validation_package,
+};
 use holochain_core_types::{
     entry::Entry,
     error::HolochainError,
     validation::{EntryLifecycle, ValidationData},
 };
 use std::sync::Arc;
-use crate::nucleus::actions::add_pending_validation::add_pending_validation;
-use crate::scheduled_jobs::pending_validations::ValidatingWorkflow;
-use crate::nucleus::validation::ValidationError;
 
 pub async fn remove_link_workflow(
     entry_with_header: &EntryWithHeader,


### PR DESCRIPTION
...instead of fetching base and target and infer it from their types

## PR summary

In #1514 I've simplified the validation process for entry types that don't need the author's source chain for validation (`ValidationPackageDefinition::Entry`) which makes it possible to gossip these entries without caching validation packages.

That helped for custom entry types but not for links since links' entry types used to be inferred through their base and target types. But since we added explicit link types recently, we don't need to depend on base and target (which had to be retrieved to tell if a link can be validated locally).

These changes simplify this by just searching for a link definition that matches the type string.

**Beware:** this introduces the assumption that link entry type names are unique across the whole DNA - which is a reasonable assumption but one we did not buy in with the old code that inferred the type through base, target and tag.

## Clean-up

While working on this PR and making tests pass again, I found that we were not using the pending validation loop for anything but newly created entries and links - not for entry updates, removals nor link removals. I've added those in this PR and harmonized the signatures of all workflow functions.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is not a code change, or doesn't effect anyone outside holochain core development
