### PR TITLE
Ignore Cargo.lock except at top-level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ app_spec_proc_macro/test/*
 **/diorama-storage
 
 dist/**
+
+Cargo.lock
+!/Cargo.lock


### PR DESCRIPTION
## PR summary

Ignore `Cargo.lock` in `wasm-test` subdirectories.

## followups

See https://github.com/holochain/holochain-rust/pull/1617.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
