### PR TITLE
Fix panic when restarting an instance

### DIFF
--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -176,7 +176,7 @@ impl Instance {
         let (kill_sender, kill_receiver) = crossbeam_channel::unbounded();
         self.kill_switch = Some(kill_sender);
         let instance_is_alive = sub_context.instance_is_alive.clone();
-
+        (*instance_is_alive.lock().unwrap()) = true;
         let _ = thread::Builder::new()
             .name(format!(
                 "action_loop/{}",


### PR DESCRIPTION
## PR summary
This make sure that `Instance::instance_is_alive` gets reset to true before entering the redux loop.
It gets initialized with true and then set to false when the redux main thread exits the action loop. This is particularly to inform any thread that is blocking and waiting for the redux state to change, to stop doing that. For that purpose `Context::block_on` lets the waiting thread panic, so that we drop everything that this callstack owns.

But we had never reset `instance_is_alive` when we would restart that same instance, which would lead to a panic during initialization.

This one line fixes that.


## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
