### PR TITLE
bugfix: CLI handling of .json files in the project root

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,4 +29,4 @@ rustyline = "=3.0.0"
 
 [dev-dependencies]
 tempfile = "=3.0.7"
-assert_cmd = "0.10"
+assert_cmd = "=0.10"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,4 +29,4 @@ rustyline = "=3.0.0"
 
 [dev-dependencies]
 tempfile = "=3.0.7"
-assert_cmd = "=0.10"
+assert_cmd = "=0.10.2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,3 +29,4 @@ rustyline = "=3.0.0"
 
 [dev-dependencies]
 tempfile = "=3.0.7"
+assert_cmd = "0.10"

--- a/cli/src/cli/package.rs
+++ b/cli/src/cli/package.rs
@@ -109,15 +109,13 @@ impl Packager {
             0 => {
                 // A root json file is optional so can still package the dna
                 None
-            },
-            1 => {
-                Some(root_json_files[0])
-            },
+            }
+            1 => Some(root_json_files[0]),
             _ => {
                 // more than one .json file is ambiguous so present an error
                 return Err (format_err!("Error Packaging DNA: Multiple files with extension .json were found in the root of the project, {:?}.\
                     This is ambiguous as the packager is unable to tell which should be used as the base for the .dna.json", root_json_files)
-                )
+                );
             }
         };
 
@@ -320,11 +318,10 @@ fn unpack_recurse(mut obj: Object, to: &PathBuf) -> DefaultResult<()> {
 // too slow!
 #[cfg(feature = "broken-tests")]
 mod tests {
-    use std::path::PathBuf;
+    use super::*;
     use crate::cli::init::tests::gen_dir;
     use assert_cmd::prelude::*;
-    use std::process::Command;
-    use super::*;
+    use std::{path::PathBuf, process::Command};
 
     #[test]
     fn package_and_unpack_isolated() {
@@ -400,7 +397,6 @@ mod tests {
             .current_dir(&root_path)
             .assert()
             .failure();
-
     }
 
     #[test]

--- a/cli/src/cli/package.rs
+++ b/cli/src/cli/package.rs
@@ -97,10 +97,29 @@ impl Packager {
             .map(|e| e.path().to_path_buf())
             .collect();
 
-        let maybe_json_file_path = root
+        let root_json_files: Vec<&PathBuf> = root
             .iter()
             .filter(|e| e.is_file())
-            .find(|e| e.to_string_lossy().ends_with(".json"));
+            .filter(|e| e.to_string_lossy().ends_with(".json"))
+            .collect();
+
+        let mut meta_section = Object::new();
+
+        let maybe_json_file_path = match root_json_files.len() {
+            0 => {
+                // A root json file is optional so can still package the dna
+                None
+            },
+            1 => {
+                Some(root_json_files[0])
+            },
+            _ => {
+                // more than one .json file is ambiguous so present an error
+                return Err (format_err!("Error Packaging DNA: Multiple files with extension .json were found in the root of the project, {:?}.\
+                    This is ambiguous as the packager is unable to tell which should be used as the base for the .dna.json", root_json_files)
+                )
+            }
+        };
 
         // Scan files but discard found json file
         let all_nodes = root.iter().filter(|node_path| {
@@ -108,8 +127,6 @@ impl Packager {
                 .and_then(|path| Some(node_path != &path))
                 .unwrap_or(true)
         });
-
-        let mut meta_section = Object::new();
 
         // Obtain the config file
         let mut main_tree: Object = if let Some(json_file_path) = maybe_json_file_path {
@@ -303,9 +320,11 @@ fn unpack_recurse(mut obj: Object, to: &PathBuf) -> DefaultResult<()> {
 // too slow!
 #[cfg(feature = "broken-tests")]
 mod tests {
+    use std::path::PathBuf;
     use crate::cli::init::tests::gen_dir;
     use assert_cmd::prelude::*;
     use std::process::Command;
+    use super::*;
 
     #[test]
     fn package_and_unpack_isolated() {
@@ -354,6 +373,34 @@ mod tests {
         unpack(&shared_space.path().to_path_buf());
 
         shared_space.close().unwrap();
+    }
+
+    #[test]
+    fn aborts_if_multiple_json_in_root() {
+        let shared_space = gen_dir();
+
+        let root_path = shared_space.path().to_path_buf();
+
+        fs::create_dir_all(&root_path).unwrap();
+
+        // Initialize and package a project
+        Command::main_binary()
+            .unwrap()
+            .args(&["init", root_path.to_str().unwrap()])
+            .assert()
+            .success();
+
+        // copy the json
+        fs::copy(root_path.join("app.json"), root_path.join("app2.json")).unwrap();
+
+        // ensure the package command fails
+        Command::main_binary()
+            .unwrap()
+            .args(&["package"])
+            .current_dir(&root_path)
+            .assert()
+            .failure();
+
     }
 
     #[test]
@@ -409,19 +456,23 @@ mod tests {
 
     #[test]
     fn auto_compilation() {
-        let tmp = gen_dir();
+        let shared_space = gen_dir();
+
+        let root_path = shared_space.path().to_path_buf();
+
+        fs::create_dir_all(&root_path).unwrap();
 
         Command::main_binary()
             .unwrap()
-            .current_dir(&tmp.path())
-            .args(&["init", "."])
+            .current_dir(&root_path)
+            .args(&["init", root_path.to_str().unwrap()])
             .assert()
             .success();
 
         Command::main_binary()
             .unwrap()
-            .current_dir(&tmp.path())
-            .args(&["g", "zomes/bubblechat", "rust"])
+            .current_dir(&root_path)
+            .args(&["generate", "zomes/bubblechat", "rust"])
             .assert()
             .success();
 
@@ -436,7 +487,7 @@ mod tests {
 
         Command::main_binary()
             .unwrap()
-            .current_dir(&tmp.path())
+            .current_dir(&shared_space.path())
             .args(&["package"])
             .assert()
             .success();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,6 +23,9 @@ extern crate serde_json;
 extern crate ignore;
 extern crate rpassword;
 
+// #[cfg(test)]
+// extern crate assert_cmd;
+
 mod cli;
 mod config_files;
 mod error;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -25,7 +25,6 @@ extern crate rpassword;
 
 // #[cfg(test)]
 // extern crate assert_cmd;
-
 mod cli;
 mod config_files;
 mod error;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,7 +24,6 @@ extern crate ignore;
 extern crate rpassword;
 
 // #[cfg(test)]
-// extern crate assert_cmd;
 mod cli;
 mod config_files;
 mod error;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,7 +23,6 @@ extern crate serde_json;
 extern crate ignore;
 extern crate rpassword;
 
-// #[cfg(test)]
 mod cli;
 mod config_files;
 mod error;


### PR DESCRIPTION
## PR summary

Previously the CLI would use the first file it found in the root directory as the template for the .dna.json. Other .json files found would be converted to base64 and included in the .dna.json.

This lead to difficult to find/debug issues if for some reason you added another .json file to the project root and it became random as to which one would be chosen as the template.

This PR adds a check, if no .json files are in the root it starts packaging from an empty object. If it finds one it uses that as the template object and if it finds more than one it notifies the user of the ambiguity.
