### PR TITLE
Upgrade to lib3h 0.0.3-alpha1

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ holochain_dpki = { path = "../dpki" }
 holochain_json_api = "=0.0.1-alpha2"
 holochain_persistence_api = "=0.0.1-alpha4"
 holochain_persistence_file = "=0.0.1-alpha4"
-lib3h_sodium = "=0.0.2-alpha1"
+lib3h_sodium = "=0.0.3-alpha1"
 holochain_wasm_utils = { path = "../wasm_utils" }
 structopt = "=0.2.15"
 failure = "=0.1.5"

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 [dependencies]
 holochain_core_types = { path = "../core_types" }
 holochain_conductor_api = { path = "../conductor_api" }
-lib3h_sodium = "=0.0.2-alpha1"
+lib3h_sodium = "=0.0.3-alpha1"
 holochain_common = { path = "../common" }
 structopt = "=0.2.15"
 tiny_http = "=0.6.2"

--- a/conductor_api/Cargo.toml
+++ b/conductor_api/Cargo.toml
@@ -14,8 +14,8 @@ holochain_persistence_file = "=0.0.1-alpha4"
 holochain_persistence_pickle = "=0.0.1-alpha6"
 holochain_dpki = { path = "../dpki" }
 holochain_net = { path = "../net" }
-lib3h ="=0.0.2-alpha1"
-lib3h_sodium = "=0.0.2-alpha1"
+lib3h ="=0.0.3-alpha1"
+lib3h_sodium = "=0.0.3-alpha1"
 holochain_common = { path = "../common" }
 chrono = "=0.4.6"
 serde = "=1.0.89"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,7 +36,7 @@ holochain_persistence_file = "=0.0.1-alpha4"
 holochain_persistence_mem = "=0.0.1-alpha4"
 holochain_core_types = { path = "../core_types" }
 holochain_dpki = { path = "../dpki" }
-lib3h_sodium = "=0.0.2-alpha1"
+lib3h_sodium = "=0.0.3-alpha1"
 boolinator = "=2.4.0"
 jsonrpc-core = { git = "https://github.com/holochain/jsonrpc", branch = "broadcaster-getter" }
 jsonrpc-lite = "=0.5.0"

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -29,7 +29,7 @@ objekt= "=0.1.2"
 holochain_persistence_api = "=0.0.1-alpha4"
 holochain_json_derive = "=0.0.1-alpha2"
 holochain_json_api = "=0.0.1-alpha2"
-lib3h_crypto_api = "=0.0.2-alpha1"
+lib3h_crypto_api = "=0.0.3-alpha1"
 uuid = { version = "=0.7.1", features = ["v4"] }
 regex = "=1.1.2"
 shrinkwraprs = "=0.2.1"

--- a/dpki/Cargo.toml
+++ b/dpki/Cargo.toml
@@ -9,7 +9,7 @@ lazy_static = "=1.2.0"
 base64 = "=0.10.1"
 holochain_core_types = { path = "../core_types" }
 holochain_persistence_api = "=0.0.1-alpha4"
-lib3h_sodium = "=0.0.2-alpha1"
+lib3h_sodium = "=0.0.3-alpha1"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -9,8 +9,9 @@ tempfile = "=3.0.7"
 
 [dependencies]
 failure = "=0.1.5"
-lib3h = "=0.0.2-alpha1"
-lib3h_protocol = "=0.0.2-alpha1"
+lib3h = "=0.0.3-alpha1"
+lib3h_protocol = "=0.0.3-alpha1"
+lib3h_crypto_api = "=0.0.3-alpha1"
 holochain_common = { path = "../common" }
 holochain_core_types = { path = "../core_types" }
 holochain_json_derive = "=0.0.1-alpha2"

--- a/net/src/lib3h_worker.rs
+++ b/net/src/lib3h_worker.rs
@@ -6,9 +6,9 @@ use crate::connection::{
     NetResult,
 };
 use lib3h::{
-  dht::mirror_dht::MirrorDht,
-  engine::{RealEngine, RealEngineConfig},
-  transport_wss::TransportWss,
+    dht::mirror_dht::MirrorDht,
+    engine::{RealEngine, RealEngineConfig},
+    transport_wss::TransportWss,
 };
 
 use lib3h_crypto_api::{FakeCryptoSystem, InsecureBuffer};
@@ -23,7 +23,8 @@ use lib3h_protocol::network_engine::NetworkEngine;
 pub struct Lib3hWorker {
     handler: NetHandler,
     can_send_P2pReady: bool,
-    net_engine: RealEngine<TransportWss<std::net::TcpStream>, MirrorDht, InsecureBuffer, FakeCryptoSystem>,
+    net_engine:
+        RealEngine<TransportWss<std::net::TcpStream>, MirrorDht, InsecureBuffer, FakeCryptoSystem>,
 }
 
 /// Constructors

--- a/net/src/lib3h_worker.rs
+++ b/net/src/lib3h_worker.rs
@@ -6,10 +6,12 @@ use crate::connection::{
     NetResult,
 };
 use lib3h::{
-    dht::mirror_dht::MirrorDht,
-    engine::{RealEngine, RealEngineConfig},
-    transport_wss::TransportWss,
+  dht::mirror_dht::MirrorDht,
+  engine::{RealEngine, RealEngineConfig},
+  transport_wss::TransportWss,
 };
