### PR TITLE
Re-enable accidentally commented app spec tests

### DIFF
--- a/app_spec/test/index.js
+++ b/app_spec/test/index.js
@@ -48,39 +48,39 @@ const orchestratorMultiDna = new Orchestrator({
   callbacksPort: 8888,
 })
 
-// require('./regressions')(orchestratorSimple.registerScenario)
-// require('./test')(orchestratorSimple.registerScenario)
-// require('./multi-dna')(orchestratorMultiDna.registerScenario)
+require('./regressions')(orchestratorSimple.registerScenario)
+require('./test')(orchestratorSimple.registerScenario)
+require('./multi-dna')(orchestratorMultiDna.registerScenario)
 require('./validate-agent-test')(dnaPath)
 
-// const run = async () => {
-//   const alice = await spawnConductor('alice', 3000)
-//   await orchestratorSimple.registerConductor({name: 'alice', url: 'http://0.0.0.0:3000'})
-//   const bob = await spawnConductor('bob', 4000)
-//   await orchestratorSimple.registerConductor({name: 'bob', url: 'http://0.0.0.0:4000'})
-//   const carol = await spawnConductor('carol', 5000)
-//   await orchestratorSimple.registerConductor({name: 'carol', url: 'http://0.0.0.0:5000'})
+const run = async () => {
+  const alice = await spawnConductor('alice', 3000)
+  await orchestratorSimple.registerConductor({name: 'alice', url: 'http://0.0.0.0:3000'})
+  const bob = await spawnConductor('bob', 4000)
+  await orchestratorSimple.registerConductor({name: 'bob', url: 'http://0.0.0.0:4000'})
+  const carol = await spawnConductor('carol', 5000)
+  await orchestratorSimple.registerConductor({name: 'carol', url: 'http://0.0.0.0:5000'})
 
-//   const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
-//   console.log("Waiting for conductors to settle...")
-//   await delay(5000)
-//   console.log("Ok, starting tests!")
+  const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+  console.log("Waiting for conductors to settle...")
+  await delay(5000)
+  console.log("Ok, starting tests!")
 
-//   await orchestratorSimple.run()
-//   alice.kill()
-//   bob.kill()
-//   carol.kill()
+  await orchestratorSimple.run()
+  alice.kill()
+  bob.kill()
+  carol.kill()
 
-//   // Multi instance tests where n3h is the network connecting them currently fails with the 2nd instance
-//   // waiting for and not receiving the agent entry of the first one.
-//   // I believe this is due to n3h not sending a peer connected message for a local instance
-//   // and core has not implented the authoring list yet...
-//   //const conductor = await spawnConductor('conductor', 6000)
-//   //await orchestratorMultiDna.registerConductor({name: 'conductor', url: 'http://0.0.0.0:6000'})
-//   //await orchestratorMultiDna.run()
-//   //conductor.kill()
+  // Multi instance tests where n3h is the network connecting them currently fails with the 2nd instance
+  // waiting for and not receiving the agent entry of the first one.
+  // I believe this is due to n3h not sending a peer connected message for a local instance
+  // and core has not implented the authoring list yet...
+  //const conductor = await spawnConductor('conductor', 6000)
+  //await orchestratorMultiDna.registerConductor({name: 'conductor', url: 'http://0.0.0.0:6000'})
+  //await orchestratorMultiDna.run()
+  //conductor.kill()
 
-//   process.exit()
-// }
+  process.exit()
+}
 
-// run()
+run()

--- a/app_spec/test/validate-agent-test.js
+++ b/app_spec/test/validate-agent-test.js
@@ -1,48 +1,14 @@
 
-const { Orchestrator, tapeExecutor, backwardCompatibilityMiddleware } = require('@holochain/try-o-rama')
-const spawnConductor = require('./spawn_conductors')
+module.exports = scenario => {
 
-module.exports = (dnaPath) => {
-
-  const dna = Orchestrator.dna(dnaPath, 'app-spec')
-
-  const orchestrator = new Orchestrator({
-    conductors: {
-      valid_agent: { instances: { app: dna } },
-      reject_agent: { instances: { app: dna } },
-    },
-    debugLog: false,
-    executor: tapeExecutor(require('tape')),
-    middleware: backwardCompatibilityMiddleware,
-  })
-
-  orchestrator.registerScenario('An agent that does not pass validate_agent will not have a visible entry in the DHT', async (s, t, {valid_agent, reject_agent}) => {
+  scenario('An agent that does not pass validate_agent will not have a visible entry in the DHT', async (s, t, {valid_agent, reject_agent}) => {
     let get_self_result = await valid_agent.app.call("simple", "get_entry", {address: valid_agent.app.agentId})
     let get_other_result = await valid_agent.app.call("simple", "get_entry", {address: reject_agent.app.agentId})
     console.log("get self response", get_self_result)
     console.log("get invalid response", get_self_result)
     t.ok(get_self_result.Ok, "Should be able to retrieve own agent entry")
     t.notOk(get_other_result.Ok, "Should not be able to retrieve agent entry for invalid agent")
+    t.end()
   })
-
-  const run = async () => {
-    const valid_agent = await spawnConductor('valid_agent', 3000)
-    await orchestrator.registerConductor({name: 'valid_agent', url: 'http://0.0.0.0:3000'})
-    const reject_agent = await spawnConductor('reject_agent', 4000)
-    await orchestrator.registerConductor({name: 'reject_agent', url: 'http://0.0.0.0:4000'})
-
-    const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
-    console.log("Waiting for conductors to settle...")
-    await delay(5000)
-    console.log("Ok, starting tests!")
-
-    await orchestrator.run()
-    valid_agent.kill()
-    reject_agent.kill()
-
-    process.exit()
-  }
-
-  run()
 
 }

--- a/app_spec/test/validate-agent-test.js
+++ b/app_spec/test/validate-agent-test.js
@@ -8,7 +8,6 @@ module.exports = scenario => {
     console.log("get invalid response", get_self_result)
     t.ok(get_self_result.Ok, "Should be able to retrieve own agent entry")
     t.notOk(get_other_result.Ok, "Should not be able to retrieve agent entry for invalid agent")
-    t.end()
   })
 
 }


### PR DESCRIPTION
## PR summary

https://github.com/holochain/holochain-rust/pull/1497 had a few extra commits that were merged into develop after all reviewers approved, one of which accidentally disabled almost all app spec tests. This PR restores the tests, and adds a simple meta-test to see if we have about as many tests as we expect to have.

## followups

We might want to discuss our code review policy when a PR undergoes more changes after passing CR. In the most strict case, we should redo CR for any new commits, but maybe we can have something more lax?

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
