### PR TITLE
Debug Conductor API

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     * `debug/running_instances`: returns array of running instance IDs
     * `debug/state_dump`: returns a state dump for a given instance
     * `debug/fetch_cas`: returns the content for a given entry address and instance ID
-    
+  
   Also added the source to the state dump.
   [#1661](https://github.com/holochain/holochain-rust/pull/1661)
 

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Ability to provide passphrase to lock/unlock keystores via IPC unix domain socket added. [#1646](https://github.com/holochain/holochain-rust/pull/1646) 
 
 * Documentation for our links ecosystem [#1628](https://github.com/holochain/holochain-rust/pull/1628)
+
+* Conductor API debug functions added: 
+    * `debug/running_instances`: returns array of running instance IDs
+    * `debug/state_dump`: returns a state dump for a given instance
+    * `debug/fetch_cas`: returns the content for a given entry address and instance ID
+    
+  Also added the source to the state dump.
+  [#1661](https://github.com/holochain/holochain-rust/pull/1661)
+
 ### Changed
 
 ### Deprecated

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -1170,7 +1170,8 @@ impl Conductor {
             conductor_api_builder = conductor_api_builder
                 .with_admin_dna_functions()
                 .with_admin_ui_functions()
-                .with_test_admin_functions();
+                .with_test_admin_functions()
+                .with_debug_functions();
         }
 
         conductor_api_builder.spawn()

--- a/conductor_api/src/conductor/debug.rs
+++ b/conductor_api/src/conductor/debug.rs
@@ -1,0 +1,21 @@
+use conductor::Conductor;
+use holochain_core_types::error::HolochainError;
+use holochain_core::state_dump::StateDump;
+
+pub trait ConductorDebug {
+    fn running_instances(&self) -> Result<Vec<String>, HolochainError>;
+    fn state_dump_for_instance(&self, instance_id: &String)
+        -> Result<StateDump, HolochainError>;
+}
+
+impl ConductorDebug for Conductor {
+    fn running_instances(&self) -> Result<Vec<String>, HolochainError> {
+        Ok(self.instances.keys().cloned().collect())
+    }
+
+    fn state_dump_for_instance(&self, instance_id: &String)
+        -> Result<StateDump, HolochainError> {
+        let hc = self.instances.get(instance_id)?;
+        Ok(hc.read().unwrap().get_state_dump()?)
+    }
+}

--- a/conductor_api/src/conductor/debug.rs
+++ b/conductor_api/src/conductor/debug.rs
@@ -1,14 +1,16 @@
 use conductor::Conductor;
-use holochain_core_types::error::HolochainError;
 use holochain_core::state_dump::StateDump;
+use holochain_core_types::error::HolochainError;
 use holochain_persistence_api::cas::content::Address;
 
 pub trait ConductorDebug {
     fn running_instances(&self) -> Result<Vec<String>, HolochainError>;
-    fn state_dump_for_instance(&self, instance_id: &String)
-        -> Result<StateDump, HolochainError>;
-    fn get_type_and_content_from_cas(&self, address: &Address, instance_id: &String)
-        -> Result<(String, String), HolochainError>;
+    fn state_dump_for_instance(&self, instance_id: &String) -> Result<StateDump, HolochainError>;
+    fn get_type_and_content_from_cas(
+        &self,
+        address: &Address,
+        instance_id: &String,
+    ) -> Result<(String, String), HolochainError>;
 }
 
 impl ConductorDebug for Conductor {
@@ -16,14 +18,16 @@ impl ConductorDebug for Conductor {
         Ok(self.instances.keys().cloned().collect())
     }
 
-    fn state_dump_for_instance(&self, instance_id: &String)
-        -> Result<StateDump, HolochainError> {
+    fn state_dump_for_instance(&self, instance_id: &String) -> Result<StateDump, HolochainError> {
         let hc = self.instances.get(instance_id)?;
         Ok(hc.read().unwrap().get_state_dump()?)
     }
 
-    fn get_type_and_content_from_cas(&self, address: &Address, instance_id: &String)
-        -> Result<(String, String), HolochainError> {
+    fn get_type_and_content_from_cas(
+        &self,
+        address: &Address,
+        instance_id: &String,
+    ) -> Result<(String, String), HolochainError> {
         let hc = self.instances.get(instance_id)?;
         Ok(hc.read().unwrap().get_type_and_content_from_cas(address)?)
     }

--- a/conductor_api/src/conductor/debug.rs
+++ b/conductor_api/src/conductor/debug.rs
@@ -1,11 +1,14 @@
 use conductor::Conductor;
 use holochain_core_types::error::HolochainError;
 use holochain_core::state_dump::StateDump;
+use holochain_persistence_api::cas::content::Address;
 
 pub trait ConductorDebug {
     fn running_instances(&self) -> Result<Vec<String>, HolochainError>;
     fn state_dump_for_instance(&self, instance_id: &String)
         -> Result<StateDump, HolochainError>;
+    fn get_type_and_content_from_cas(&self, address: &Address, instance_id: &String)
+        -> Result<(String, String), HolochainError>;
 }
 
 impl ConductorDebug for Conductor {
@@ -17,5 +20,11 @@ impl ConductorDebug for Conductor {
         -> Result<StateDump, HolochainError> {
         let hc = self.instances.get(instance_id)?;
         Ok(hc.read().unwrap().get_state_dump()?)
+    }
+
+    fn get_type_and_content_from_cas(&self, address: &Address, instance_id: &String)
+        -> Result<(String, String), HolochainError> {
+        let hc = self.instances.get(instance_id)?;
+        Ok(hc.read().unwrap().get_type_and_content_from_cas(address)?)
     }
 }

--- a/conductor_api/src/conductor/mod.rs
+++ b/conductor_api/src/conductor/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod base;
 pub mod broadcaster;
+pub mod debug;
 pub mod passphrase_manager;
 pub mod test_admin;
 pub mod ui_admin;
@@ -8,6 +9,7 @@ pub mod ui_admin;
 pub use self::{
     admin::ConductorAdmin,
     base::{mount_conductor_from_config, Conductor, CONDUCTOR},
+    debug::ConductorDebug,
     test_admin::ConductorTestAdmin,
     ui_admin::ConductorUiAdmin,
 };

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -110,7 +110,8 @@ use holochain_json_api::json::JsonString;
 use holochain_core::state::StateWrapper;
 use jsonrpc_core::IoHandler;
 use std::sync::Arc;
-use holochain_core::state_dump::StateDump;
+use holochain_core::state_dump::{StateDump, address_to_content_and_type};
+use holochain_persistence_api::cas::content::Address;
 
 /// contains a Holochain application instance
 pub struct Holochain {
@@ -269,6 +270,13 @@ impl Holochain {
         self.check_instance()?;
         Ok(StateDump::from(self.context.clone()
             .expect("Context must be Some since we've checked it with check_instance()? above"))
+        )
+    }
+
+    pub fn get_type_and_content_from_cas(&self, address: &Address) -> Result<(String, String), HolochainInstanceError> {
+        self.check_instance()?;
+        Ok(address_to_content_and_type(address, self.context.clone()
+            .expect("Context must be Some since we've checked it with check_instance()? above"))?
         )
     }
 }

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -107,11 +107,13 @@ use holochain_core_types::{
 
 use holochain_json_api::json::JsonString;
 
-use holochain_core::state::StateWrapper;
+use holochain_core::{
+    state::StateWrapper,
+    state_dump::{address_to_content_and_type, StateDump},
+};
+use holochain_persistence_api::cas::content::Address;
 use jsonrpc_core::IoHandler;
 use std::sync::Arc;
-use holochain_core::state_dump::{StateDump, address_to_content_and_type};
-use holochain_persistence_api::cas::content::Address;
 
 /// contains a Holochain application instance
 pub struct Holochain {
@@ -268,16 +270,22 @@ impl Holochain {
 
     pub fn get_state_dump(&self) -> Result<StateDump, HolochainInstanceError> {
         self.check_instance()?;
-        Ok(StateDump::from(self.context.clone()
-            .expect("Context must be Some since we've checked it with check_instance()? above"))
-        )
+        Ok(StateDump::from(self.context.clone().expect(
+            "Context must be Some since we've checked it with check_instance()? above",
+        )))
     }
 
-    pub fn get_type_and_content_from_cas(&self, address: &Address) -> Result<(String, String), HolochainInstanceError> {
+    pub fn get_type_and_content_from_cas(
+        &self,
+        address: &Address,
+    ) -> Result<(String, String), HolochainInstanceError> {
         self.check_instance()?;
-        Ok(address_to_content_and_type(address, self.context.clone()
-            .expect("Context must be Some since we've checked it with check_instance()? above"))?
-        )
+        Ok(address_to_content_and_type(
+            address,
+            self.context
+                .clone()
+                .expect("Context must be Some since we've checked it with check_instance()? above"),
+        )?)
     }
 }
 

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -110,6 +110,7 @@ use holochain_json_api::json::JsonString;
 use holochain_core::state::StateWrapper;
 use jsonrpc_core::IoHandler;
 use std::sync::Arc;
+use holochain_core::state_dump::StateDump;
 
 /// contains a Holochain application instance
 pub struct Holochain {
@@ -262,6 +263,13 @@ impl Holochain {
     pub fn set_conductor_api(&mut self, api: IoHandler) -> Result<(), HolochainInstanceError> {
         self.context()?.conductor_api.reset(api);
         Ok(())
+    }
+
+    pub fn get_state_dump(&self) -> Result<StateDump, HolochainInstanceError> {
+        self.check_instance()?;
+        Ok(StateDump::from(self.context.clone()
+            .expect("Context must be Some since we've checked it with check_instance()? above"))
+        )
     }
 }
 

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -718,10 +718,8 @@ impl ConductorApiBuilder {
     /// Adds functions useful for debugging.
     ///
     /// - `debug/running_instances`
-    ///     Install a UI bundle that can later be hosted by an interface
-    ///     Params:
-    ///     - `id` ID used to refer to this bundle
-    ///     - `root_dir` Directory to host on the HTTP server
+    ///     Get all currently running instances.
+    ///     Returns an array of instance ID strings.
     ///
     /// - `debug/state_dump`
     ///   Returns a JSON object with all relevant fields of an instance's state.

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -738,6 +738,21 @@ impl ConductorApiBuilder {
             )?)
         });
 
+        self.io.add_method("debug/fetch_cas", move |params| {
+            let params_map = Self::unwrap_params_map(params)?;
+            let instance_id = Self::get_as_string("instance_id", &params_map)?;
+            let address = Self::get_as_string("address", &params_map)?;
+
+            let (entry_type, content) = conductor_call!(
+                |c| c.get_type_and_content_from_cas(&Address::from(address), &instance_id)
+            )?;
+
+            Ok(json!({
+                "type": entry_type,
+                "content": content,
+            }))
+        });
+
         self
     }
 

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -734,28 +734,22 @@ impl ConductorApiBuilder {
     ///   - `instance_id` ID of the instance of which's CAS content is requested
     ///   - `address` Address (hash) of the content that is requests
     ///   Returns an object of the form: {type:"<entry type>", content: "<content>"}
-    /// 
+    ///
     pub fn with_debug_functions(mut self) -> Self {
-        self.io.add_method("debug/running_instances", move |_params| {
-            let running_instances_ids = conductor_call!(
-                |c| c.running_instances()
-            )?;
-            Ok(serde_json::to_value(running_instances_ids)
-                .map_err(|_| jsonrpc_core::Error::internal_error())?
-            )
-        });
+        self.io
+            .add_method("debug/running_instances", move |_params| {
+                let running_instances_ids = conductor_call!(|c| c.running_instances())?;
+                Ok(serde_json::to_value(running_instances_ids)
+                    .map_err(|_| jsonrpc_core::Error::internal_error())?)
+            });
 
         self.io.add_method("debug/state_dump", move |params| {
             let params_map = Self::unwrap_params_map(params)?;
             let instance_id = Self::get_as_string("instance_id", &params_map)?;
 
-            let dump = conductor_call!(
-                |c| c.state_dump_for_instance(&instance_id)
-            )?;
+            let dump = conductor_call!(|c| c.state_dump_for_instance(&instance_id))?;
 
-            Ok(serde_json::to_value(dump).map_err(|_|
-                jsonrpc_core::Error::internal_error()
-            )?)
+            Ok(serde_json::to_value(dump).map_err(|_| jsonrpc_core::Error::internal_error())?)
         });
 
         self.io.add_method("debug/fetch_cas", move |params| {

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -22,7 +22,7 @@ use std::{
     thread,
 };
 
-use conductor::{ConductorAdmin, ConductorTestAdmin, ConductorUiAdmin, CONDUCTOR};
+use conductor::{ConductorAdmin, ConductorDebug, ConductorTestAdmin, ConductorUiAdmin, CONDUCTOR};
 use config::{
     AgentConfiguration, Bridge, DnaConfiguration, InstanceConfiguration, InterfaceConfiguration,
     InterfaceDriver, UiBundleConfiguration, UiInterfaceConfiguration,
@@ -710,6 +710,32 @@ impl ConductorApiBuilder {
             let bridges =
                 conductor_call!(|c| Ok(c.config().bridges) as Result<Vec<Bridge>, String>)?;
             Ok(serde_json::to_value(bridges).map_err(|_| jsonrpc_core::Error::internal_error())?)
+        });
+
+        self
+    }
+
+    pub fn with_debug_functions(mut self) -> Self {
+        self.io.add_method("debug/running_instances", move |_params| {
+            let running_instances_ids = conductor_call!(
+                |c| c.running_instances()
+            )?;
+            Ok(serde_json::to_value(running_instances_ids)
+                .map_err(|_| jsonrpc_core::Error::internal_error())?
+            )
+        });
+
+        self.io.add_method("debug/state_dump", move |params| {
+            let params_map = Self::unwrap_params_map(params)?;
+            let instance_id = Self::get_as_string("instance_id", &params_map)?;
+
+            let dump = conductor_call!(
+                |c| c.state_dump_for_instance(&instance_id)
+            )?;
+
+            Ok(serde_json::to_value(dump).map_err(|_|
+                jsonrpc_core::Error::internal_error()
+            )?)
         });
 
         self

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -715,6 +715,26 @@ impl ConductorApiBuilder {
         self
     }
 
+    /// Adds functions useful for debugging.
+    ///
+    /// - `debug/running_instances`
+    ///     Install a UI bundle that can later be hosted by an interface
+    ///     Params:
+    ///     - `id` ID used to refer to this bundle
+    ///     - `root_dir` Directory to host on the HTTP server
+    ///
+    /// - `debug/state_dump`
+    ///   Returns a JSON object with all relevant fields of an instance's state.
+    ///   Params:
+    ///   - `instance_id` ID of the instance of which the state is requested
+    ///
+    /// - `debug/fetch_cas`
+    ///   Returns content of a given instance's CAS.
+    ///   Params:
+    ///   - `instance_id` ID of the instance of which's CAS content is requested
+    ///   - `address` Address (hash) of the content that is requests
+    ///   Returns an object of the form: {type:"<entry type>", content: "<content>"}
+    /// 
     pub fn with_debug_functions(mut self) -> Self {
         self.io.add_method("debug/running_instances", move |_params| {
             let running_instances_ids = conductor_call!(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,6 +43,7 @@ pub mod persister;
 pub mod scheduled_jobs;
 pub mod signal;
 pub mod state;
+pub mod state_dump;
 pub mod workflows;
 
 mod conductor_api;

--- a/core/src/scheduled_jobs/state_dump.rs
+++ b/core/src/scheduled_jobs/state_dump.rs
@@ -75,7 +75,6 @@ pub fn state_dump(context: Arc<Context>) {
 
     let source_chain_strings = dump.source_chain
         .iter()
-        .rev()
         .map(|h| format!(
             "{}\n=> {}",
             header_to_string(h),

--- a/core/src/scheduled_jobs/state_dump.rs
+++ b/core/src/scheduled_jobs/state_dump.rs
@@ -1,6 +1,43 @@
 use crate::context::Context;
 use std::sync::Arc;
 use crate::state_dump::{StateDump, address_to_content_and_type};
+use holochain_core_types::chain_header::ChainHeader;
+use holochain_persistence_api::cas::content::{AddressableContent, Address};
+
+fn header_to_string(h: &ChainHeader) -> String {
+    format!(
+r#"===========Header===========
+Type: {:?}
+Timestamp: {}
+Sources: {:?}
+Header address: {}
+Prev. address: {:?}
+----------Content----------"#,
+    h.entry_type(),
+    h.timestamp(),
+    h.provenances()
+        .iter()
+        .map(|p| p.source().to_string())
+        .collect::<Vec<String>>()
+        .join(", "),
+    h.address(),
+    h.link().map(|l| l.to_string()))
+}
+
+fn address_to_content_string(address: &Address, context: Arc<Context>) -> String {
+    let maybe_content = address_to_content_and_type(address, context.clone());
+    maybe_content
+        .map(|(content_type, content)| {
+            format!("* [{}] {}: {}", content_type, address.to_string(), content)
+        })
+        .unwrap_or_else(|err| {
+            format!(
+                "* [UNKNOWN] {}: Error trying to get type/content: {}",
+                address.to_string(),
+                err
+            )
+        })
+}
 
 pub fn state_dump(context: Arc<Context>) {
     let dump = StateDump::from(context.clone());
@@ -33,25 +70,26 @@ pub fn state_dump(context: Arc<Context>) {
 
     let holding_strings = dump.held_entries
         .iter()
-        .map(|address| {
-            let maybe_content = address_to_content_and_type(address, context.clone());
-            maybe_content
-                .map(|(content_type, content)| {
-                    format!("* [{}] {}: {}", content_type, address.to_string(), content)
-                })
-                .unwrap_or_else(|err| {
-                    format!(
-                        "* [UNKNOWN] {}: Error trying to get type/content: {}",
-                        address.to_string(),
-                        err
-                    )
-                })
-        })
+        .map(|address| address_to_content_string(address, context.clone()))
+        .collect::<Vec<String>>();
+
+    let source_chain_strings = dump.source_chain
+        .iter()
+        .rev()
+        .map(|h| format!(
+            "{}\n=> {}",
+            header_to_string(h),
+            address_to_content_string(h.entry_address(), context.clone())
+        ))
         .collect::<Vec<String>>();
 
     let debug_dump = format!(
         r#"
 =============STATE DUMP===============
+Agent's Source Chain:
+========
+
+{source_chain}
 
 Nucleus:
 ========
@@ -75,6 +113,7 @@ Holding:
 {holding_list}
 --------
     "#,
+        source_chain = source_chain_strings.join("\n\n"),
         calls = dump.running_calls,
         validations = pending_validation_strings.join("\n"),
         flows = dump.query_flows,

--- a/core/src/scheduled_jobs/state_dump.rs
+++ b/core/src/scheduled_jobs/state_dump.rs
@@ -1,38 +1,6 @@
 use crate::context::Context;
-use holochain_core_types::{entry::Entry, error::HolochainError};
-use holochain_persistence_api::cas::content::{Address, AddressableContent};
-use std::{convert::TryInto, sync::Arc};
-use crate::state_dump::StateDump;
-
-fn address_to_content_and_type(
-    address: &Address,
-    context: Arc<Context>,
-) -> Result<(String, String), HolochainError> {
-    let raw_content = context.dht_storage.read()?.fetch(address)??;
-    let maybe_entry: Result<Entry, _> = raw_content.clone().try_into();
-    if let Ok(entry) = maybe_entry {
-        let mut entry_type = entry.entry_type().to_string();
-        let content = match entry {
-            Entry::Dna(_) => String::from("DNA omitted"),
-            Entry::AgentId(agent_id) => agent_id.nick,
-            Entry::LinkAdd(link) | Entry::LinkRemove((link, _)) => format!(
-                "({}#{})\n\t{} => {}",
-                link.link.link_type(),
-                link.link.tag(),
-                link.link.base(),
-                link.link.target(),
-            ),
-            Entry::App(app_type, app_value) => {
-                entry_type = app_type.to_string();
-                app_value.to_string()
-            }
-            _ => entry.content().to_string(),
-        };
-        Ok((entry_type, content))
-    } else {
-        Ok((String::from("UNKNOWN"), raw_content.to_string()))
-    }
-}
+use std::sync::Arc;
+use crate::state_dump::{StateDump, address_to_content_and_type};
 
 pub fn state_dump(context: Arc<Context>) {
     let dump = StateDump::from(context.clone());

--- a/core/src/state_dump.rs
+++ b/core/src/state_dump.rs
@@ -1,0 +1,86 @@
+use crate::nucleus::ZomeFnCall;
+use crate::action::QueryKey;
+use holochain_persistence_api::cas::content::Address;
+use crate::network::direct_message::DirectMessage;
+use crate::scheduled_jobs::pending_validations::ValidatingWorkflow;
+use crate::context::Context;
+use std::sync::Arc;
+
+#[derive(Serialize)]
+pub struct PendingValidationDump{
+    pub address: Address,
+    pub dependencies: Vec<Address>,
+    pub workflow: ValidatingWorkflow,
+}
+
+#[derive(Serialize)]
+pub struct StateDump {
+    pub running_calls: Vec<ZomeFnCall>,
+    pub query_flows: Vec<QueryKey>,
+    pub validation_package_flows: Vec<Address>,
+    pub direct_message_flows: Vec<(String, DirectMessage)>,
+    pub pending_validations: Vec<PendingValidationDump>,
+    pub held_entries: Vec<Address>,
+}
+
+impl From<Arc<Context>> for StateDump {
+    fn from(context: Arc<Context>) -> StateDump {
+        let (nucleus, network, dht) = {
+            let state_lock = context.state().expect("No state?!");
+            (
+                (*state_lock.nucleus()).clone(),
+                (*state_lock.network()).clone(),
+                (*state_lock.dht()).clone(),
+            )
+        };
+
+        let running_calls: Vec<ZomeFnCall> = nucleus
+            .zome_calls
+            .into_iter()
+            .filter(|(_, result)| result.is_none())
+            .map(|(call, _)| call)
+            .collect();
+
+        let query_flows: Vec<QueryKey> = network
+            .get_query_results
+            //using iter so that we don't copy this again and again if it is a scheduled job that runs everytime
+            //it might be slow if copied
+            .iter()
+            .filter(|(_,result)|result.is_none())
+            .map(|(key,_)|key.clone())
+            .collect();
+
+
+        let validation_package_flows: Vec<Address> = network
+            .get_validation_package_results
+            .into_iter()
+            .filter(|(_, result)| result.is_none())
+            .map(|(address, _)| address)
+            .collect();
+
+        let direct_message_flows: Vec<(String, DirectMessage)> = network
+            .direct_message_connections
+            .into_iter()
+            .map(|(s, dm)| (s.clone(), dm.clone()))
+            .collect();
+
+        let pending_validations = nucleus
+            .pending_validations
+            .into_iter()
+            .map(|(pending_validation_key, pending_validation)| {
+                PendingValidationDump {
+                    address: pending_validation_key.address,
+                    workflow: pending_validation_key.workflow,
+                    dependencies: pending_validation.dependencies.clone(),
+                }
+            })
+            .collect::<Vec<PendingValidationDump>>();
+
+        let held_entries = dht.get_all_held_entry_addresses().clone();
+
+        StateDump {
+            running_calls, query_flows, validation_package_flows, direct_message_flows,
+            pending_validations, held_entries
+        }
+    }
+}

--- a/core/src/state_dump.rs
+++ b/core/src/state_dump.rs
@@ -38,7 +38,7 @@ impl From<Arc<Context>> for StateDump {
             )
         };
 
-        let source_chain: Vec<ChainHeader> = agent.iter_chain().collect();
+        let source_chain: Vec<ChainHeader> = agent.iter_chain().rev().collect();
 
         let running_calls: Vec<ZomeFnCall> = nucleus
             .zome_calls

--- a/core/src/state_dump.rs
+++ b/core/src/state_dump.rs
@@ -38,7 +38,8 @@ impl From<Arc<Context>> for StateDump {
             )
         };
 
-        let source_chain: Vec<ChainHeader> = agent.iter_chain().rev().collect();
+        let source_chain: Vec<ChainHeader> = agent.iter_chain().collect();
+        let source_chain: Vec<ChainHeader> = source_chain.into_iter().rev().collect();
 
         let running_calls: Vec<ZomeFnCall> = nucleus
             .zome_calls


### PR DESCRIPTION
## PR summary
This adds conductor API functions for the purpose of debugging and showing detailed debug information in a windowed UI like [Holoscape](https://github.com/holochain/holoscape).

Added functions:
* `debug/running_instances`
* `debug/state_dump`
* `debug/fetch_cas`

## followups

Using these functions in a debug view in Holoscape.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
