### PR TITLE
added n3h keepalive network

### DIFF
--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -118,6 +118,14 @@ impl Drop for Conductor {
             }
         }
         self.shutdown();
+        if let Some(network) = self.n3h_keepalive_network.take() {
+            if let Err(err) = network.stop() {
+                println!("ERROR stopping network thread: {:?}", err);
+            } else {
+                println!("Network thread successfully stopped");
+            }
+            self.n3h_keepalive_network = None;
+        };
     }
 }
 
@@ -448,14 +456,6 @@ impl Conductor {
             .as_ref()
             .map(|sender| sender.send(()));
         self.instances = HashMap::new();
-        if let Some(network) = self.n3h_keepalive_network.take() {
-            if let Err(err) = network.stop() {
-                println!("ERROR stopping network thread: {:?}", err);
-            } else {
-                println!("Network thread successfully stopped");
-            }
-            self.n3h_keepalive_network = None;
-        };
     }
 
     pub fn spawn_network(&mut self) -> Result<SpawnResult, HolochainError> {

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -46,8 +46,10 @@ use conductor::passphrase_manager::{PassphraseManager, PassphraseServiceCmd};
 use config::AgentConfiguration;
 use holochain_core_types::dna::bridges::BridgePresence;
 use holochain_net::{
+    connection::net_connection::NetHandler,
     ipc::spawn::{ipc_spawn, SpawnResult},
     p2p_config::{BackendConfig, P2pBackendKind, P2pConfig},
+    p2p_network::P2pNetwork,
 };
 use interface::{ConductorApiBuilder, InstanceMap, Interface};
 use signal_wrapper::SignalWrapper;
@@ -104,6 +106,8 @@ pub struct Conductor {
     network_spawn: Option<SpawnResult>,
     pub passphrase_manager: Arc<PassphraseManager>,
     pub hash_config: Option<PwHashConfig>, // currently this has to be pub for testing.  would like to remove
+    // TODO: remove this when n3h gets deprecated
+    n3h_keepalive_network: Option<P2pNetwork>, // hack needed so that n3h process stays alive even if all instances get shutdown.
 }
 
 impl Drop for Conductor {
@@ -163,6 +167,7 @@ impl Conductor {
                 PassphraseServiceCmd {},
             )))),
             hash_config: None,
+            n3h_keepalive_network: None,
         }
     }
 
@@ -443,6 +448,14 @@ impl Conductor {
             .as_ref()
             .map(|sender| sender.send(()));
         self.instances = HashMap::new();
+        if let Some(network) = self.n3h_keepalive_network.take() {
+            if let Err(err) = network.stop() {
+                println!("ERROR stopping network thread: {:?}", err);
+            } else {
+                println!("Network thread successfully stopped");
+            }
+            self.n3h_keepalive_network = None;
+        };
     }
 
     pub fn spawn_network(&mut self) -> Result<SpawnResult, HolochainError> {
@@ -518,7 +531,18 @@ impl Conductor {
                             .as_ref()
                             .map(|spawn| spawn.ipc_binding.clone())
                     });
-                P2pConfig::new_ipc_uri(uri, &config.bootstrap_nodes, config.networking_config_file)
+                let config = P2pConfig::new_ipc_uri(
+                    uri,
+                    &config.bootstrap_nodes,
+                    config.networking_config_file,
+                );
+                // create an empty network with this config just so the n3h process doesn't
+                // kill itself in the case that all instances are closed down (as happens in app-spec)
+                let network =
+                    P2pNetwork::new(NetHandler::new(Box::new(|_r| Ok(()))), config.clone())
+                        .expect("unable to create conductor keepalive P2pNetwork");
+                self.n3h_keepalive_network = Some(network);
+                config
             }
             NetworkConfig::Lib3h(config) => P2pConfig {
                 backend_kind: P2pBackendKind::LIB3H,

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -20,6 +20,7 @@ use holochain_core_types::{
     },
     error::{HcResult, HolochainError},
 };
+//use logging::rule::Rule;
 
 use holochain_json_api::json::JsonString;
 use holochain_persistence_api::cas::content::AddressableContent;


### PR DESCRIPTION
## PR summary

Adds an instance of P2pNetwork into the conductor just to keep the n3h process alive so that it doesn't get shutdown if all of the instances in the conductor are shutdown.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
