### PR TITLE
Remove serde default for dna hash - merge ASAP!

### DIFF
--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -573,7 +573,6 @@ impl From<AgentConfiguration> for AgentId {
 pub struct DnaConfiguration {
     pub id: String,
     pub file: String,
-    #[serde(default)]
     pub hash: String,
 }
 


### PR DESCRIPTION
## PR summary

quick fix for #1335 -- currently because of this lingering default, when running a config file that omits a dna hash designation, I get the unhelpful error:

    err/Conductor: DNA hashes mismatch: 'Conductor config' != 'Conductor instance': '' != 'QmWquQXU2rgYY6cyp15QUoX8KWnVaKgQkxTtugFnkNVcev'

With this PR, it becomes the more sensible:

    Error while trying to boot from config: IoError("Error loading configuration: missing field `hash` for key `dnas`")

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
