### PR TITLE
Fix log filter

### DIFF
--- a/logging/examples/fastlog-filtering-example.rs
+++ b/logging/examples/fastlog-filtering-example.rs
@@ -29,8 +29,10 @@ fn main() {
         .build()
         .expect("Fail to build logger from toml.");
 
-    debug!("Should be logged 'Cyan' thanks to a rule.");
+    debug!(target: "In Cyan", "Should be logged 'Cyan' thanks to a rule.");
     debug!(target: "holochain-app-5", "Should be 'Green' thanks to the last rule.");
+
+    // Should be logged thanks to the rule about 'app-5'
     debug!(target: "rpc-app-5", "Should be 'Green' thanks to the last rule as well.");
 
     // Should NOT be logged

--- a/logging/examples/log-to-file.rs
+++ b/logging/examples/log-to-file.rs
@@ -7,32 +7,26 @@ fn main() {
     file = "humpty_dumpty.log"
 
         [[logger.rules]]
-        pattern = "Abort"
-        color = "red"
-
-        [[logger.rules]]
         pattern = "warned"
-        color = "yellow"
+        color = "blue"
 
         [[logger.rules]]
         pattern = "twice"
         exclude = true
-        color = "blue"
-
     "#;
 
     FastLoggerBuilder::from_toml(toml)
         .expect("Fail to instantiate the logger from toml.")
-        // .redirect_to_file("humpty_dumpty-blop.log")
+        .redirect_to_file("humpty_dumpty-blop.log")
         .build()
         .expect("Fail to build logger from toml.");
 
     trace!("Track me if you can.");
     debug!("What's bugging you today?");
     info!("Some interesting info here");
-    warn!("You've been warned Sir!");
+    debug!(target: "warned", "You've been warned Sir!");
     // This next one will not be logged according to our rule defined in the toml
-    warn!("Let's not warn twice about the same stuff.");
+    warn!(target: "twice", "Let's not warn twice about the same stuff.");
     // And this one will be printed in red
     error!("Abort the mission!!");
 

--- a/logging/examples/simple-fastlog-example.rs
+++ b/logging/examples/simple-fastlog-example.rs
@@ -10,11 +10,12 @@ fn main() {
         .expect("Fail to instanciate the logging factory.");
 
     trace!("Track me if you can.");
-    debug!("What's bugging you today?");
+    debug!(target: "Buggy day", "What's bugging you today?");
     info!(target: "Simple_example_instance_id", "Some interesting info here");
     warn!("You've been warned Sir!");
     // This next one will not be logged according to our defined rule
-    warn!("Let's not warn twice about the same stuff.");
+    // about the "twice" target
+    warn!(target: "twice", "Let's not warn twice about the same stuff.");
     // And this one will be printed in red
     error!("Abort the mission!!");
 

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -221,25 +221,12 @@ impl log::Log for FastLogger {
     /// This is where we build the log message and send it to the logging thread that is in charge
     /// of formatting and printing the log message.
     fn log(&self, record: &Record) {
-        let args = record.args().to_string();
 
-        // If it happens to slow the performances, maybe we should combine those two operations in
-        // order to ovoid walking twice the same rule filter loop
-        let should_log_args = self.should_log_in(&args);
-        let should_log_target = self.should_log_in(&record.target());
-
-        // Prioritizing the target color rule (if any) over the args one
-        let should_log_in = should_log_target.clone();
-        let should_log_in = match (should_log_args, should_log_target) {
-            (Some(_), Some(target_color)) | (None, Some(target_color)) => Some(target_color),
-            (Some(args_color), None) => Some(args_color),
-            _ => should_log_in,
-        };
-
+        let should_log_in = self.should_log_in(&record.target());
 
         if self.enabled(record.metadata()) && should_log_in != None {
             let msg = LogMessage {
-                args,
+                args: record.args().to_string(),
                 module: record.module_path().unwrap_or("module-name").to_string(),
                 line: record.line().unwrap_or(000),
                 file: record.file().unwrap_or("").to_string(),


### PR DESCRIPTION
## PR summary

This is related to [this issue](https://github.com/holochain/lib3h/issues/244) and proposes a fix by disabling the filtering on the `args` log record to only apply it to the `target` log record. 
Which I think is still OK and less error prone / confusing from the user perspective.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
