### PR TITLE
Deactivate validation tests for now as Try-o-rama has issues with multiple scenario-sets

### DIFF
--- a/app_spec/test/index.js
+++ b/app_spec/test/index.js
@@ -142,7 +142,7 @@ const run = async () => {
 
   await runSimpleTests()
   // await runMultiDnaTests()
-  await runValidationTests()
+  // await runValidationTests()
   process.exit()
 }
 


### PR DESCRIPTION
## PR summary

This should restore app-spec to tests to it's current flaky state that is flaky due to n3h, but solves a problem that had it fail every time.

## Follow-up
This should be added back in after the underlying issue in Try-o-rama got fixed. It must have been there for a while as the multi-DNA-tests were deactivated for a while and the validation-tests got added recently, which made app-spec break.

## changelog

- [x] this is not a code change, or doesn't effect anyone outside holochain core development