+
+use lib3h_crypto_api::{FakeCryptoSystem, InsecureBuffer};
 use lib3h_protocol::network_engine::NetworkEngine;
 
 /// A worker that makes use of lib3h / NetworkEngine.
@@ -21,7 +23,7 @@ use lib3h_protocol::network_engine::NetworkEngine;
 pub struct Lib3hWorker {
     handler: NetHandler,
     can_send_P2pReady: bool,
-    net_engine: RealEngine<TransportWss<std::net::TcpStream>, MirrorDht>,
+    net_engine: RealEngine<TransportWss<std::net::TcpStream>, MirrorDht, InsecureBuffer, FakeCryptoSystem>,
 }
 
 /// Constructors
@@ -80,7 +82,7 @@ impl NetWorker for Lib3hWorker {
 
     /// Set the advertise as worker's endpoint
     fn endpoint(&self) -> Option<String> {
-        Some(self.net_engine.advertise())
+        Some(self.net_engine.advertise().to_string())
     }
 }
 

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 holochain_core_types = { path = "../core_types" }
 holochain_persistence_api = "=0.0.1-alpha4"
 holochain_net = { path = "../net" }
-lib3h = "=0.0.2-alpha1"
-lib3h_protocol = "=0.0.2-alpha1"
+lib3h = "=0.0.3-alpha1"
+lib3h_protocol = "=0.0.3-alpha1"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 tempfile = "=3.0.7"
 failure = "=0.1.5"
@@ -18,7 +18,7 @@ backtrace = "=0.3.14"
 multihash = "=0.8.0"
 crossbeam-channel = "=0.3.8"
 bincode = "=1.1.4"
-
+url = "=1.7.2"
 [[bin]]
 name = "holochain_test_bin"
 path = "src/main.rs"

--- a/test_bin/src/lib3h_workflows.rs
+++ b/test_bin/src/lib3h_workflows.rs
@@ -55,7 +55,8 @@ pub fn setup_two_lib3h_nodes(
         alex.send(
             Lib3hClientProtocol::Connect(lib3h_protocol::data_types::ConnectData {
                 request_id: "connect_req_1".into(),
-                peer_uri: Url::parse(billy.p2p_binding.clone().as_str()).expect("well formed peer uri"),
+                peer_uri: Url::parse(billy.p2p_binding.clone().as_str())
+                    .expect("well formed peer uri"),
                 network_id: "FIXME".into(),
             })
             .into(),

--- a/test_bin/src/lib3h_workflows.rs
+++ b/test_bin/src/lib3h_workflows.rs
@@ -7,6 +7,7 @@ use holochain_persistence_api::cas::content::Address;
 use lib3h_protocol::{protocol_client::Lib3hClientProtocol, protocol_server::Lib3hServerProtocol};
 use p2p_node::test_node::TestNode;
 use std::str;
+use url::Url;
 
 /// Do normal setup: 'TrackDna' & 'Connect',
 /// and check that we received 'PeerConnected'
@@ -54,7 +55,7 @@ pub fn setup_two_lib3h_nodes(
         alex.send(
             Lib3hClientProtocol::Connect(lib3h_protocol::data_types::ConnectData {
                 request_id: "connect_req_1".into(),
-                peer_transport: billy.p2p_binding.clone().into(),
+                peer_uri: Url::parse(billy.p2p_binding.clone().as_str()).expect("well formed peer uri"),
                 network_id: "FIXME".into(),
             })
             .into(),

--- a/test_bin/src/main.rs
+++ b/test_bin/src/main.rs
@@ -3,6 +3,7 @@
 
 #[macro_use]
 extern crate failure;
+extern crate url;
 
 extern crate holochain_persistence_api;
 

--- a/test_bin/src/p2p_node/create_config.rs
+++ b/test_bin/src/p2p_node/create_config.rs
@@ -115,10 +115,11 @@ pub(crate) fn create_lib3h_config(
             backend_kind: P2pBackendKind::LIB3H,
             backend_config: BackendConfig::Lib3h(RealEngineConfig {
                 socket_type: "ws".into(),
+                tls_config: lib3h::transport_wss::TlsConfig::Unencrypted,
                 bootstrap_nodes: bootstrap_nodes,
                 work_dir: dir.clone(),
                 log_level: 'd',
-                bind_url: format!("FIXME"),
+                bind_url: url::Url::parse("fixme://bind_url").unwrap(),
                 dht_custom_config: vec![],
             }),
             maybe_end_user_config: None,

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -12,7 +12,7 @@ holochain_core_types = { path = "../core_types" }
 holochain_dpki = { path = "../dpki" }
 holochain_persistence_api = "=0.0.1-alpha4"
 holochain_json_api = "=0.0.1-alpha2"
-lib3h_sodium = "=0.0.2-alpha1"
+lib3h_sodium = "=0.0.3-alpha1"
 wabt = "=0.7.4"
 tempfile = "=3.0.7"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }


### PR DESCRIPTION
## PR summary

This PR updates all lib3h related crates to `0.0.3-alpha1`.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
