### PR TITLE
WIP - Add header publishing

### DIFF
--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -1,5 +1,25 @@
 module.exports = scenario => {
 
+scenario('header publishing', async (s, t, { alice, bob }) => {
+    const publish_result = await alice.app.call("simple", "create_simple_entry", {content: "testing header publish"})
+    console.log(publish_result)
+    t.ok(publish_result.Ok)
+
+    // get the address of the header from Alice
+    const header_addr = await alice.app.call("simple", "get_entry_header_address", { address: publish_result.Ok })
+    t.ok(header_addr.Ok)
+    console.log(header_addr)
+
+    // load the entry from its address as Bob and check it matches the entry
+    const header = await bob.app.call("simple", "get_entry", {address: header_addr.Ok})
+    t.ok(header.Ok)
+    console.log(header)
+    t.equal(
+      header.Ok.entry_address,
+      publish_result.Ok
+    )
+
+})
 scenario('capabilities grant and claim', async (s, t, { alice, bob }) => {
 
     // Ask for alice to grant a token for bob  (it's hard-coded for bob in re function for now)

--- a/app_spec/test/test.js
+++ b/app_spec/test/test.js
@@ -1,25 +1,37 @@
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
+
 module.exports = scenario => {
 
 scenario('header publishing', async (s, t, { alice, bob }) => {
-    const publish_result = await alice.app.call("simple", "create_simple_entry", {content: "testing header publish"})
+    const publish_result = await alice.app.callSync("simple", "create_simple_entry", {content: "testing header publish"})
     console.log(publish_result)
     t.ok(publish_result.Ok)
 
     // get the address of the header from Alice
-    const header_addr = await alice.app.call("simple", "get_entry_header_address", { address: publish_result.Ok })
+    const header_addr = await alice.app.callSync("simple", "get_entry_header_address", { address: publish_result.Ok })
     t.ok(header_addr.Ok)
-    console.log(header_addr)
+    console.log("Header addresses: ", header_addr.Ok)
 
-    // load the entry from its address as Bob and check it matches the entry
-    const header = await bob.app.call("simple", "get_entry", {address: header_addr.Ok})
-    t.ok(header.Ok)
-    console.log(header)
+    // load the entry from its address as Alice and check it matches the entry
+    const header_from_alice = await alice.app.callSync("simple", "get_entry", {address: header_addr.Ok[0]})
+    t.ok(header_from_alice.Ok)
+    console.log(header_from_alice)
     t.equal(
-      header.Ok.entry_address,
+      header_from_alice.Ok.ChainHeader.entry_address,
       publish_result.Ok
     )
 
+    // load the entry from its address as Bob and  check it matches the entry
+    const header_from_bob = await bob.app.callSync("simple", "get_entry", {address: header_addr.Ok[0]})
+    t.ok(header_from_bob.Ok)
+    console.log(header_from_bob)
+    t.equal(
+      header_from_bob.Ok.ChainHeader.entry_address,
+      publish_result.Ok
+    )
 })
+
 scenario('capabilities grant and claim', async (s, t, { alice, bob }) => {
 
     // Ask for alice to grant a token for bob  (it's hard-coded for bob in re function for now)

--- a/app_spec/zomes/simple/code/src/lib.rs
+++ b/app_spec/zomes/simple/code/src/lib.rs
@@ -162,10 +162,10 @@ fn get_entry_handler(address: Address) -> ZomeApiResult<Option<Entry>> {
     hdk::get_entry(&address)
 }
 
-fn handle_get_entry_header_address(address: Address) -> ZomeApiResult<Address> {
+fn handle_get_entry_header_address(address: Address) -> ZomeApiResult<Vec<Address>> {
    hdk::get_entry_result(&address, GetEntryOptions{headers: true, ..GetEntryOptions::default()}).map(|result| {
         if let GetEntryResultType::Single(result) = result.result {
-            result.headers[0].address()
+            result.headers.iter().map(|h| Entry::ChainHeader(h.clone()).address()).collect()
         } else {
             panic!("Failed to get headers")
         }
@@ -208,7 +208,7 @@ define_zome! {
         }
         get_entry_header_address: {
             inputs: |address: Address|,
-            outputs: |result: ZomeApiResult<Address>|,
+            outputs: |result: ZomeApiResult<Vec<Address>>|,
             handler: handle_get_entry_header_address
         }
         create_link: {

--- a/app_spec_proc_macro/zomes/simple/code/src/lib.rs
+++ b/app_spec_proc_macro/zomes/simple/code/src/lib.rs
@@ -15,22 +15,24 @@ use hdk::{
     error::ZomeApiResult,
     entry_definition::ValidatingEntryType,
     holochain_core_types::{
-        entry::Entry,
+        entry::{Entry},
         dna::entry_types::Sharing,
         link::LinkMatch,
         agent::AgentId,
         validation::EntryValidationData,
     },
     holochain_persistence_api::{
-        cas::content::Address,
+        cas::content::{Address, AddressableContent},
     },
     holochain_json_api::{
        json::JsonString,
        error::JsonError
     },
-    holochain_wasm_utils::api_serialization::get_links::{GetLinksResult,LinksStatusRequestKind,GetLinksOptions,GetLinksResultCount}
+    holochain_wasm_utils::api_serialization::{
+        get_links::{GetLinksResult,LinksStatusRequestKind,GetLinksOptions,GetLinksResultCount},
+        get_entry::{GetEntryOptions, GetEntryResultType},
+    },
 };
-
 
 
 #[zome]
@@ -181,6 +183,22 @@ pub mod simple {
     pub fn decrypt(payload : String) -> ZomeApiResult<String> 
     {
        hdk::decrypt(payload)
+    }
+
+    #[zome_fn("hc_public")]
+    pub fn get_entry_header_address(address: Address) -> ZomeApiResult<Vec<Address>> {
+       hdk::get_entry_result(&address, GetEntryOptions{headers: true, ..GetEntryOptions::default()}).map(|result| {
+            if let GetEntryResultType::Single(result) = result.result {
+                result.headers.iter().map(|h| Entry::ChainHeader(h.clone()).address()).collect()
+            } else {
+                panic!("Failed to get headers")
+            }
+        })
+    }
+
+    #[zome_fn("hc_public")]
+    pub fn create_simple_entry(content: String) -> ZomeApiResult<Address> {
+        hdk::commit_entry(&simple_entry(content))
     }
 
 }

--- a/core/src/network/handler/store.rs
+++ b/core/src/network/handler/store.rs
@@ -41,7 +41,6 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
                     .expect("Could not spawn thread for storing EntryAspect::Content");
             }
             EntryAspect::Header(header) => {
-                // panic!(format!("unimplemented store aspect Header: {:?}", header));
                 context
                     .log("debug/net/handle: handle_store: Got EntryAspect::Header. processing...");
                 thread::Builder::new()

--- a/core/src/network/reducers/publish.rs
+++ b/core/src/network/reducers/publish.rs
@@ -50,13 +50,14 @@ fn publish_header(
     network_state: &mut NetworkState,
     chain_header: &ChainHeader,
 ) -> Result<(), HolochainError> {
+    let header_entry = Entry::ChainHeader(chain_header.clone());
     send(
         network_state,
         Lib3hClientProtocol::PublishEntry(ProvidedEntryData {
             space_address: network_state.dna_address.clone().unwrap().into(),
             provider_agent_id: network_state.agent_id.clone().unwrap().into(),
             entry: EntryData {
-                entry_address: chain_header.address().clone(),
+                entry_address: header_entry.address().clone(),
                 aspect_list: vec![EntryAspect::Header(
                     chain_header.clone()
                 )

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -105,7 +105,10 @@ pub async fn author_entry<'a>(
 pub mod tests {
     use super::author_entry;
     use crate::nucleus::actions::tests::*;
-    use holochain_core_types::entry::test_entry_with_value;
+    use holochain_core_types::{
+        entry::test_entry_with_value
+    };
+    use holochain_persistence_api::cas::content::AddressableContent;
     use holochain_json_api::json::JsonString;
     use std::{thread, time};
 
@@ -155,5 +158,62 @@ pub mod tests {
             "{\"App\":[\"testEntryType\",\"{\\\"stuff\\\":\\\"test entry value\\\"}\"]}"
                 .to_string(),
         );
+    }
+
+    #[test]
+    /// test that the header of an entry can be retrieved directly by its hash by another agent connected
+    /// via the in-memory network
+    fn test_commit_with_dht_publish_header_is_published() {
+        let mut dna = test_dna();
+        dna.uuid = "test_commit_with_dht_publish_header_is_published".to_string();
+        let netname = Some("test_commit_with_dht_publish_header_is_published, the network");
+        let (_instance1, context1) = instance_by_name("jill", dna.clone(), netname);
+        let (_instance2, context2) = instance_by_name("jack", dna, netname);
+
+        let entry_address = context1
+            .block_on(author_entry(
+                &test_entry_with_value("{\"stuff\":\"test entry value\"}"),
+                None,
+                &context1,
+                &vec![],
+            ))
+            .unwrap()
+            .address();
+
+        // get the header from the top of Jill's chain
+        let state = &context1.state().unwrap();
+        let header = state.get_headers(entry_address)
+            .expect("Could not retrieve headers from authors chain")
+            .into_iter()
+            .next()
+            .expect("No headers were found for this entry in the authors chain");
+        thread::sleep(time::Duration::from_millis(500));
+
+        // try and load it by its address as Jack. This means it has been communicated over the network
+        let mut json: Option<JsonString> = None;
+        let mut tries = 0;
+        while json.is_none() && tries < 120 {
+            tries = tries + 1;
+            {
+                let state = &context2.state().unwrap();
+                json = state
+                    .dht()
+                    .content_storage()
+                    .read()
+                    .unwrap()
+                    .fetch(&header.address())
+                    .expect("could not fetch header from CAS");
+            }
+            println!("Try {}: {:?}", tries, json);
+            if json.is_none() {
+                thread::sleep(time::Duration::from_millis(1000));
+            }
+        }
+
+        assert_eq!(
+            json.unwrap(),
+            header.into(),
+        );
+
     }
 }

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -181,6 +181,7 @@ pub mod tests {
             .into_iter()
             .next()
             .expect("No headers were found for this entry in the authors chain");
+        let header_entry = Entry::ChainHeader(header);
 
         // try and load it by its address as Jack. This means it has been communicated over the mock network
         let mut entry: Option<Entry> = None;
@@ -188,7 +189,7 @@ pub mod tests {
         while entry.is_none() && tries < 5 {
             tries = tries + 1;
             {
-                entry = get_entry_from_dht(&context2, &header.address()).expect("Could not retrieve entry from DHT");
+                entry = get_entry_from_dht(&context2, &header_entry.address()).expect("Could not retrieve entry from DHT");
             }
             println!("Try {}: {:?}", tries, entry);
             if entry.is_none() {
@@ -197,7 +198,7 @@ pub mod tests {
         }
         assert_eq!(
             entry,
-            Some(Entry::ChainHeader(header)),
+            Some(header_entry),
         );
     }
 }

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -110,7 +110,6 @@ pub mod tests {
         entry::{test_entry_with_value, Entry}
     };
     use holochain_persistence_api::cas::content::AddressableContent;
-    use holochain_json_api::json::JsonString;
     use std::{thread, time};
 
     #[test]
@@ -184,65 +183,9 @@ pub mod tests {
             .expect("No headers were found for this entry in the authors chain");
 
         // try and load it by its address as Jack. This means it has been communicated over the mock network
-        let mut json: Option<JsonString> = None;
-        let mut tries = 0;
-        while json.is_none() && tries < 120 {
-            tries = tries + 1;
-            {
-                let state = &context2.state().unwrap();
-                json = state
-                    .dht()
-                    .content_storage()
-                    .read()
-                    .unwrap()
-                    .fetch(&header.address())
-                    .expect("could not fetch header from CAS");
-            }
-            println!("Try {}: {:?}", tries, json);
-            if json.is_none() {
-                thread::sleep(time::Duration::from_millis(1000));
-            }
-        }
-        assert_eq!(
-            json.unwrap(),
-            header.into(),
-        );
-    }
-
-    #[test]
-    /// test that the header of an entry can be retrieved directly by its hash by another agent connected
-    /// via the in-memory network
-    fn test_2_commit_with_dht_publish_header_is_published() {
-        let mut dna = test_dna();
-        dna.uuid = "test_commit_with_dht_publish_header_is_published_2".to_string();
-        let netname = Some("test_commit_with_dht_publish_header_is_published_2, the network");
-        let (_instance1, context1) = instance_by_name("jill", dna.clone(), netname);
-        let (_instance2, context2) = instance_by_name("jack", dna, netname);
-
-        let entry_address = context1
-            .block_on(author_entry(
-                &test_entry_with_value("{\"stuff\":\"test entry value\"}"),
-                None,
-                &context1,
-                &vec![],
-            ))
-            .unwrap()
-            .address();
-
-        thread::sleep(time::Duration::from_millis(500));
-
-        // get the header from the top of Jill's chain
-        let state = &context1.state().unwrap();
-        let header = state.get_headers(entry_address)
-            .expect("Could not retrieve headers from authors chain")
-            .into_iter()
-            .next()
-            .expect("No headers were found for this entry in the authors chain");
-
-        // try and load it by its address as Jack. This means it has been communicated over the mock network
         let mut entry: Option<Entry> = None;
         let mut tries = 0;
-        while entry.is_none() && tries < 120 {
+        while entry.is_none() && tries < 5 {
             tries = tries + 1;
             {
                 entry = get_entry_from_dht(&context2, &header.address()).expect("Could not retrieve entry from DHT");

--- a/core/src/workflows/author_entry.rs
+++ b/core/src/workflows/author_entry.rs
@@ -180,6 +180,8 @@ pub mod tests {
             .unwrap()
             .address();
 
+        thread::sleep(time::Duration::from_millis(500));
+
         // get the header from the top of Jill's chain
         let state = &context1.state().unwrap();
         let header = state.get_headers(entry_address)
@@ -187,7 +189,6 @@ pub mod tests {
             .into_iter()
             .next()
             .expect("No headers were found for this entry in the authors chain");
-        thread::sleep(time::Duration::from_millis(500));
 
         // try and load it by its address as Jack. This means it has been communicated over the network
         let mut json: Option<JsonString> = None;

--- a/core/src/workflows/hold_header.rs
+++ b/core/src/workflows/hold_header.rs
@@ -21,12 +21,13 @@ pub async fn hold_header_workflow(
 
     // 1. No need to validate. Store header in local DHT shard
     // create an entry_with_header to leverage existing functionality. A headers header is itself.
-    let entry_with_header = EntryWithHeader::new(Entry::ChainHeader(chain_header.clone()), chain_header.clone());
+    let chain_header_entry = Entry::ChainHeader(chain_header.clone());
+    let entry_with_header = EntryWithHeader::new(chain_header_entry.clone(), chain_header.clone());
     await!(hold_entry(&entry_with_header, context.clone()))?;
 
     context.log(format!(
         "debug/workflow/hold_header: HOLDING: {}",
-        chain_header.address()
+        chain_header_entry.address()
     ));
 
     Ok(())

--- a/core/src/workflows/hold_header.rs
+++ b/core/src/workflows/hold_header.rs
@@ -1,0 +1,33 @@
+use crate::{
+    context::Context,
+    dht::actions::hold::hold_entry,
+    network::entry_with_header::EntryWithHeader,
+};
+
+use holochain_core_types::{
+    error::HolochainError,
+    chain_header::ChainHeader,
+    entry::Entry,
+};
+
+use holochain_persistence_api::cas::content::AddressableContent;
+
+use std::sync::Arc;
+
+pub async fn hold_header_workflow(
+    chain_header: &ChainHeader,
+    context: Arc<Context>,
+) -> Result<(), HolochainError> {
+
+    // 1. No need to validate. Store header in local DHT shard
+    // create an entry_with_header to leverage existing functionality. A headers header is itself.
+    let entry_with_header = EntryWithHeader::new(Entry::ChainHeader(chain_header.clone()), chain_header.clone());
+    await!(hold_entry(&entry_with_header, context.clone()))?;
+
+    context.log(format!(
+        "debug/workflow/hold_header: HOLDING: {}",
+        chain_header.address()
+    ));
+
+    Ok(())
+}

--- a/core/src/workflows/mod.rs
+++ b/core/src/workflows/mod.rs
@@ -9,6 +9,7 @@ pub mod hold_entry_remove;
 pub mod hold_entry_update;
 pub mod hold_link;
 pub mod remove_link;
+pub mod hold_header;
 pub mod respond_validation_package_request;
 
 use crate::{

--- a/core_types/src/entry/mod.rs
+++ b/core_types/src/entry/mod.rs
@@ -227,13 +227,13 @@ pub fn test_unpublishable_entry() -> Entry {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::convert::TryInto;
-    use chain_header::test_chain_header;
     use crate::entry::{expected_entry_address, Entry};
+    use chain_header::test_chain_header;
     use holochain_persistence_api::cas::{
         content::{AddressableContent, AddressableContentTestSuite},
         storage::{test_content_addressable_storage, ExampleContentAddressableStorage},
     };
+    use std::convert::TryInto;
 
     #[test]
     /// tests for PartialEq
@@ -306,20 +306,23 @@ pub mod tests {
         let chain_header = Entry::ChainHeader(test_chain_header());
         let chain_header_json = "{\"ChainHeader\":{\"entry_type\":{\"App\":\"testEntryType\"},\"entry_address\":\"Qma6RfzvZRL127UCEVEktPhQ7YSS1inxEFw7SjEsfMJcrq\",\"provenances\":[[\"HcScIkRaAaaaaaaaaaAaaaAAAAaaaaaaaaAaaaaAaaaaaaaaAaaAAAAatzu4aqa\",\"sig\"]],\"link\":null,\"link_same_type\":null,\"link_update_delete\":null,\"timestamp\":\"2018-10-11T03:23:38+00:00\"}}";
         let expected = JsonString::from_json(chain_header_json);
-        assert_eq!(expected, JsonString::from(Entry::from(chain_header.clone())));
+        assert_eq!(
+            expected,
+            JsonString::from(Entry::from(chain_header.clone()))
+        );
         assert_eq!(
             &chain_header,
             &Entry::from(Entry::try_from(expected.clone()).unwrap())
         );
-        assert_eq!(&chain_header, &Entry::from(Entry::from(chain_header.clone())),);
+        assert_eq!(
+            &chain_header,
+            &Entry::from(Entry::from(chain_header.clone())),
+        );
         // test the conversion used in get_entry_from_cas
         let entry: Option<Entry> = Some(expected)
             .and_then(|js| js.try_into().ok())
             .map(|s: Entry| s.into());
-        assert_eq!(
-            entry,
-            Some(chain_header)
-        )
+        assert_eq!(entry, Some(chain_header))
     }
 
     #[test]

--- a/core_types/src/entry/mod.rs
+++ b/core_types/src/entry/mod.rs
@@ -227,6 +227,8 @@ pub fn test_unpublishable_entry() -> Entry {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use std::convert::TryInto;
+    use chain_header::test_chain_header;
     use crate::entry::{expected_entry_address, Entry};
     use holochain_persistence_api::cas::{
         content::{AddressableContent, AddressableContentTestSuite},
@@ -300,6 +302,24 @@ pub mod tests {
             &Entry::from(Entry::try_from(expected.clone()).unwrap())
         );
         assert_eq!(&sys_entry, &Entry::from(Entry::from(sys_entry.clone())),);
+
+        let chain_header = Entry::ChainHeader(test_chain_header());
+        let chain_header_json = "{\"ChainHeader\":{\"entry_type\":{\"App\":\"testEntryType\"},\"entry_address\":\"Qma6RfzvZRL127UCEVEktPhQ7YSS1inxEFw7SjEsfMJcrq\",\"provenances\":[[\"HcScIkRaAaaaaaaaaaAaaaAAAAaaaaaaaaAaaaaAaaaaaaaaAaaAAAAatzu4aqa\",\"sig\"]],\"link\":null,\"link_same_type\":null,\"link_update_delete\":null,\"timestamp\":\"2018-10-11T03:23:38+00:00\"}}";
+        let expected = JsonString::from_json(chain_header_json);
+        assert_eq!(expected, JsonString::from(Entry::from(chain_header.clone())));
+        assert_eq!(
+            &chain_header,
+            &Entry::from(Entry::try_from(expected.clone()).unwrap())
+        );
+        assert_eq!(&chain_header, &Entry::from(Entry::from(chain_header.clone())),);
+        // test the conversion used in get_entry_from_cas
+        let entry: Option<Entry> = Some(expected)
+            .and_then(|js| js.try_into().ok())
+            .map(|s: Entry| s.into());
+        assert_eq!(
+            entry,
+            Some(chain_header)
+        )
     }
 
     #[test]


### PR DESCRIPTION
## PR summary

Published headers as entries to the DHT when publishing an app entry. This is pre-work to allow for constructing an agents local chain when they are offline for validation or data recovery purposes.

**WIP** Currently only public entries headers are published. This is incorrect and will prevent proper validation. Also cannot seem to load headers to the HDK although tests show they are successfully being published.
