### PR TITLE
Have `hc run` set the DNA hash in the conductor config

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 
 ### Fixed
+- Fixed problem with `hc run` that was introduced by [Conductor config sanitizing](https://github.com/holochain/holochain-rust/pull/1335) a week ago: The conductor config now needs to include the correct hash of each configured DNA file. [#1603](https://github.com/holochain/holochain-rust/pull/1603) adds the proper hash to the internally created conductor config that `hc run` runs.
 
 ### Security
 

--- a/cli/src/cli/run.rs
+++ b/cli/src/cli/run.rs
@@ -234,14 +234,15 @@ fn networking_configuration(networked: bool) -> Option<NetworkConfig> {
 
 #[cfg(test)]
 mod tests {
+    extern crate tempfile;
     // use crate::cli::init::{init, tests::gen_dir};
     // use assert_cmd::prelude::*;
     // use std::{env, process::Command, path::PathBuf};
+    use self::tempfile::tempdir;
     use holochain_conductor_api::config::*;
     use holochain_core_types::dna::Dna;
     use holochain_persistence_api::cas::content::AddressableContent;
     use std::fs::{create_dir, File};
-    use tempfile::tempdir;
 
     #[test]
     // flagged as broken for:

--- a/cli/src/cli/run.rs
+++ b/cli/src/cli/run.rs
@@ -3,13 +3,14 @@ use colored::*;
 use error::DefaultResult;
 use holochain_common::env_vars::EnvVar;
 use holochain_conductor_api::{
-    conductor::{mount_conductor_from_config, CONDUCTOR},
+    conductor::{mount_conductor_from_config, Conductor, CONDUCTOR},
     config::*,
     key_loaders::{test_keystore, test_keystore_loader},
     keystore::PRIMARY_KEYBUNDLE_ID,
     logger::LogRules,
 };
 use holochain_core_types::agent::AgentId;
+use holochain_persistence_api::cas::content::AddressableContent;
 use std::{fs, path::PathBuf};
 
 /// Starts a minimal configuration Conductor with the current application running
@@ -118,13 +119,17 @@ fn agent_configuration() -> AgentConfiguration {
 const DNA_CONFIG_ID: &str = "hc-run-dna";
 
 fn dna_configuration(dna_path: &PathBuf) -> DnaConfiguration {
+    let dna = Conductor::load_dna(dna_path).expect(&format!(
+        "Could not load DNA file {}",
+        dna_path.to_str().expect("No DNA file path given")
+    ));
     DnaConfiguration {
         id: DNA_CONFIG_ID.into(),
         file: dna_path
             .to_str()
             .expect("Expected DNA path to be valid unicode")
             .to_string(),
-        hash: String::from("DNA Hash"),
+        hash: dna.address().to_string(),
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,7 +21,6 @@ extern crate toml;
 extern crate serde_json;
 extern crate ignore;
 extern crate rpassword;
-extern crate tempfile;
 
 mod cli;
 mod config_files;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,7 @@ extern crate toml;
 extern crate serde_json;
 extern crate ignore;
 extern crate rpassword;
+extern crate tempfile;
 
 mod cli;
 mod config_files;

--- a/core_types/src/dna/mod.rs
+++ b/core_types/src/dna/mod.rs
@@ -290,7 +290,7 @@ pub mod tests {
     use holochain_persistence_api::cas::content::Address;
     use std::convert::TryFrom;
 
-    fn test_dna() -> Dna {
+    pub fn test_dna() -> Dna {
         let fixture = String::from(
             r#"{
                 "name": "test",


### PR DESCRIPTION
## PR summary

This was missed when adding strict config checks in https://github.com/holochain/holochain-rust/pull/1335.

`hc run` creates a conductor config to run the given DNA in the working directory. In order for this config to pass the strict hash checks, hc needs to set the right DNA hash in that config.

Fixes https://github.com/holochain/holochain-rust/issues/1594

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
