### PR TITLE
Spike - Add `call_and_measure` to conductor for Holo service logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "self-meter 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2236,6 +2237,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "quote"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2649,18 @@ dependencies = [
  "MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "self-meter"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3783,6 +3801,7 @@ dependencies = [
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eca14c727ad12702eb4b6bfb5a232287dcf8385cb8ca83a3eeaf6519c44c408"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -3826,6 +3845,7 @@ dependencies = [
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfab8dda0e7a327c696d893df9ffa19cadc4bd195797997f5223cf5831beaf05"
 "checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
+"checksum self-meter 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f5db5de2ab21bed9d4cde060886b4fdbee58a9d8a95c8becc7ea549a7ba8bc8"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"

--- a/conductor_api/Cargo.toml
+++ b/conductor_api/Cargo.toml
@@ -43,6 +43,7 @@ crossbeam-channel = "=0.3.8"
 log = "=0.4.8"
 logging = { path = "../logging" }
 nickel = "=0.11.0"
+self-meter = "=0.6.0"
 
 [dev-dependencies]
 test_utils = { path = "../test_utils"}

--- a/conductor_api/Cargo.toml
+++ b/conductor_api/Cargo.toml
@@ -43,6 +43,8 @@ crossbeam-channel = "=0.3.8"
 log = "=0.4.8"
 logging = { path = "../logging" }
 nickel = "=0.11.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 self-meter = "=0.6.0"
 
 [dev-dependencies]

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -1171,7 +1171,7 @@ impl Conductor {
                 .with_admin_dna_functions()
                 .with_admin_ui_functions()
                 .with_test_admin_functions()
-                .with_call_with_metrics();
+                .with_call_and_measure();
         }
 
         conductor_api_builder.spawn()

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -1170,7 +1170,8 @@ impl Conductor {
             conductor_api_builder = conductor_api_builder
                 .with_admin_dna_functions()
                 .with_admin_ui_functions()
-                .with_test_admin_functions();
+                .with_test_admin_functions()
+                .with_call_with_metrics();
         }
 
         conductor_api_builder.spawn()


### PR DESCRIPTION
## PR summary

This is a spike of a possible implementation for resource measurement for calls made to the conductor. 

It adds a new RPC method `call_and_measure` to conductor admin interfaces. This is identical to the regular `call` except it spawns a monitor thread which polls the resource usage every 100ms. When the call is completed it generates a report. The measuring and reporting is done via the [self-meter](https://docs.rs/self-meter/0.6.0/self_meter/) crate. The [schema of a report](https://docs.rs/self-meter/0.6.0/self_meter/struct.Report.html) is used directly from that crate for now and contains many fields some of which may be useful.

The response from `call_and_measure` contains the regular call result and the resource report. An example response looks as follows:
```json
{
	"call_response": {...},
	"resource_usage": {
           "timestamp": 0
	    "duration": 0
	    "start_time": 0
	    "system_uptime": 0
	    "global_cpu_usage": 0
	    "process_cpu_usage": 0
	    "gross_cpu_usage": 0
	    "memory_rss": 0
	    "memory_virtual": 0
	    "memory_swap": 0
	    "memory_rss_peak": 0
	    "memory_virtual_peak": 0
	    "memory_swap_peak": 0
	    "disk_read": 0
	    "disk_write": 0
	    "disk_cancelled": 0
	    "io_read": 0
	    "io_write": 0
	    "io_read_ops": 0
	    "io_write_ops": 0
	} 
}
```

Since this method for getting usage measurements is only supported on Linux this RPC function will only be available on that platform. This should be ok for Holo since it only needs to work on HoloportOS.

Currently this spike is up for feedback from relevant parties as to whether this provides an acceptable MVP for use by the service logger.
