### PR TITLE
Passphrase via IPC

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 * New logging implementation added as a subcrate : a fast logger with a filtering capability using regex expressions, please so [logging](logging) for more details. [#1537](https://github.com/holochain/holochain-rust/pull/1537) and [#1639](https://github.com/holochain/holochain-rust/pull/1639)
+* Ability to provide passphrase to lock/unlock keystores via IPC unix domain socket added. [#1646](https://github.com/holochain/holochain-rust/pull/1646) 
 
 ### Changed
 

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,11 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-* New logging implementation added as a subcrate : a fast logger with a filtering capability using regex expressions, please so [logging](logging) for more details.
+* New logging implementation added as a subcrate : a fast logger with a filtering capability using regex expressions, please so [logging](logging) for more details. [#1537](https://github.com/holochain/holochain-rust/pull/1537) and [#1639](https://github.com/holochain/holochain-rust/pull/1639)
 
 ### Changed
 
-- Bump dependent crate versions (holochain_persistence 0.0.7, holochain_serialization 0.0.7, lib3h 0.0.10) in preparation futures 0.3.0-alpha17 which will allow us to shift to the upcoming Rust 1.38.0 beta
+- Bump dependent crate versions (holochain_persistence 0.0.7, holochain_serialization 0.0.7, lib3h 0.0.10) in preparation futures 0.3.0-alpha17 which will allow us to shift to the upcoming Rust 1.38.0 beta [#1632](https://github.com/holochain/holochain-rust/pull/1632)
 
 ### Deprecated
 

--- a/app_spec/test/index.js
+++ b/app_spec/test/index.js
@@ -68,16 +68,9 @@ const registerAllScenarios = () => {
   // test cases if there is any Promise awaiting in between test declarations.
   let numRegistered = 0
 
-  const registerer = orchestrator => {
-    const f = (...info) => {
-      numRegistered += 1
-      return orchestrator.registerScenario(...info)
-    }
-    f.only = (...info) => {
-      numRegistered += 1
-      return orchestrator.registerScenario.only(...info)
-    }
-    return f
+  const registerer = orchestrator => (...info) => {
+    numRegistered += 1
+    return orchestrator.registerScenario(...info)
   }
 
   require('./regressions')(registerer(orchestratorSimple))

--- a/app_spec/test/index.js
+++ b/app_spec/test/index.js
@@ -68,9 +68,16 @@ const registerAllScenarios = () => {
   // test cases if there is any Promise awaiting in between test declarations.
   let numRegistered = 0
 
-  const registerer = orchestrator => (...info) => {
-    numRegistered += 1
-    return orchestrator.registerScenario(...info)
+  const registerer = orchestrator => {
+    const f = (...info) => {
+      numRegistered += 1
+      return orchestrator.registerScenario(...info)
+    }
+    f.only = (...info) => {
+      numRegistered += 1
+      return orchestrator.registerScenario.only(...info)
+    }
+    return f
   }
 
   require('./regressions')(registerer(orchestratorSimple))

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -735,6 +735,11 @@ exclude = false
 pattern = '.*'"#
             .to_string()
     }
+    pub fn passphrase_service() -> String {
+        r#"[passphrase_service]
+type = 'cmd'"#
+            .to_string()
+    }
 
     pub fn add_block(base: String, new_block: String) -> String {
         format!("{}\n\n{}", base, new_block)
@@ -842,6 +847,7 @@ id = 'new-dna'"#,
         toml = add_block(toml, instance2());
         toml = add_block(toml, interface(3000));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1153,6 +1159,7 @@ id = 'new-instance'"#,
         );
         toml = add_block(toml, interface(3001));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1201,6 +1208,7 @@ type = 'websocket'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1249,6 +1257,7 @@ type = 'websocket'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1296,6 +1305,7 @@ type = 'http'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1336,6 +1346,7 @@ type = 'http'"#,
         toml = add_block(toml, instance1());
         toml = add_block(toml, instance2());
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1460,6 +1471,7 @@ type = 'websocket'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1513,6 +1525,7 @@ type = 'websocket'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1561,6 +1574,7 @@ public_address = '{}'"#,
         toml = add_block(toml, instance2());
         toml = add_block(toml, interface(3009));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1606,6 +1620,7 @@ type = 'websocket'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1651,6 +1666,7 @@ handle = 'my favourite instance!'"#,
         toml = add_block(toml, instance2());
         toml = add_block(toml, interface(3011));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -1678,6 +1694,7 @@ handle = 'my favourite instance!'"#,
         toml = add_block(toml, instance2());
         toml = add_block(toml, interface(3011));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -188,6 +188,8 @@ impl Conductor {
             if let PassphraseServiceConfig::UnixSocket { path } = config.passphrase_service.clone()
             {
                 #[cfg(not(unix))]
+                let _ = path;
+                #[cfg(not(unix))]
                 panic!("Unix domain sockets are not available on non-Unix systems. Can't create a PassphraseServiceUnixSocket.");
 
                 #[cfg(unix)]

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -40,11 +40,11 @@ use std::{
 };
 
 use boolinator::Boolinator;
+#[cfg(unix)]
+use conductor::passphrase_manager::PassphraseServiceUnixSocket;
 use conductor::passphrase_manager::{
     PassphraseManager, PassphraseService, PassphraseServiceCmd, PassphraseServiceMock,
 };
-#[cfg(unix)]
-use conductor::passphrase_manager::PassphraseServiceUnixSocket;
 use config::{AgentConfiguration, PassphraseServiceConfig};
 use holochain_core_types::dna::bridges::BridgePresence;
 use holochain_net::{
@@ -184,27 +184,23 @@ impl Conductor {
             println!();
         }
 
+        let passphrase_service: Arc<Mutex<dyn PassphraseService + Send>> =
+            if let PassphraseServiceConfig::UnixSocket { path } = config.passphrase_service.clone()
+            {
+                #[cfg(not(unix))]
+                panic!("Unix domain sockets are not available on non-Unix systems. Can't create a PassphraseServiceUnixSocket.");
 
-
-        let passphrase_service: Arc<Mutex<dyn PassphraseService + Send>> = if let PassphraseServiceConfig::UnixSocket{path} = config.passphrase_service.clone() {
-            #[cfg(not(unix))]
-            panic!("Unix domain sockets are not available on non-Unix systems. Can't create a PassphraseServiceUnixSocket.");
-
-            #[cfg(unix)]
-            Arc::new(Mutex::new(PassphraseServiceUnixSocket::new(path)))
-        } else {
-            match config.passphrase_service.clone() {
-                PassphraseServiceConfig::Cmd => Arc::new(Mutex::new(PassphraseServiceCmd {})),
-                PassphraseServiceConfig::Mock { passphrase } => {
-                    Arc::new(Mutex::new(PassphraseServiceMock { passphrase }))
-                },
-                _ => unreachable!()
-            }
-        };
-
-
-
-
+                #[cfg(unix)]
+                Arc::new(Mutex::new(PassphraseServiceUnixSocket::new(path)))
+            } else {
+                match config.passphrase_service.clone() {
+                    PassphraseServiceConfig::Cmd => Arc::new(Mutex::new(PassphraseServiceCmd {})),
+                    PassphraseServiceConfig::Mock { passphrase } => {
+                        Arc::new(Mutex::new(PassphraseServiceMock { passphrase }))
+                    }
+                    _ => unreachable!(),
+                }
+            };
 
         Conductor {
             instances: HashMap::new(),

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -40,7 +40,10 @@ use std::{
 };
 
 use boolinator::Boolinator;
-use conductor::passphrase_manager::{PassphraseManager, PassphraseServiceUnixSocket, PassphraseServiceCmd, PassphraseServiceMock, PassphraseService};
+use conductor::passphrase_manager::{
+    PassphraseManager, PassphraseService, PassphraseServiceCmd, PassphraseServiceMock,
+    PassphraseServiceUnixSocket,
+};
 use config::{AgentConfiguration, PassphraseServiceConfig};
 use holochain_core_types::dna::bridges::BridgePresence;
 use holochain_net::{
@@ -180,11 +183,16 @@ impl Conductor {
             println!();
         }
 
-        let passphrase_service: Arc<Mutex<dyn PassphraseService + Send>> = match config.passphrase_service.clone() {
-            PassphraseServiceConfig::Cmd => Arc::new(Mutex::new(PassphraseServiceCmd {})),
-            PassphraseServiceConfig::UnixSocket{path} => Arc::new(Mutex::new(PassphraseServiceUnixSocket::new(path))),
-            PassphraseServiceConfig::Mock{passphrase} => Arc::new(Mutex::new(PassphraseServiceMock {passphrase}))
-        };
+        let passphrase_service: Arc<Mutex<dyn PassphraseService + Send>> =
+            match config.passphrase_service.clone() {
+                PassphraseServiceConfig::Cmd => Arc::new(Mutex::new(PassphraseServiceCmd {})),
+                PassphraseServiceConfig::UnixSocket { path } => {
+                    Arc::new(Mutex::new(PassphraseServiceUnixSocket::new(path)))
+                }
+                PassphraseServiceConfig::Mock { passphrase } => {
+                    Arc::new(Mutex::new(PassphraseServiceMock { passphrase }))
+                }
+            };
 
         Conductor {
             instances: HashMap::new(),

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -40,7 +40,7 @@ use std::{
 };
 
 use boolinator::Boolinator;
-use conductor::passphrase_manager::{PassphraseManager, PassphraseServiceCmd};
+use conductor::passphrase_manager::{PassphraseManager, PassphraseServiceUnixSocket};
 use config::AgentConfiguration;
 use holochain_core_types::dna::bridges::BridgePresence;
 use holochain_net::{
@@ -197,7 +197,7 @@ impl Conductor {
             p2p_config: None,
             network_spawn: None,
             passphrase_manager: Arc::new(PassphraseManager::new(Arc::new(Mutex::new(
-                PassphraseServiceCmd {},
+                PassphraseServiceUnixSocket::new(),
             )))),
             hash_config: None,
             n3h_keepalive_network: None,

--- a/conductor_api/src/conductor/passphrase_manager.rs
+++ b/conductor_api/src/conductor/passphrase_manager.rs
@@ -1,9 +1,10 @@
 use crossbeam_channel::{unbounded, Sender};
 use holochain_core_types::error::HolochainError;
 use lib3h_sodium::secbuf::SecBuf;
+#[cfg(unix)]
 use log::Level;
 use std::{
-    io::{self, BufRead, BufReader, Write},
+    io::{self, Write},
     sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant},
@@ -11,6 +12,8 @@ use std::{
 
 #[cfg(unix)]
 use std::os::unix::net::{UnixListener, UnixStream};
+#[cfg(unix)]
+use std::io::{BufRead, BufReader};
 
 /// We are caching the passphrase for 10 minutes.
 const PASSPHRASE_CACHE_DURATION_SECS: u64 = 600;

--- a/conductor_api/src/conductor/passphrase_manager.rs
+++ b/conductor_api/src/conductor/passphrase_manager.rs
@@ -4,11 +4,13 @@ use lib3h_sodium::secbuf::SecBuf;
 use log::Level;
 use std::{
     io::{self, BufRead, BufReader, Write},
-    os::unix::net::{UnixListener, UnixStream},
     sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant},
 };
+
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
 
 /// We are caching the passphrase for 10 minutes.
 const PASSPHRASE_CACHE_DURATION_SECS: u64 = 600;
@@ -128,11 +130,13 @@ impl PassphraseService for PassphraseServiceMock {
     }
 }
 
+#[cfg(unix)]
 pub struct PassphraseServiceUnixSocket {
     path: String,
     stream: Arc<Mutex<Option<std::io::Result<BufReader<UnixStream>>>>>,
 }
 
+#[cfg(unix)]
 impl PassphraseServiceUnixSocket {
     pub fn new(path: String) -> Self {
         let stream = Arc::new(Mutex::new(None));
@@ -152,12 +156,14 @@ impl PassphraseServiceUnixSocket {
     }
 }
 
+#[cfg(unix)]
 impl Drop for PassphraseServiceUnixSocket {
     fn drop(&mut self) {
         std::fs::remove_file(self.path.clone()).unwrap();
     }
 }
 
+#[cfg(unix)]
 impl PassphraseService for PassphraseServiceUnixSocket {
     fn request_passphrase(&self) -> Result<SecBuf, HolochainError> {
         log_debug!("Passphrase needed. Using unix socket passphrase service...");

--- a/conductor_api/src/conductor/passphrase_manager.rs
+++ b/conductor_api/src/conductor/passphrase_manager.rs
@@ -1,8 +1,10 @@
 use crossbeam_channel::{unbounded, Sender};
 use holochain_core_types::error::HolochainError;
 use lib3h_sodium::secbuf::SecBuf;
+use log::Level;
 use std::{
-    io::{self, Write},
+    io::{self, BufRead, BufReader, Write},
+    os::unix::net::{UnixListener, UnixStream},
     sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant},
@@ -123,5 +125,75 @@ pub struct PassphraseServiceMock {
 impl PassphraseService for PassphraseServiceMock {
     fn request_passphrase(&self) -> Result<SecBuf, HolochainError> {
         Ok(SecBuf::with_insecure_from_string(self.passphrase.clone()))
+    }
+}
+
+pub struct PassphraseServiceUnixSocket {
+    stream: Arc<Mutex<Option<std::io::Result<BufReader<UnixStream>>>>>,
+}
+
+impl PassphraseServiceUnixSocket {
+    pub fn new() -> Self {
+        let stream = Arc::new(Mutex::new(None));
+        let stream_clone = stream.clone();
+        let listener = UnixListener::bind("/home/lucksus/.config/Holoscape/conductor_login.socket")
+            .expect("Could not create unix socket for passphrase service");
+        log_info!("Start accepting passphrase IPC connections on socket...");
+        thread::spawn(move || {
+            let accept_result = listener.accept();
+            {
+                *(stream_clone.lock().unwrap()) =
+                    Some(accept_result.map(|(stream, _)| BufReader::new(stream)));
+            }
+            log_info!("Passphrase provider connected through unix socket");
+        });
+        PassphraseServiceUnixSocket { stream }
+    }
+}
+
+impl PassphraseService for PassphraseServiceUnixSocket {
+    fn request_passphrase(&self) -> Result<SecBuf, HolochainError> {
+        log_debug!("Passphrase needed. Using unix socket passphrase service...");
+        while self.stream.lock().unwrap().is_none() {
+            log_debug!("No one connected via socket yet. Waiting...");
+            thread::sleep(Duration::from_millis(500));
+        }
+
+        log_debug!("We have an open connection to a passphrase provider.");
+
+        // Request and read passphrase from socket
+        let mut passphrase_string = {
+            let mut stream_option = self.stream.lock().unwrap();
+            let listen_result = stream_option.as_mut().unwrap();
+            let stream = listen_result
+                .as_mut()
+                .expect("Error accepting unix socket connection for passphrase service");
+
+            log_debug!("Sending passphrase request via unix socket...");
+            stream
+                .get_mut()
+                .write_all(b"request_passphrase")
+                .expect("Could not write to passphrase socket");
+            log_debug!("Passphrase request sent.");
+            let mut passphrase_string = String::new();
+            log_debug!("Reading passphrase from socket...");
+            stream
+                .read_line(&mut passphrase_string)
+                .expect("Could not read from passphrase socket");
+            log_debug!("Got passphrase. All fine.");
+            passphrase_string
+        };
+
+        // Move passphrase in secure memory
+        let passphrase_bytes = unsafe { passphrase_string.as_mut_vec() };
+        let mut passphrase_buf = SecBuf::with_insecure(passphrase_bytes.len());
+        passphrase_buf.write(0, passphrase_bytes.as_slice())?;
+
+        // Overwrite the unsafe passphrase memory with zeros
+        for byte in passphrase_bytes.iter_mut() {
+            *byte = 0u8;
+        }
+
+        Ok(passphrase_buf)
     }
 }

--- a/conductor_api/src/conductor/passphrase_manager.rs
+++ b/conductor_api/src/conductor/passphrase_manager.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::os::unix::net::{UnixListener, UnixStream};
-#[cfg(unix)]
 use std::io::{BufRead, BufReader};
+#[cfg(unix)]
+use std::os::unix::net::{UnixListener, UnixStream};
 
 /// We are caching the passphrase for 10 minutes.
 const PASSPHRASE_CACHE_DURATION_SECS: u64 = 600;
@@ -179,8 +179,9 @@ impl PassphraseService for PassphraseServiceUnixSocket {
 
         // Request and read passphrase from socket
         let mut passphrase_string = {
-            let mut stream_option = self.stream.lock()
-                .expect("Could not lock mutex holding unix domain socket connection for passphrase service");
+            let mut stream_option = self.stream.lock().expect(
+                "Could not lock mutex holding unix domain socket connection for passphrase service",
+            );
             let listen_result = stream_option.as_mut()
                 .expect("This option must be some at this point since we would be in above while loop otherwise.");
             let stream = listen_result

--- a/conductor_api/src/conductor/passphrase_manager.rs
+++ b/conductor_api/src/conductor/passphrase_manager.rs
@@ -170,8 +170,10 @@ impl PassphraseService for PassphraseServiceUnixSocket {
 
         // Request and read passphrase from socket
         let mut passphrase_string = {
-            let mut stream_option = self.stream.lock().unwrap();
-            let listen_result = stream_option.as_mut().unwrap();
+            let mut stream_option = self.stream.lock()
+                .expect("Could not lock mutex holding unix domain socket connection for passphrase service");
+            let listen_result = stream_option.as_mut()
+                .expect("This option must be some at this point since we would be in above while loop otherwise.");
             let stream = listen_result
                 .as_mut()
                 .expect("Error accepting unix socket connection for passphrase service");

--- a/conductor_api/src/conductor/ui_admin.rs
+++ b/conductor_api/src/conductor/ui_admin.rs
@@ -220,6 +220,7 @@ root_dir = '.'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -269,6 +270,7 @@ id = 'test-bundle-id'"#,
         );
         toml = add_line(toml, format!("root_dir = '{}'", dest.display()));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -312,6 +314,7 @@ id = 'test-bundle-id'"#,
         toml = add_block(toml, instance2());
         toml = add_block(toml, interface(3001));
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -387,6 +390,7 @@ reroute_to_root = true"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 
@@ -456,6 +460,7 @@ root_dir = '.'"#,
             ),
         );
         toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
         toml = add_block(toml, signals());
         toml = format!("{}\n", toml);
 

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -108,7 +108,7 @@ pub struct Configuration {
     #[serde(default)]
     pub signals: SignalConfig,
 
-    /// How should the conductor prompt the user for the passphrase to lock/unlock keystores?
+    /// Configure how the conductor should prompt the user for the passphrase to lock/unlock keystores.
     /// The conductor is independent of the specialized implementation of the trait
     /// PassphraseService. It just needs something to provide a passphrase when needed.
     /// This config setting selects one of the available services (i.e. CLI prompt, IPC, mock)

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -107,6 +107,23 @@ pub struct Configuration {
     /// Which signals to emit
     #[serde(default)]
     pub signals: SignalConfig,
+
+    #[serde(default)]
+    pub passphrase_service: PassphraseServiceConfig,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum PassphraseServiceConfig {
+    Cmd,
+    UnixSocket { path: String },
+    Mock { passphrase: String },
+}
+
+impl Default for PassphraseServiceConfig {
+    fn default() -> PassphraseServiceConfig {
+        PassphraseServiceConfig::Cmd
+    }
 }
 
 pub fn default_persistence_dir() -> PathBuf {

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -305,6 +305,15 @@ impl Configuration {
 
         let _ = self.instance_ids_sorted_by_bridge_dependencies()?;
 
+        #[cfg(not(unix))]
+        {
+            if let PassphraseServiceConfig::UnixSocket{path} = self.passphrase_service.clone() {
+                let _ = path;
+                return Err(String::from("Passphrase service type 'unixsocket' is not available on non-Unix systems"));
+            }
+        }
+
+
         Ok(())
     }
 

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -307,12 +307,13 @@ impl Configuration {
 
         #[cfg(not(unix))]
         {
-            if let PassphraseServiceConfig::UnixSocket{path} = self.passphrase_service.clone() {
+            if let PassphraseServiceConfig::UnixSocket { path } = self.passphrase_service.clone() {
                 let _ = path;
-                return Err(String::from("Passphrase service type 'unixsocket' is not available on non-Unix systems"));
+                return Err(String::from(
+                    "Passphrase service type 'unixsocket' is not available on non-Unix systems",
+                ));
             }
         }
-
 
         Ok(())
     }

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -108,10 +108,21 @@ pub struct Configuration {
     #[serde(default)]
     pub signals: SignalConfig,
 
+    /// How should the conductor prompt the user for the passphrase to lock/unlock keystores?
+    /// The conductor is independent of the specialized implementation of the trait
+    /// PassphraseService. It just needs something to provide a passphrase when needed.
+    /// This config setting selects one of the available services (i.e. CLI prompt, IPC, mock)
     #[serde(default)]
     pub passphrase_service: PassphraseServiceConfig,
 }
 
+/// The default passphrase service is `Cmd` which will ask for a passphrase via stdout stdin.
+/// In the context of a UI that wraps the conductor, this way of providing passphrases
+/// is not feasible.
+/// Setting the type to "unixsocket" and providing a path to a file socket enables
+/// arbitrary UIs to connect to the conductor and prompt the user for a passphrase.
+/// The according `PassphraseServiceUnixSocket` will send a request message over the socket
+/// then receives bytes as passphrase until a newline is sent.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum PassphraseServiceConfig {


### PR DESCRIPTION
## PR summary

This adds a new config item to the conductor config: `passphrase_service`.
It is optional and the default setting is the same behaviour as before: passphrases are prompted via command line (i.e. stdout/stdin).

With this setting a new passphrase service `UnixSocket` can be selected like this:
```rust
[passphrase_service]
type = "unixsocket"
path = "/home/lucksus/.config/Holoscape/conductor-passphrase.sock"
```

That is exactly how [Holoscape](https://github.com/holochain/holoscape/) initializes the conductor config so that it can implement a desktop/windows passphrase prompt.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
