### PR TITLE
Make test registerer not hide `.only`

### DIFF
--- a/app_spec/test/index.js
+++ b/app_spec/test/index.js
@@ -68,9 +68,16 @@ const registerAllScenarios = () => {
   // test cases if there is any Promise awaiting in between test declarations.
   let numRegistered = 0
 
-  const registerer = orchestrator => (...info) => {
-    numRegistered += 1
-    return orchestrator.registerScenario(...info)
+  const registerer = orchestrator => {
+    const f = (...info) => {
+      numRegistered += 1
+      return orchestrator.registerScenario(...info)
+    }
+    f.only = (...info) => {
+      numRegistered += 1
+      return orchestrator.registerScenario.only(...info)
+    }
+    return f
   }
 
   require('./regressions')(registerer(orchestratorSimple))

--- a/app_spec/test/regressions.js
+++ b/app_spec/test/regressions.js
@@ -1,6 +1,6 @@
 module.exports = scenario => {
 
-scenario.only('calling get_links before link_entries makes no difference', async (s, t, {alice}) => {
+scenario('calling get_links before link_entries makes no difference', async (s, t, {alice}) => {
 
   const get1 = await alice.app.call("blog", "my_posts", {})
   t.ok(get1.Ok)

--- a/app_spec/test/regressions.js
+++ b/app_spec/test/regressions.js
@@ -1,6 +1,6 @@
 module.exports = scenario => {
 
-scenario('calling get_links before link_entries makes no difference', async (s, t, {alice}) => {
+scenario.only('calling get_links before link_entries makes no difference', async (s, t, {alice}) => {
 
   const get1 = await alice.app.call("blog", "my_posts", {})
   t.ok(get1.Ok)


### PR DESCRIPTION
## PR summary

The "registerer" introduced in #1604 wound up eclipsing the `registerScenario.only` function, this makes it visible again.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
