### PR TITLE
Don't check public_address match for test_agent

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed
 
 ### Fixed
+- When using agent config with `test_agent = true`, the conductor was checking the `public_address` field against the generated keystore. No longer so. [PR#1629](https://github.com/holochain/holochain-rust/pull/1629)
 
 ### Security
 

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -1030,13 +1030,17 @@ impl Conductor {
                 .get_keybundle(PRIMARY_KEYBUNDLE_ID)
                 .map_err(|err| format!("{}", err,))?;
 
-            if agent_config.public_address != keybundle.get_id() {
-                return Err(format!(
-                    "Key from file '{}' ('{}') does not match public address {} mentioned in config!",
-                    agent_config.keystore_file,
-                    keybundle.get_id(),
-                    agent_config.public_address,
-                ));
+            if let Some(true) = agent_config.test_agent {
+                // don't worry about public_address if this is a test_agent
+            } else {
+                if agent_config.public_address != keybundle.get_id() {
+                    return Err(format!(
+                        "Key from file '{}' ('{}') does not match public address {} mentioned in config!",
+                        agent_config.keystore_file,
+                        keybundle.get_id(),
+                        agent_config.public_address,
+                    ));
+                }
             }
 
             self.agent_keys


### PR DESCRIPTION
## PR summary

Title says it all

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
