### PR TITLE
adds ability to use other attributes and doc comments on zome funcs

### DIFF
--- a/app_spec_proc_macro/zomes/simple/code/src/lib.rs
+++ b/app_spec_proc_macro/zomes/simple/code/src/lib.rs
@@ -90,6 +90,7 @@ pub mod simple {
         Entry::App("simple".into(), Simple::new(content).into())
     }
 
+    /// doc comments are allowed on entry defs
     #[entry_def]
     pub fn simple_entry_def() -> ValidatingEntryType {
           definition()
@@ -115,6 +116,7 @@ pub mod simple {
         }
     }
 
+    /// doc comments are allowed on zome functions
     #[zome_fn("hc_public")]
     fn get_entry(address: Address) -> ZomeApiResult<Option<Entry>> {
         hdk::get_entry(&address)

--- a/hdk-proc-macros/src/into_zome.rs
+++ b/hdk-proc-macros/src/into_zome.rs
@@ -195,9 +195,11 @@ impl IntoZome for syn::ItemMod {
         funcs_iter(self)
             .filter(is_tagged_with(ENTRY_DEF_ATTRIBUTE))
             .fold(Vec::new(), |mut acc, mut func| {
-                // TODO: drop all attributes on the fn. This may cause problems
-                // and really should only drop the ENTRY_DEF_ATTRIBUTE
-                func.attrs = Vec::new();
+                // Drop the EntryDef attribute on the functions so this doesn't recurse
+                func.attrs = func.attrs
+                    .into_iter()
+                    .filter(|attr| !attr.path.is_ident(ENTRY_DEF_ATTRIBUTE))
+                    .collect();
                 acc.push(func);
                 acc
             })
@@ -208,7 +210,10 @@ impl IntoZome for syn::ItemMod {
 	    .filter(is_tagged_with(ZOME_FN_ATTRIBUTE))
 	    .fold(BTreeMap::new(), |mut acc, func| {
             let func_name = func.ident.to_string();
-            func.attrs.iter().for_each(|attr| { // this will error if zome fn has multiple attriutes defined
+            func.attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident(ZOME_FN_ATTRIBUTE))
+            .for_each(|attr| {
                 let meta = attr.parse_meta().unwrap();
                 match meta {
                 	syn::Meta::List(meta_list) => {
@@ -223,9 +228,9 @@ impl IntoZome for syn::ItemMod {
 		                });
                 	},
                 	syn::Meta::Word(_) => emit_warning(&func.ident,
-                        "Function is tagged as zome_fn but is not exposed via a trait. Did you mean to expose it publicly '#[zome_fn(\"hc_public\")]'?"),
+                        "Function is tagged as zome_fn but is not exposed via a Holochain trait. Did you mean to expose it publicly '#[zome_fn(\"hc_public\")]'?"),
                 	_ => emit_error(&func.ident,
-                        "zome_fn must be preceded by a comma delimited list of traits e.g. #[zome_fn(\"hc_public\", \"custom_trait\")"),
+                        "zome_fn must be preceded by a comma delimited list of Holochain traits e.g. #[zome_fn(\"hc_public\", \"custom_trait\")"),
                 }
             });
 	        acc


### PR DESCRIPTION
...and entry defs in the proc macro HDK.

The way function attributes were handled caused the macros to error with an unhelpful error message if tagging zome functions with additional attributes to `#zome_fn()`.

This now ignores other attributes which mainly enables the use of doc comments (`///`). It does not persist the other attributes since the entire zome function is removed from the source tree and rewritten. At this time I can think of no reason we need to allow other attributes. This also may lead to difficult to track down bugs.

Closes #1619 

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
