### PR TITLE
Tiny - remove last traces of genesis from proc-macro

### DIFF
--- a/hdk-proc-macros/src/into_zome.rs
+++ b/hdk-proc-macros/src/into_zome.rs
@@ -131,7 +131,7 @@ impl IntoZome for syn::ItemMod {
     }
 
     fn extract_validate_agent(&self) -> ValidateAgentCallback {
-        // find all the functions tagged as the genesis callback
+        // find all the functions tagged as the validate_agent callback
         let callbacks: Vec<syn::ItemFn> = funcs_iter(self)
             .filter(is_tagged_with(VALIDATE_AGENT_ATTRIBUTE))
             .fold(Vec::new(), |mut acc, func| {

--- a/hdk-proc-macros/src/to_tokens.rs
+++ b/hdk-proc-macros/src/to_tokens.rs
@@ -106,7 +106,7 @@ impl ToTokens for FnDeclaration {
 
 impl ToTokens for ZomeCodeDef {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let genesis = self.init();
+        let init = self.init();
         let zome_setup = self.zome_setup();
         let list_traits = self.list_traits();
         let list_functions = self.list_functions();
@@ -122,7 +122,7 @@ impl ToTokens for ZomeCodeDef {
 
             #(#entry_def_fns )*
 
-            #genesis
+            #init
 
             #zome_setup
 


### PR DESCRIPTION
## PR summary

There was just a few instances of the name `genesis` still hanging around. This gets rid of them.

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
