### PR TITLE
adds --dna or -d flag to hc run so it can point to a non-default dna

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `Encryption` and `Decryption` methods in the HDK [#1534](https://github.com/holochain/holochain-rust/pull/1534)
+- Adds a --dna flag to the CLI so `hc run` can run DNAs outside the standard ./dist/ directory [1561](https://github.com/holochain/holochain-rust/pull/1561)
 
 ### Changed
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -104,7 +104,7 @@ enum Cli {
         #[structopt(
             long = "dna",
             short = "d",
-            help = "Absolute path to the .dna.json file to run. [default: ./dist/<dna-name>.dna.json]",
+            help = "Absolute path to the .dna.json file to run. [default: ./dist/<dna-name>.dna.json]"
         )]
         dna_path: Option<PathBuf>,
         #[structopt(long, help = "Produce logging output")]
@@ -219,9 +219,8 @@ fn run() -> HolochainResult<()> {
             interface,
             logging,
         } => {
-            let dna_path = dna_path.unwrap_or(
-                util::std_package_path(&project_path).map_err(HolochainError::Default)?
-            );
+            let dna_path = dna_path
+                .unwrap_or(util::std_package_path(&project_path).map_err(HolochainError::Default)?);
             let interface_type = cli::get_interface_type_string(interface);
             let conductor_config = cli::hc_run_configuration(
                 &dna_path,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -101,6 +101,12 @@ enum Cli {
             help = "Automatically package project before running"
         )]
         package: bool,
+        #[structopt(
+            long = "dna",
+            short = "d",
+            help = "Absolute path to the .dna.json file to run. [default: ./dist/<dna-name>.dna.json]",
+        )]
+        dna_path: Option<PathBuf>,
         #[structopt(long, help = "Produce logging output")]
         logging: bool,
         #[structopt(long, help = "Save generated data to file system")]
@@ -207,13 +213,15 @@ fn run() -> HolochainResult<()> {
         Cli::Run {
             package,
             port,
+            dna_path,
             persist,
             networked,
             interface,
             logging,
         } => {
-            let dna_path =
-                util::std_package_path(&project_path).map_err(HolochainError::Default)?;
+            let dna_path = dna_path.unwrap_or(
+                util::std_package_path(&project_path).map_err(HolochainError::Default)?
+            );
             let interface_type = cli::get_interface_type_string(interface);
             let conductor_config = cli::hc_run_configuration(
                 &dna_path,


### PR DESCRIPTION
## PR summary

Closes #1423 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
