### PR TITLE
fix v in scaffold versions

### DIFF
--- a/cli/src/cli/scaffold/rust.rs
+++ b/cli/src/cli/scaffold/rust.rs
@@ -49,7 +49,7 @@ fn generate_cargo_toml(name: &str, contents: &str, template: &str) -> DefaultRes
     let version_default = if maybe_version.is_some() {
         maybe_version.unwrap()
     } else {
-        String::from("tag = \"v0.0.25-alpha1\"")
+        String::from("tag = \"0.0.25-alpha1\"")
     };
     let maybe_package = config.get("package");
 


### PR DESCRIPTION
## PR summary

- remove a wayward `"v"` that causes downstream chaos

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
