### PR TITLE
Fix app-spec (flakyness and false positives)

### DIFF
--- a/app_spec/build_and_test.sh
+++ b/app_spec/build_and_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 mkdir -p dist
 echo "===================================================================================="
 echo "RUNNING cargo test for zomes"

--- a/app_spec/test/run-ci.sh
+++ b/app_spec/test/run-ci.sh
@@ -6,6 +6,7 @@ STORAGE="`pwd`/diorama-storage"
 rm -fr $STORAGE
 mkdir $STORAGE
 if [ -z $1];
-then DIORAMA_STORAGE=$STORAGE node index.js | tee test.out~ || ( cat test.out~; false );
+# We are directly pointing to the faucet executable because we can't use symlinks in vagrant on windows
+then DIORAMA_STORAGE=$STORAGE node index.js | tee test.out~ | node_modules/faucet/bin/cmd.js || ( cat test.out~; false );
 else DIORAMA_STORAGE=$STORAGE node $1;
 fi;

--- a/app_spec/zomes/blog/code/src/memo.rs
+++ b/app_spec/zomes/blog/code/src/memo.rs
@@ -71,14 +71,17 @@ pub fn definition() -> ValidatingEntryType {
 mod tests {
 
     use crate::memo::{definition, Memo};
-    use hdk::holochain_core_types::{
-        chain_header::test_chain_header,
-        dna::entry_types::{EntryTypeDef, Sharing},
-        entry::{
-            entry_type::{AppEntryType, EntryType},
-            Entry,
+    use hdk::{
+        holochain_core_types::{
+            chain_header::test_chain_header,
+            dna::entry_types::{EntryTypeDef, Sharing},
+            entry::{
+                entry_type::{AppEntryType, EntryType},
+                Entry,
+            },
+            validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
         },
-        validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
+        holochain_json_api::json::JsonString,
     };
 
     #[test]
@@ -101,7 +104,7 @@ mod tests {
         assert_eq!(expected_name, memo_definition.name.clone());
 
         let expected_definition = EntryTypeDef {
-            description: "A private memo entry type.".to_string(),
+            properties: JsonString::from("A private memo entry type."),
             linked_from: vec![],
             links_to: Vec::new(),
             sharing: Sharing::Private,

--- a/app_spec/zomes/blog/code/src/post.rs
+++ b/app_spec/zomes/blog/code/src/post.rs
@@ -128,6 +128,7 @@ mod tests {
             },
             validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
         },
+        holochain_json_api::json::JsonString,
         holochain_wasm_utils::api_serialization::validation::LinkDirection,
     };
     use std::convert::TryInto;
@@ -152,7 +153,7 @@ mod tests {
         assert_eq!(expected_name, post_definition.name.clone());
 
         let expected_definition = EntryTypeDef {
-            description: "blog entry post".to_string(),
+            properties: JsonString::from("blog entry post"),
             linked_from: vec![
                 LinkedFrom {
                     base_type: "%agent_id".to_string(),

--- a/app_spec/zomes/simple/code/src/lib.rs
+++ b/app_spec/zomes/simple/code/src/lib.rs
@@ -168,7 +168,7 @@ define_zome! {
     ]
 
     traits: {
-        hc_public [create_link, delete_link, get_my_links, test_emit_signal]
+        hc_public [create_link, delete_link, get_my_links, test_emit_signal, encrypt, decrypt]
     }
 }
 

--- a/app_spec_proc_macro/build_and_test.sh
+++ b/app_spec_proc_macro/build_and_test.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 mkdir -p dist
 echo "===================================================================================="
 echo "RUNNING cargo test for zomes"

--- a/app_spec_proc_macro/build_and_test.sh
+++ b/app_spec_proc_macro/build_and_test.sh
@@ -14,7 +14,9 @@ echo "DONE."
 echo "===================================================================================="
 echo "Copying test from app_spec and running test.js in node"
 echo "------------------------------------------------------------------------------------"
+rm -rf ./test
 cp -rf ../app_spec/test ./test
 cd test
-npm install
-npm test
+rm -rf diorama-storage
+npm install --no-bin-links
+npm run test-ci

--- a/app_spec_proc_macro/zomes/blog/code/src/memo.rs
+++ b/app_spec_proc_macro/zomes/blog/code/src/memo.rs
@@ -70,14 +70,17 @@ pub fn definition() -> ValidatingEntryType {
 mod tests {
 
     use crate::memo::{definition, Memo};
-    use hdk::holochain_core_types::{
-        chain_header::test_chain_header,
-        dna::entry_types::{EntryTypeDef, Sharing},
-        entry::{
-            entry_type::{AppEntryType, EntryType},
-            Entry,
+    use hdk::{
+        holochain_core_types::{
+            chain_header::test_chain_header,
+            dna::entry_types::{EntryTypeDef, Sharing},
+            entry::{
+                entry_type::{AppEntryType, EntryType},
+                Entry,
+            },
+            validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
         },
-        validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
+        holochain_json_api::json::JsonString,
     };
 
     #[test]
@@ -100,7 +103,7 @@ mod tests {
         assert_eq!(expected_name, memo_definition.name.clone());
 
         let expected_definition = EntryTypeDef {
-            description: "A private memo entry type.".to_string(),
+            properties: JsonString::from("A private memo entry type."),
             linked_from: vec![],
             links_to: Vec::new(),
             sharing: Sharing::Private,

--- a/app_spec_proc_macro/zomes/blog/code/src/post.rs
+++ b/app_spec_proc_macro/zomes/blog/code/src/post.rs
@@ -127,6 +127,7 @@ mod tests {
             },
             validation::{EntryLifecycle, EntryValidationData, ValidationData, ValidationPackage},
         },
+        holochain_json_api::json::JsonString,
         holochain_wasm_utils::api_serialization::validation::LinkDirection,
     };
     use std::convert::TryInto;
@@ -151,7 +152,7 @@ mod tests {
         assert_eq!(expected_name, post_definition.name.clone());
 
         let expected_definition = EntryTypeDef {
-            description: "blog entry post".to_string(),
+            properties: JsonString::from("blog entry post"),
             linked_from: vec![
                 LinkedFrom {
                     base_type: "%agent_id".to_string(),

--- a/app_spec_proc_macro/zomes/converse/code/src/lib.rs
+++ b/app_spec_proc_macro/zomes/converse/code/src/lib.rs
@@ -22,7 +22,10 @@ pub mod converse {
     #[genesis]
     pub fn genesis() {
         hdk::keystore_new_random("app_root_seed", 32)
-            .map_err(|err| format!("new seed generation failed: {}",err) )
+            .map_err(|err|
+                hdk::debug(format!("ignoring new seed generation because of error: {}",err))
+            ).unwrap_or(());
+        Ok(())
     }
 
     #[zome_fn("hc_public")]

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 let
- holonix-release-tag = "0.0.1";
- holonix-release-sha256 = "1n26n9q4i2k11n1m7disjs7s5s11lq29icqyk8qngqs5gf7kq4pi";
+ holonix-release-tag = "0.0.3";
+ holonix-release-sha256 = "0da3kam3sxri73rfanlr8mkl95q74cqvn02y3fa0c021144qxgxv";
 
  holonix = import (fetchTarball {
   url = "https://github.com/holochain/holonix/tarball/${holonix-release-tag}";


### PR DESCRIPTION
## PR summary

This fixes several problems that lead to app-spec CI tests being almost always wrong, which in turn was the cause for red cold builds.

Errors during the build of `hc`, `holochain` or the app-spec zome were shown but did not make the whole suite fail as long as there were old build artifacts which then masked errors.

But even if app-spec scenarios would fail, because faucet was removed the return code was 0 in all cases and CircleCI treated that as a pass.

This gets all cleaned up in this PR. Some of that was fixes in holonix which also gets version bumped in here.

Also some app-spec and app-spec-proc-macro fixes are in here that were masked because of all the above and that I included here to get CI to pass again.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is not a code change, or doesn't effect anyone outside holochain core development
