### PR TITLE
updates to use CryptoSystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.14"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,7 +87,6 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -498,7 +497,7 @@ name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -516,7 +515,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -776,7 +775,7 @@ dependencies = [
  "holochain_persistence_file 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_wasm_utils 0.0.28-alpha1",
  "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_sodium 0.0.10",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -852,7 +851,7 @@ dependencies = [
  "holochain_common 0.0.28-alpha1",
  "holochain_conductor_api 0.0.28-alpha1",
  "holochain_core_types 0.0.28-alpha1",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_sodium 0.0.10",
  "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -895,7 +894,7 @@ dependencies = [
  "jsonrpc-ws-server 10.0.1 (git+https://github.com/holochain/jsonrpc?branch=broadcaster-getter)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lib3h 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_sodium 0.0.10",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.28-alpha1",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -958,8 +957,8 @@ dependencies = [
  "jsonrpc-core 10.0.1 (git+https://github.com/holochain/jsonrpc?branch=broadcaster-getter)",
  "jsonrpc-lite 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_protocol 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_protocol 0.0.10",
+ "lib3h_sodium 0.0.10",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.0.28-alpha1",
  "num-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1010,7 +1009,7 @@ dependencies = [
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_crypto_api 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_crypto_api 0.0.10",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "objekt 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1045,7 +1044,8 @@ dependencies = [
  "holochain_core_types 0.0.28-alpha1",
  "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_crypto_api 0.0.10",
+ "lib3h_sodium 0.0.10",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1100,10 +1100,10 @@ dependencies = [
  "holochain_json_derive 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_crypto_api 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_protocol 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h 0.0.10",
+ "lib3h_crypto_api 0.0.10",
+ "lib3h_protocol 0.0.10",
+ "lib3h_sodium 0.0.10",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1204,7 +1204,7 @@ dependencies = [
 name = "holochain_test_bin"
 version = "0.0.28-alpha1"
 dependencies = [
- "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1212,8 +1212,8 @@ dependencies = [
  "holochain_net 0.0.28-alpha1",
  "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_protocol 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h 0.0.10",
+ "lib3h_protocol 0.0.10",
  "multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1484,6 +1484,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "lib3h"
 version = "0.0.10"
+dependencies = [
+ "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_crypto_api 0.0.10",
+ "lib3h_protocol 0.0.10",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nanoid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tungstenite 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lib3h"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1504,11 +1525,34 @@ dependencies = [
 [[package]]
 name = "lib3h_crypto_api"
 version = "0.0.10"
+dependencies = [
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lib3h_crypto_api"
+version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lib3h_protocol"
+version = "0.0.10"
+dependencies = [
+ "backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1528,10 +1572,9 @@ dependencies = [
 [[package]]
 name = "lib3h_sodium"
 version = "0.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_crypto_api 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_crypto_api 0.0.10",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_sodium-sys 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1756,6 +1799,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2915,7 +2966,7 @@ dependencies = [
  "holochain_persistence_api 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 10.0.1 (git+https://github.com/holochain/jsonrpc?branch=broadcaster-getter)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_sodium 0.0.10",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3554,7 +3605,7 @@ dependencies = [
 "checksum assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7ac5c260f75e4e4ba87b7342be6edcecbcb3eb6741a0507fda7ad115845cc65"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
+"checksum backtrace 0.3.26 (registry+https://github.com/rust-lang/crates.io-index)" = "1a13fc43f04daf08ab4f71e3d27e1fc27fc437d3e95ac0063a796d92fb40f39b"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
@@ -3672,7 +3723,6 @@ dependencies = [
 "checksum lib3h 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b3303a1158e15a188950c707b113cb54072767f7a2e22f67f10e7ee9d388ec"
 "checksum lib3h_crypto_api 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5cdaecc3983ba97b99f15a0c2c459810773a3c9f46564aff7e24f67f58301266"
 "checksum lib3h_protocol 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "85c3a939d09e8afcd50f62c6f885193304333e3be99a483992235241751e4280"
-"checksum lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "64e4481f9ce96d85863a294f9f058bb20b44b068911552ebdab2343cbf77482b"
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum libflate 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "45c97cf62125b79dcac52d506acdc4799f21a198597806947fd5f40dc7b93412"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
@@ -3698,6 +3748,7 @@ dependencies = [
 "checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum multihash 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c62469025f45dee2464ef9fc845f4683c543993792c1993e7d903c17a4546b74"
 "checksum mustache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51956ef1c5d20a1384524d91e616fb44dfc7d8f249bf696d49c97dd3289ecab5"
+"checksum nanoid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef553a0f07a7a45c731f0c5d83cf9ef9caddf7407e413142731db416504bfe0f"
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nickel 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5061a832728db2dacb61cefe0ce303b58f85764ec680e71d9138229640a46d9"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ holochain_dpki = { path = "../dpki" }
 holochain_json_api = "=0.0.17"
 holochain_persistence_api = "=0.0.7"
 holochain_persistence_file = "=0.0.7"
-lib3h_sodium = "=0.0.10"
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
 holochain_wasm_utils = { path = "../wasm_utils" }
 structopt = "=0.2.15"
 failure = "=0.1.5"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ holochain_dpki = { path = "../dpki" }
 holochain_json_api = "=0.0.17"
 holochain_persistence_api = "=0.0.7"
 holochain_persistence_file = "=0.0.7"
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 holochain_wasm_utils = { path = "../wasm_utils" }
 structopt = "=0.2.15"
 failure = "=0.1.5"

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 [dependencies]
 holochain_core_types = { path = "../core_types" }
 holochain_conductor_api = { path = "../conductor_api" }
-lib3h_sodium = "=0.0.10"
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
 holochain_common = { path = "../common" }
 signal-hook = "=0.1.9"
 structopt = "=0.2.15"

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 [dependencies]
 holochain_core_types = { path = "../core_types" }
 holochain_conductor_api = { path = "../conductor_api" }
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 holochain_common = { path = "../common" }
 signal-hook = "=0.1.9"
 structopt = "=0.2.15"

--- a/conductor_api/Cargo.toml
+++ b/conductor_api/Cargo.toml
@@ -15,7 +15,7 @@ holochain_persistence_pickle = "=0.0.7"
 holochain_dpki = { path = "../dpki" }
 holochain_net = { path = "../net" }
 lib3h ="=0.0.10"
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 holochain_common = { path = "../common" }
 chrono = "=0.4.6"
 serde = "=1.0.89"

--- a/conductor_api/Cargo.toml
+++ b/conductor_api/Cargo.toml
@@ -15,7 +15,7 @@ holochain_persistence_pickle = "=0.0.7"
 holochain_dpki = { path = "../dpki" }
 holochain_net = { path = "../net" }
 lib3h ="=0.0.10"
-lib3h_sodium = "=0.0.10"
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
 holochain_common = { path = "../common" }
 chrono = "=0.4.6"
 serde = "=1.0.89"

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -1,4 +1,4 @@
-use crate::{
+puse crate::{
     conductor::broadcaster::Broadcaster,
     config::{
         serialize_configuration, Configuration, InterfaceConfiguration, InterfaceDriver,
@@ -1418,7 +1418,7 @@ pub mod tests {
         .unwrap();
 
         // Create deterministic seed
-        let mut seed = SecBuf::with_insecure(SEED_SIZE);
+        let mut seed = CRYPTO.buf_new_insecure(SEED_SIZE);
         let mock_seed: Vec<u8> = (1..SEED_SIZE).map(|e| e as u8 + index).collect();
         seed.write(0, mock_seed.as_slice())
             .expect("SecBuf must be writeable");

--- a/conductor_api/src/conductor/passphrase_manager.rs
+++ b/conductor_api/src/conductor/passphrase_manager.rs
@@ -1,6 +1,10 @@
 use crossbeam_channel::{unbounded, Sender};
 use holochain_core_types::error::HolochainError;
-use lib3h_sodium::secbuf::SecBuf;
+use holochain_dpki::{
+    utils::secbuf_new_insecure_from_string,
+    SecBuf,
+};
+
 #[cfg(unix)]
 use log::Level;
 use std::{
@@ -81,7 +85,7 @@ impl PassphraseManager {
 
         match *passphrase {
             Some(ref mut passphrase_buf) => {
-                let mut new_passphrase_buf = SecBuf::with_insecure(passphrase_buf.len());
+                let mut new_passphrase_buf = CRYPTO.buf_new_insecure(passphrase_buf.len());
                 new_passphrase_buf.write(0, &*(passphrase_buf.read_lock()))?;
                 Ok(new_passphrase_buf)
             }
@@ -111,7 +115,7 @@ impl PassphraseService for PassphraseServiceCmd {
 
         // Move passphrase in secure memory
         let passphrase_bytes = unsafe { passphrase_string.as_mut_vec() };
-        let mut passphrase_buf = SecBuf::with_insecure(passphrase_bytes.len());
+        let mut passphrase_buf = CRYPTO.buf_new_insecure(passphrase_bytes.len());
         passphrase_buf.write(0, passphrase_bytes.as_slice())?;
 
         // Overwrite the unsafe passphrase memory with zeros
@@ -129,7 +133,7 @@ pub struct PassphraseServiceMock {
 
 impl PassphraseService for PassphraseServiceMock {
     fn request_passphrase(&self) -> Result<SecBuf, HolochainError> {
-        Ok(SecBuf::with_insecure_from_string(self.passphrase.clone()))
+        Ok(secbuf_new_insecure_from_string(self.passphrase.clone()))
     }
 }
 
@@ -205,7 +209,7 @@ impl PassphraseService for PassphraseServiceUnixSocket {
 
         // Move passphrase in secure memory
         let passphrase_bytes = unsafe { passphrase_string.as_mut_vec() };
-        let mut passphrase_buf = SecBuf::with_insecure(passphrase_bytes.len());
+        let mut passphrase_buf = CRYPTO.buf_new_insecure(passphrase_bytes.len());
         passphrase_buf.write(0, passphrase_bytes.as_slice())?;
 
         // Overwrite the unsafe passphrase memory with zeros

--- a/conductor_api/src/holochain.rs
+++ b/conductor_api/src/holochain.rs
@@ -46,8 +46,8 @@
 //!
 //! // We need to provide a cryptographic key that represents the agent.
 //! // Creating a new random one on the fly:
-//! let mut seed = SecBuf::with_insecure(SEED_SIZE);
-//! seed.randomize();
+//! let mut seed = CRYPTO.buf_new_insecure(SEED_SIZE);
+//! CRYPTO.randombytes_buf(&mut seed);
 //!
 //! let keybundle = KeyBundle::new_from_seed_buf(&mut seed).unwrap();
 //!

--- a/conductor_api/src/key_loaders.rs
+++ b/conductor_api/src/key_loaders.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use conductor::passphrase_manager::{PassphraseManager, PassphraseServiceMock};
 use holochain_core_types::error::HolochainError;
-use holochain_dpki::{password_encryption::PwHashConfig, SEED_SIZE};
+use holochain_dpki::{secbuf_new_insecure_from_string, SEED_SIZE};
 use keystore::test_hash_config;
 use lib3h_sodium::{hash::sha256, secbuf::SecBuf};
 use std::{
@@ -42,8 +42,8 @@ pub fn test_keystore(agent_name: &String) -> Keystore {
     .unwrap();
 
     // Create seed from name
-    let mut name = SecBuf::with_insecure_from_string(agent_name.clone());
-    let mut seed = SecBuf::with_insecure(SEED_SIZE);
+    let mut name = secbuf_new_insecure_from_string(agent_name.clone());
+    let mut seed = CRYPTO.buf_new_insecure(SEED_SIZE);
     sha256(&mut name, &mut seed).expect("Could not hash test agent name");
 
     let secret = Arc::new(Mutex::new(Secret::Seed(seed)));

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,8 +29,8 @@ toml = "=0.5.0"
 holochain_net = { path = "../net" }
 holochain_wasm_utils = { path = "../wasm_utils"}
 holochain_common = { path = "../common" }
-lib3h_protocol = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h_protocol" }
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h_protocol = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 holochain_json_derive = "=0.0.17"
 holochain_json_api = "=0.0.17"
 holochain_persistence_api = "=0.0.7"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,8 +29,8 @@ toml = "=0.5.0"
 holochain_net = { path = "../net" }
 holochain_wasm_utils = { path = "../wasm_utils"}
 holochain_common = { path = "../common" }
-lib3h_protocol = "=0.0.10"
-lib3h_sodium = "=0.0.10"
+lib3h_protocol = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h_protocol" }
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
 holochain_json_derive = "=0.0.17"
 holochain_json_api = "=0.0.17"
 holochain_persistence_api = "=0.0.7"

--- a/core/src/nucleus/ribosome/api/sign.rs
+++ b/core/src/nucleus/ribosome/api/sign.rs
@@ -1,8 +1,7 @@
 use crate::nucleus::ribosome::{api::ZomeApiResult, Runtime};
 use holochain_core_types::{error::HcResult, signature::Signature};
-use holochain_dpki::keypair::generate_random_sign_keypair;
+use holochain_dpki::keypair::{secbuf_new_insecure_from_string, generate_random_sign_keypair, SecBuf};
 use holochain_wasm_utils::api_serialization::sign::{OneTimeSignArgs, SignOneTimeResult};
-use lib3h_sodium::secbuf::SecBuf;
 use std::convert::TryFrom;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
@@ -35,7 +34,7 @@ pub fn sign_one_time(payloads: Vec<String>) -> HcResult<SignOneTimeResult> {
     let mut sign_keys = generate_random_sign_keypair()?;
     let mut signatures = Vec::new();
     for data in payloads {
-        let mut data_buf = SecBuf::with_insecure_from_string(data);
+        let mut data_buf = secbuf_new_insecure_from_string(data);
 
         let mut signature_buf = sign_keys.sign(&mut data_buf)?;
         let buf = signature_buf.read_lock();

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -28,7 +28,7 @@ objekt= "=0.1.2"
 holochain_persistence_api = "=0.0.7"
 holochain_json_derive = "=0.0.17"
 holochain_json_api = "=0.0.17"
-lib3h_crypto_api = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/crypto_api" }
+lib3h_crypto_api = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 uuid = { version = "=0.7.1", features = ["v4"] }
 regex = "=1.1.2"
 shrinkwraprs = "=0.2.1"

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -28,7 +28,7 @@ objekt= "=0.1.2"
 holochain_persistence_api = "=0.0.7"
 holochain_json_derive = "=0.0.17"
 holochain_json_api = "=0.0.17"
-lib3h_crypto_api = "=0.0.10"
+lib3h_crypto_api = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/crypto_api" }
 uuid = { version = "=0.7.1", features = ["v4"] }
 regex = "=1.1.2"
 shrinkwraprs = "=0.2.1"

--- a/dpki/Cargo.toml
+++ b/dpki/Cargo.toml
@@ -9,8 +9,8 @@ lazy_static = "=1.2.0"
 base64 = "=0.10.1"
 holochain_core_types = { path = "../core_types" }
 holochain_persistence_api = "=0.0.7"
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
-lib3h_crypto_api = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/crypto_api" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
+lib3h_crypto_api = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }

--- a/dpki/Cargo.toml
+++ b/dpki/Cargo.toml
@@ -9,7 +9,8 @@ lazy_static = "=1.2.0"
 base64 = "=0.10.1"
 holochain_core_types = { path = "../core_types" }
 holochain_persistence_api = "=0.0.7"
-lib3h_sodium = "=0.0.10"
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h_crypto_api = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/crypto_api" }
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }

--- a/dpki/src/key_blob.rs
+++ b/dpki/src/key_blob.rs
@@ -1,17 +1,5 @@
-#![allow(warnings)]
-use lib3h_sodium::{kx, secbuf::SecBuf, sign, *};
-
-use crate::{
-    key_bundle::*,
-    keypair::*,
-    password_encryption::{self, pw_dec, pw_enc, pw_hash, EncryptedData, PwHashConfig},
-    seed::*,
-    utils, SEED_SIZE,
-};
-use holochain_core_types::{
-    agent::Base32,
-    error::{HcResult, HolochainError},
-};
+use crate::{key_bundle::*, keypair::*, seed::*, utils, SecBuf, CRYPTO, SEED_SIZE};
+use holochain_core_types::error::{HcResult, HolochainError};
 use std::str;
 
 use serde_derive::{Deserialize, Serialize};
@@ -43,29 +31,16 @@ pub trait Blobbable {
     fn blob_type() -> BlobType;
     fn blob_size() -> usize;
 
-    fn from_blob(
-        blob: &KeyBlob,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<Self>
+    fn from_blob(blob: &KeyBlob, passphrase: &mut SecBuf) -> HcResult<Self>
     where
         Self: Sized;
 
-    fn as_blob(
-        &mut self,
-        passphrase: &mut SecBuf,
-        hint: String,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<KeyBlob>;
+    fn as_blob(&mut self, passphrase: &mut SecBuf, hint: String) -> HcResult<KeyBlob>;
 
     // -- Common methods -- //
 
     /// Blobs a data buf
-    fn finalize_blobbing(
-        data_buf: &mut SecBuf,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<String> {
+    fn finalize_blobbing(data_buf: &mut SecBuf, passphrase: &mut SecBuf) -> HcResult<String> {
         // Check size
         if data_buf.len() != Self::blob_size() {
             return Err(HolochainError::ErrorGeneric(
@@ -73,22 +48,18 @@ pub trait Blobbable {
             ));
         }
 
-        utils::encrypt_with_passphrase_buf(data_buf, passphrase, config)
+        utils::encrypt_with_passphrase_buf(data_buf, passphrase)
     }
 
     /// Get the data buf back from a Blob
-    fn unblob(
-        blob: &KeyBlob,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<SecBuf> {
+    fn unblob(blob: &KeyBlob, passphrase: &mut SecBuf) -> HcResult<SecBuf> {
         // Check type
         if blob.blob_type != Self::blob_type() {
             return Err(HolochainError::ErrorGeneric(
                 "Blob type mismatch while unblobbing".to_string(),
             ));
         }
-        utils::decrypt_with_passphrase_buf(&blob.data, passphrase, config, Self::blob_size())
+        utils::decrypt_with_passphrase_buf(&blob.data, passphrase, Self::blob_size())
     }
 }
 
@@ -108,15 +79,10 @@ impl Blobbable for Seed {
     /// Get the Seed from a Seed Blob
     /// @param {object} blob - the seed blob to unblob
     /// @param {string} passphrase - the decryption passphrase
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
     /// @return Resulting Seed
-    fn from_blob(
-        blob: &KeyBlob,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<Self> {
+    fn from_blob(blob: &KeyBlob, passphrase: &mut SecBuf) -> HcResult<Self> {
         // Retrieve data buf from blob
-        let mut seed_buf = Self::unblob(blob, passphrase, config)?;
+        let seed_buf = Self::unblob(blob, passphrase)?;
         // Construct
         Ok(Seed::new(seed_buf, blob.seed_type.clone()))
     }
@@ -124,16 +90,10 @@ impl Blobbable for Seed {
     ///  generate a persistence bundle with hint info
     ///  @param {string} passphrase - the encryption passphrase
     ///  @param {string} hint - additional info / description for persistence
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
     /// @return {KeyBlob} - bundle of the seed
-    fn as_blob(
-        &mut self,
-        passphrase: &mut SecBuf,
-        hint: String,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<KeyBlob> {
+    fn as_blob(&mut self, passphrase: &mut SecBuf, hint: String) -> HcResult<KeyBlob> {
         // Blob seed buf directly
-        let encoded_blob = Self::finalize_blobbing(&mut self.buf, passphrase, config)?;
+        let encoded_blob = Self::finalize_blobbing(&mut self.buf, passphrase)?;
         // Done
         Ok(KeyBlob {
             seed_type: self.kind.clone(),
@@ -150,13 +110,15 @@ impl Blobbable for Seed {
 
 const KEYBUNDLE_BLOB_FORMAT_VERSION: u8 = 2;
 
-const KEYBUNDLE_BLOB_SIZE: usize = 1 // version byte
-    + sign::PUBLICKEYBYTES
-    + kx::PUBLICKEYBYTES
-    + sign::SECRETKEYBYTES
-    + kx::SECRETKEYBYTES;
-
-pub const KEYBUNDLE_BLOB_SIZE_ALIGNED: usize = ((KEYBUNDLE_BLOB_SIZE + 8 - 1) / 8) * 8;
+lazy_static! {
+    pub static ref KEYBUNDLE_BLOB_SIZE: usize =
+        1 // version byte
+        + CRYPTO.sign_public_key_bytes()
+        + CRYPTO.kx_public_key_bytes()
+        + CRYPTO.sign_secret_key_bytes()
+        + CRYPTO.kx_secret_key_bytes();
+    pub static ref KEYBUNDLE_BLOB_SIZE_ALIGNED: usize = ((*KEYBUNDLE_BLOB_SIZE + 8 - 1) / 8) * 8;
+}
 
 impl Blobbable for KeyBundle {
     fn blob_type() -> BlobType {
@@ -164,53 +126,47 @@ impl Blobbable for KeyBundle {
     }
 
     fn blob_size() -> usize {
-        KEYBUNDLE_BLOB_SIZE_ALIGNED
+        *KEYBUNDLE_BLOB_SIZE_ALIGNED
     }
 
     /// Generate an encrypted blob for persistence
     /// @param {SecBuf} passphrase - the encryption passphrase
     /// @param {string} hint - additional info / description for the bundle
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
-    fn as_blob(
-        &mut self,
-        passphrase: &mut SecBuf,
-        hint: String,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<KeyBlob> {
+    fn as_blob(&mut self, passphrase: &mut SecBuf, hint: String) -> HcResult<KeyBlob> {
         // Initialize buffer
-        let mut data_buf = SecBuf::with_secure(KEYBUNDLE_BLOB_SIZE_ALIGNED);
+        let mut data_buf = CRYPTO.buf_new_secure(KeyBundle::blob_size());
         let mut offset: usize = 0;
         // Write version
         data_buf.write(0, &[KEYBUNDLE_BLOB_FORMAT_VERSION]).unwrap();
         offset += 1;
         // Write public signing key
         let key = self.sign_keys.decode_pub_key();
-        assert_eq!(sign::PUBLICKEYBYTES, key.len());
+        assert_eq!(CRYPTO.sign_public_key_bytes(), key.len());
         data_buf
             .write(offset, &key)
             .expect("Failed blobbing public signing key");
-        offset += sign::PUBLICKEYBYTES;
+        offset += CRYPTO.sign_public_key_bytes();
         // Write public encoding key
         let key = self.enc_keys.decode_pub_key();
-        assert_eq!(kx::PUBLICKEYBYTES, key.len());
+        assert_eq!(CRYPTO.kx_public_key_bytes(), key.len());
         data_buf
             .write(offset, &key)
             .expect("Failed blobbing public encoding key");
-        offset += kx::PUBLICKEYBYTES;
+        offset += CRYPTO.kx_public_key_bytes();
         // Write private signing key
         data_buf
-            .write(offset, &**self.sign_keys.private.read_lock())
+            .write(offset, &*self.sign_keys.private.read_lock())
             .expect("Failed blobbing private signing key");
-        offset += sign::SECRETKEYBYTES;
+        offset += CRYPTO.sign_secret_key_bytes();
         // Write private encoding key
         data_buf
-            .write(offset, &**self.enc_keys.private.read_lock())
+            .write(offset, &*self.enc_keys.private.read_lock())
             .expect("Failed blobbing private encoding key");
-        offset += kx::SECRETKEYBYTES;
-        assert_eq!(offset, KEYBUNDLE_BLOB_SIZE);
+        offset += CRYPTO.kx_secret_key_bytes();
+        assert_eq!(offset, *KEYBUNDLE_BLOB_SIZE);
 
         // Finalize
-        let encoded_blob = Self::finalize_blobbing(&mut data_buf, passphrase, config)?;
+        let encoded_blob = Self::finalize_blobbing(&mut data_buf, passphrase)?;
 
         // Done
         Ok(KeyBlob {
@@ -224,20 +180,15 @@ impl Blobbable for KeyBundle {
     /// Construct the pairs from an encrypted blob
     /// @param {object} bundle - persistence info
     /// @param {SecBuf} passphrase - decryption passphrase
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
-    fn from_blob(
-        blob: &KeyBlob,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<KeyBundle> {
+    fn from_blob(blob: &KeyBlob, passphrase: &mut SecBuf) -> HcResult<KeyBundle> {
         // Retrieve data buf from blob
-        let mut keybundle_blob = Self::unblob(blob, passphrase, config)?;
+        let keybundle_blob = Self::unblob(blob, passphrase)?;
 
         // Deserialize manually
-        let mut pub_sign = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
-        let mut pub_enc = SecBuf::with_insecure(kx::PUBLICKEYBYTES);
-        let mut priv_sign = SecBuf::with_secure(sign::SECRETKEYBYTES);
-        let mut priv_enc = SecBuf::with_secure(kx::SECRETKEYBYTES);
+        let mut pub_sign = CRYPTO.buf_new_insecure(CRYPTO.sign_public_key_bytes());
+        let mut pub_enc = CRYPTO.buf_new_insecure(CRYPTO.kx_public_key_bytes());
+        let mut priv_sign = CRYPTO.buf_new_secure(CRYPTO.sign_secret_key_bytes());
+        let mut priv_enc = CRYPTO.buf_new_secure(CRYPTO.kx_secret_key_bytes());
         {
             let keybundle_blob = keybundle_blob.read_lock();
             if keybundle_blob[0] != KEYBUNDLE_BLOB_FORMAT_VERSION {
@@ -271,11 +222,12 @@ impl Blobbable for KeyBundle {
 
 const SIGNING_KEY_BLOB_FORMAT_VERSION: u8 = 1;
 
-const SIGNING_KEY_BLOB_SIZE: usize = 1 // version byte
-    + sign::PUBLICKEYBYTES
-    + sign::SECRETKEYBYTES;
-
-pub const SIGNING_KEY_BLOB_SIZE_ALIGNED: usize = ((SIGNING_KEY_BLOB_SIZE + 8 - 1) / 8) * 8;
+lazy_static! {
+    pub static ref SIGNING_KEY_BLOB_SIZE: usize = 1 // version byte
+        + CRYPTO.sign_public_key_bytes()
+        + CRYPTO.sign_secret_key_bytes();
+    pub static ref SIGNING_KEY_BLOB_SIZE_ALIGNED: usize = ((*SIGNING_KEY_BLOB_SIZE + 8 - 1) / 8) * 8;
+}
 
 impl Blobbable for SigningKeyPair {
     fn blob_type() -> BlobType {
@@ -283,21 +235,15 @@ impl Blobbable for SigningKeyPair {
     }
 
     fn blob_size() -> usize {
-        SIGNING_KEY_BLOB_SIZE_ALIGNED
+        *SIGNING_KEY_BLOB_SIZE_ALIGNED
     }
 
     /// Generate an encrypted blob for persistence
     /// @param {SecBuf} passphrase - the encryption passphrase
     /// @param {string} hint - additional info / description for the bundle
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
-    fn as_blob(
-        &mut self,
-        passphrase: &mut SecBuf,
-        hint: String,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<KeyBlob> {
+    fn as_blob(&mut self, passphrase: &mut SecBuf, hint: String) -> HcResult<KeyBlob> {
         // Initialize buffer
-        let mut data_buf = SecBuf::with_secure(SIGNING_KEY_BLOB_SIZE_ALIGNED);
+        let mut data_buf = CRYPTO.buf_new_secure(SigningKeyPair::blob_size());
         let mut offset: usize = 0;
         // Write version
         data_buf
@@ -306,19 +252,19 @@ impl Blobbable for SigningKeyPair {
         offset += 1;
         // Write public signing key
         let key = self.decode_pub_key();
-        assert_eq!(sign::PUBLICKEYBYTES, key.len());
+        assert_eq!(CRYPTO.sign_public_key_bytes(), key.len());
         data_buf
             .write(offset, &key)
             .expect("Failed blobbing public signing key");
-        offset += sign::PUBLICKEYBYTES;
+        offset += CRYPTO.sign_public_key_bytes();
         // Write private signing key
         data_buf
-            .write(offset, &**self.private.read_lock())
+            .write(offset, &*self.private.read_lock())
             .expect("Failed blobbing private signing key");
-        offset += sign::SECRETKEYBYTES;
+//        offset += CRYPTO.sign_secret_key_bytes();
 
         // Finalize
-        let encoded_blob = Self::finalize_blobbing(&mut data_buf, passphrase, config)?;
+        let encoded_blob = Self::finalize_blobbing(&mut data_buf, passphrase)?;
 
         // Done
         Ok(KeyBlob {
@@ -332,18 +278,13 @@ impl Blobbable for SigningKeyPair {
     /// Construct the pairs from an encrypted blob
     /// @param {object} bundle - persistence info
     /// @param {SecBuf} passphrase - decryption passphrase
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
-    fn from_blob(
-        blob: &KeyBlob,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<SigningKeyPair> {
+    fn from_blob(blob: &KeyBlob, passphrase: &mut SecBuf) -> HcResult<SigningKeyPair> {
         // Retrieve data buf from blob
-        let mut keybundle_blob = Self::unblob(blob, passphrase, config)?;
+        let keybundle_blob = Self::unblob(blob, passphrase)?;
 
         // Deserialize manually
-        let mut pub_sign = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
-        let mut priv_sign = SecBuf::with_secure(sign::SECRETKEYBYTES);
+        let mut pub_sign = CRYPTO.buf_new_insecure(CRYPTO.sign_public_key_bytes());
+        let mut priv_sign = CRYPTO.buf_new_secure(CRYPTO.sign_secret_key_bytes());
         {
             let keybundle_blob = keybundle_blob.read_lock();
             if keybundle_blob[0] != SIGNING_KEY_BLOB_FORMAT_VERSION {
@@ -369,11 +310,13 @@ impl Blobbable for SigningKeyPair {
 
 const ENCRYPTING_KEY_BLOB_FORMAT_VERSION: u8 = 1;
 
-const ENCRYPTING_KEY_BLOB_SIZE: usize = 1 // version byte
-    + kx::PUBLICKEYBYTES
-    + kx::SECRETKEYBYTES;
+lazy_static! {
+    pub static ref ENCRYPTING_KEY_BLOB_SIZE: usize = 1 // version byte
+        + CRYPTO.kx_public_key_bytes()
+        + CRYPTO.kx_secret_key_bytes();
 
-pub const ENCRYPTING_KEY_BLOB_SIZE_ALIGNED: usize = ((ENCRYPTING_KEY_BLOB_SIZE + 8 - 1) / 8) * 8;
+    pub static ref ENCRYPTING_KEY_BLOB_SIZE_ALIGNED: usize = ((*ENCRYPTING_KEY_BLOB_SIZE + 8 - 1) / 8) * 8;
+}
 
 impl Blobbable for EncryptingKeyPair {
     fn blob_type() -> BlobType {
@@ -381,21 +324,15 @@ impl Blobbable for EncryptingKeyPair {
     }
 
     fn blob_size() -> usize {
-        ENCRYPTING_KEY_BLOB_SIZE_ALIGNED
+        *ENCRYPTING_KEY_BLOB_SIZE_ALIGNED
     }
 
     /// Generate an encrypted blob for persistence
     /// @param {SecBuf} passphrase - the encryption passphrase
     /// @param {string} hint - additional info / description for the bundle
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
-    fn as_blob(
-        &mut self,
-        passphrase: &mut SecBuf,
-        hint: String,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<KeyBlob> {
+    fn as_blob(&mut self, passphrase: &mut SecBuf, hint: String) -> HcResult<KeyBlob> {
         // Initialize buffer
-        let mut data_buf = SecBuf::with_secure(ENCRYPTING_KEY_BLOB_SIZE_ALIGNED);
+        let mut data_buf = CRYPTO.buf_new_secure(EncryptingKeyPair::blob_size());
         let mut offset: usize = 0;
         // Write version
         data_buf
@@ -404,19 +341,19 @@ impl Blobbable for EncryptingKeyPair {
         offset += 1;
         // Write public encrypting key
         let key = self.decode_pub_key();
-        assert_eq!(kx::PUBLICKEYBYTES, key.len());
+        assert_eq!(CRYPTO.kx_public_key_bytes(), key.len());
         data_buf
             .write(offset, &key)
             .expect("Failed blobbing public encrypting key");
-        offset += kx::PUBLICKEYBYTES;
+        offset += CRYPTO.kx_public_key_bytes();
         // Write private encyrpting key
         data_buf
-            .write(offset, &**self.private.read_lock())
+            .write(offset, &*self.private.read_lock())
             .expect("Failed blobbing private ecrypting key");
-        offset += kx::SECRETKEYBYTES;
+//        offset += CRYPTO.kx_secret_key_bytes();
 
         // Finalize
-        let encoded_blob = Self::finalize_blobbing(&mut data_buf, passphrase, config)?;
+        let encoded_blob = Self::finalize_blobbing(&mut data_buf, passphrase)?;
 
         // Done
         Ok(KeyBlob {
@@ -430,18 +367,13 @@ impl Blobbable for EncryptingKeyPair {
     /// Construct the pairs from an encrypted blob
     /// @param {object} bundle - persistence info
     /// @param {SecBuf} passphrase - decryption passphrase
-    /// @param {Option<PwHashConfig>} config - Settings for pwhash
-    fn from_blob(
-        blob: &KeyBlob,
-        passphrase: &mut SecBuf,
-        config: Option<PwHashConfig>,
-    ) -> HcResult<EncryptingKeyPair> {
+    fn from_blob(blob: &KeyBlob, passphrase: &mut SecBuf) -> HcResult<EncryptingKeyPair> {
         // Retrieve data buf from blob
-        let mut keybundle_blob = Self::unblob(blob, passphrase, config)?;
+        let keybundle_blob = Self::unblob(blob, passphrase)?;
 
         // Deserialize manually
-        let mut pub_sign = SecBuf::with_insecure(kx::PUBLICKEYBYTES);
-        let mut priv_sign = SecBuf::with_secure(kx::SECRETKEYBYTES);
+        let mut pub_sign = CRYPTO.buf_new_insecure(CRYPTO.kx_public_key_bytes());
+        let mut priv_sign = CRYPTO.buf_new_secure(CRYPTO.kx_secret_key_bytes());
         {
             let keybundle_blob = keybundle_blob.read_lock();
             if keybundle_blob[0] != ENCRYPTING_KEY_BLOB_FORMAT_VERSION {
@@ -465,12 +397,9 @@ impl Blobbable for EncryptingKeyPair {
 mod tests {
     use super::*;
     use crate::{
-        key_bundle::tests::*,
         keypair::{generate_random_enc_keypair, generate_random_sign_keypair},
-        utils::generate_random_seed_buf,
-        SEED_SIZE,
+        utils::{generate_random_seed_buf, tests::TEST_CRYPTO},
     };
-    use lib3h_sodium::pwhash;
 
     #[test]
     fn it_should_blob_keybundle() {
@@ -479,22 +408,20 @@ mod tests {
 
         let mut bundle = KeyBundle::new_from_seed_buf(&mut seed_buf).unwrap();
 
-        let blob = bundle
-            .as_blob(&mut passphrase, "hint".to_string(), TEST_CONFIG)
-            .unwrap();
+        let blob = bundle.as_blob(&mut passphrase, "hint".to_string()).unwrap();
 
         println!("blob.data: {}", blob.data);
 
         assert_eq!(SeedType::Mock, blob.seed_type);
         assert_eq!("hint", blob.hint);
 
-        let mut unblob = KeyBundle::from_blob(&blob, &mut passphrase, TEST_CONFIG).unwrap();
+        let mut unblob = KeyBundle::from_blob(&blob, &mut passphrase).unwrap();
 
         assert!(bundle.is_same(&mut unblob));
 
         // Test with wrong passphrase
-        passphrase.randomize();
-        let maybe_unblob = KeyBundle::from_blob(&blob, &mut passphrase, TEST_CONFIG);
+        TEST_CRYPTO.randombytes_buf(&mut passphrase);
+        let maybe_unblob = KeyBundle::from_blob(&blob, &mut passphrase);
         assert!(maybe_unblob.is_err());
     }
 
@@ -505,7 +432,7 @@ mod tests {
         let mut signing_key = generate_random_sign_keypair().unwrap();
 
         let blob = signing_key
-            .as_blob(&mut passphrase, "hint".to_string(), TEST_CONFIG)
+            .as_blob(&mut passphrase, "hint".to_string())
             .unwrap();
 
         println!("blob.data: {}", blob.data);
@@ -513,14 +440,14 @@ mod tests {
         assert_eq!(SeedType::Mock, blob.seed_type);
         assert_eq!("hint", blob.hint);
 
-        let mut unblob = SigningKeyPair::from_blob(&blob, &mut passphrase, TEST_CONFIG).unwrap();
+        let mut unblob = SigningKeyPair::from_blob(&blob, &mut passphrase).unwrap();
 
         assert_eq!(0, unblob.private().compare(&mut signing_key.private()));
         assert_eq!(unblob.public(), signing_key.public());
 
         // Test with wrong passphrase
-        passphrase.randomize();
-        let maybe_unblob = SigningKeyPair::from_blob(&blob, &mut passphrase, TEST_CONFIG);
+        TEST_CRYPTO.randombytes_buf(&mut passphrase);
+        let maybe_unblob = SigningKeyPair::from_blob(&blob, &mut passphrase);
         assert!(maybe_unblob.is_err());
     }
 
@@ -531,7 +458,7 @@ mod tests {
         let mut enc_key = generate_random_enc_keypair().unwrap();
 
         let blob = enc_key
-            .as_blob(&mut passphrase, "hint".to_string(), TEST_CONFIG)
+            .as_blob(&mut passphrase, "hint".to_string())
             .unwrap();
 
         println!("blob.data: {}", blob.data);
@@ -539,14 +466,14 @@ mod tests {
         assert_eq!(SeedType::Mock, blob.seed_type);
         assert_eq!("hint", blob.hint);
 
-        let mut unblob = EncryptingKeyPair::from_blob(&blob, &mut passphrase, TEST_CONFIG).unwrap();
+        let mut unblob = EncryptingKeyPair::from_blob(&blob, &mut passphrase).unwrap();
 
         assert_eq!(0, unblob.private().compare(&mut enc_key.private()));
         assert_eq!(unblob.public(), enc_key.public());
 
         // Test with wrong passphrase
-        passphrase.randomize();
-        let maybe_unblob = EncryptingKeyPair::from_blob(&blob, &mut passphrase, TEST_CONFIG);
+        TEST_CRYPTO.randombytes_buf(&mut passphrase);
+        let maybe_unblob = EncryptingKeyPair::from_blob(&blob, &mut passphrase);
         assert!(maybe_unblob.is_err());
     }
 
@@ -557,10 +484,10 @@ mod tests {
         let mut initial_seed = Seed::new(seed_buf, SeedType::Root);
 
         let blob = initial_seed
-            .as_blob(&mut passphrase, "hint".to_string(), TEST_CONFIG)
+            .as_blob(&mut passphrase, "hint".to_string())
             .unwrap();
 
-        let mut root_seed = Seed::from_blob(&blob, &mut passphrase, TEST_CONFIG).unwrap();
+        let mut root_seed = Seed::from_blob(&blob, &mut passphrase).unwrap();
         assert_eq!(SeedType::Root, root_seed.kind);
         assert_eq!(0, root_seed.buf.compare(&mut initial_seed.buf));
     }
@@ -573,10 +500,10 @@ mod tests {
 
         let blob = initial_device_pin_seed
             .seed_mut()
-            .as_blob(&mut passphrase, "hint".to_string(), TEST_CONFIG)
+            .as_blob(&mut passphrase, "hint".to_string())
             .unwrap();
 
-        let seed = Seed::from_blob(&blob, &mut passphrase, TEST_CONFIG).unwrap();
+        let seed = Seed::from_blob(&blob, &mut passphrase).unwrap();
         let mut typed_seed = seed.into_typed().unwrap();
 
         match typed_seed {

--- a/dpki/src/key_bundle.rs
+++ b/dpki/src/key_bundle.rs
@@ -1,11 +1,10 @@
 #![allow(warnings)]
-use lib3h_sodium::{kx, secbuf::SecBuf, sign, *};
 
 use crate::{
     keypair::*,
     password_encryption::{self, EncryptedData, PwHashConfig},
     seed::{Seed, SeedType},
-    utils, SEED_SIZE,
+    utils, SecBuf, CRYPTO, SEED_SIZE,
 };
 use holochain_core_types::{agent::Base32, error::HcResult};
 use serde_json::json;
@@ -60,26 +59,26 @@ impl KeyBundle {
     }
 
     pub fn encrypt(&mut self, data: &mut SecBuf) -> HcResult<SecBuf> {
-        let mut encrypted_data = SecBuf::with_insecure(
-            data.len() + lib3h_sodium::aead::ABYTES + lib3h_sodium::aead::NONCEBYTES,
+        let mut encrypted_data = CRYPTO.buf_new_insecure(
+            data.len() + CRYPTO.aead_auth_bytes() + CRYPTO.aead_nonce_bytes(),
         );
         self.enc_keys.encrypt(data, &mut encrypted_data);
-        Ok(encrypted_data.clone())
+        Ok(encrypted_data.box_clone())
     }
 
     pub fn decrypt(&mut self, cipher: &mut SecBuf) -> HcResult<SecBuf> {
-        let mut decrypted_data = SecBuf::with_insecure(
-            (cipher.len() - lib3h_sodium::aead::NONCEBYTES) + lib3h_sodium::aead::ABYTES,
+        let mut decrypted_data = CRYPTO.buf_new_insecure(
+            (cipher.len() - lib3h_sodium::aead::NONCEBYTES) + CRYPTO.aead_auth_bytes(),
         );
         self.enc_keys.decrypt(cipher, &mut decrypted_data);
-        Ok(decrypted_data.clone())
+        Ok(decrypted_data.box_clone())
     }
 
     /// verify data that was signed with our private signing key
     /// @param {SecBuf} data buffer to verify
     /// @param {SecBuf} signature candidate for that data buffer
     /// @return true if verification succeeded
-    pub fn verify(&mut self, data: &mut SecBuf, signature: &mut SecBuf) -> bool {
+    pub fn verify(&mut self, data: &mut SecBuf, signature: &mut SecBuf) -> HcResult<bool> {
         self.sign_keys.verify(data, signature)
     }
 
@@ -92,7 +91,11 @@ impl KeyBundle {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{keypair::*, utils::generate_random_seed_buf, SIGNATURE_SIZE};
+    use crate::{
+        keypair::*,
+        utils::{generate_random_seed_buf, tests::TEST_CRYPTO},
+        SIGNATURE_SIZE,
+    };
     use lib3h_sodium::pwhash;
 
     pub(crate) const TEST_CONFIG: Option<PwHashConfig> = Some(PwHashConfig(
@@ -134,26 +137,26 @@ pub(crate) mod tests {
         let mut bundle = test_generate_random_bundle();
 
         // Create random data
-        let mut message = SecBuf::with_insecure(16);
-        message.randomize();
+        let mut message = TEST_CRYPTO.buf_new_insecure(16);
+        TEST_CRYPTO.randombytes_buf(&mut message);
 
         // sign it
         let mut signature = bundle.sign(&mut message).unwrap();
         // authentify signature
         let succeeded = bundle.verify(&mut message, &mut signature);
-        assert!(succeeded);
+        assert_eq!(succeeded, Ok(true));
 
         // Create random data
-        let mut random_signature = SecBuf::with_insecure(SIGNATURE_SIZE);
-        random_signature.randomize();
+        let mut random_signature = TEST_CRYPTO.buf_new_insecure(SIGNATURE_SIZE);
+        TEST_CRYPTO.randombytes_buf(&mut random_signature);
         // authentify random signature
         let succeeded = bundle.verify(&mut message, &mut random_signature);
-        assert!(!succeeded);
+        assert_eq!(succeeded, Ok(false));
 
         // Randomize data again
-        message.randomize();
+        TEST_CRYPTO.randombytes_buf(&mut message);
         let succeeded = bundle.verify(&mut message, &mut signature);
-        assert!(!succeeded);
+        assert_eq!(succeeded, Ok(false));
     }
 
     #[test]
@@ -162,10 +165,10 @@ pub(crate) mod tests {
         let mut bundle = test_generate_random_bundle();
 
         // Create random data
-        let mut message = SecBuf::with_insecure(16);
-        message.randomize();
+        let mut message = TEST_CRYPTO.buf_new_insecure(16);
+        TEST_CRYPTO.randombytes_buf(&mut message);
         //encrypt it
-        let mut encrypted_message = bundle.encrypt(&mut message.clone()).unwrap();
+        let mut encrypted_message = bundle.encrypt(&mut message.box_clone()).unwrap();
 
         //decrypted same message
         let mut decrypted_message = bundle.decrypt(&mut encrypted_message).unwrap();

--- a/dpki/src/keypair.rs
+++ b/dpki/src/keypair.rs
@@ -3,11 +3,10 @@
 use crate::{
     key_bundle,
     password_encryption::{self, PwHashConfig},
-    utils, CODEC_HCK0, CODEC_HCS0, SEED_SIZE, SIGNATURE_SIZE,
+    utils, SecBuf, CODEC_HCK0, CODEC_HCS0, CRYPTO, SEED_SIZE, SIGNATURE_SIZE,
 };
 use hcid::*;
 use holochain_core_types::{agent::Base32, error::HcResult};
-use lib3h_sodium::{kx, secbuf::SecBuf, sign};
 use serde_json::json;
 use std::str;
 
@@ -77,9 +76,9 @@ impl KeyPair for SigningKeyPair {
     fn new_from_seed(seed: &mut SecBuf) -> HcResult<Self> {
         assert_eq!(seed.len(), SEED_SIZE);
         // Generate keys
-        let mut pub_sec_buf = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
-        let mut priv_sec_buf = SecBuf::with_secure(sign::SECRETKEYBYTES);
-        lib3h_sodium::sign::seed_keypair(&mut pub_sec_buf, &mut priv_sec_buf, seed)?;
+        let mut pub_sec_buf = CRYPTO.buf_new_insecure(CRYPTO.sign_public_key_bytes());
+        let mut priv_sec_buf = CRYPTO.buf_new_secure(CRYPTO.sign_secret_key_bytes());
+        CRYPTO.sign_seed_keypair(&mut pub_sec_buf, &mut priv_sec_buf, seed)?;
         // Convert and encode public key side
         let pub_key_b32 = utils::encode_pub_key(&mut pub_sec_buf, Self::codec())?;
         // Done
@@ -87,7 +86,7 @@ impl KeyPair for SigningKeyPair {
     }
 
     fn new_from_self(&mut self) -> HcResult<Self> {
-        Ok(SigningKeyPair::new(self.public(), self.private.clone()))
+        Ok(SigningKeyPair::new(self.public(), self.private.box_clone()))
     }
 }
 
@@ -107,8 +106,8 @@ impl SigningKeyPair {
     /// @param {SecBuf} data - the data to sign
     /// @return {SecBuf} signature - Empty SecBuf to be filled with the signature
     pub fn sign(&mut self, data: &mut SecBuf) -> HcResult<SecBuf> {
-        let mut signature = SecBuf::with_insecure(SIGNATURE_SIZE);
-        lib3h_sodium::sign::sign(data, &mut self.private, &mut signature)?;
+        let mut signature = CRYPTO.buf_new_insecure(SIGNATURE_SIZE);
+        CRYPTO.sign(data, &mut self.private, &mut signature)?;
         Ok(signature)
     }
 
@@ -116,9 +115,10 @@ impl SigningKeyPair {
     /// @param {SecBuf} data
     /// @param {SecBuf} signature
     /// @return true if verification succeeded
-    pub fn verify(&mut self, data: &mut SecBuf, signature: &mut SecBuf) -> bool {
+    pub fn verify(&mut self, data: &mut SecBuf, signature: &mut SecBuf) -> HcResult<bool> {
         let mut pub_key = self.decode_pub_key_into_secbuf();
-        lib3h_sodium::sign::verify(signature, data, &mut pub_key)
+        let result = CRYPTO.sign_verify(signature, data, &mut pub_key)?;
+        Ok(result)
     }
 }
 
@@ -148,9 +148,9 @@ impl KeyPair for EncryptingKeyPair {
     fn new_from_seed(seed: &mut SecBuf) -> HcResult<Self> {
         assert_eq!(seed.len(), SEED_SIZE);
         // Generate keys
-        let mut pub_sec_buf = SecBuf::with_insecure(kx::PUBLICKEYBYTES);
-        let mut priv_sec_buf = SecBuf::with_secure(kx::SECRETKEYBYTES);
-        lib3h_sodium::kx::seed_keypair(&mut pub_sec_buf, &mut priv_sec_buf, seed)?;
+        let mut pub_sec_buf = CRYPTO.buf_new_insecure(CRYPTO.kx_public_key_bytes());
+        let mut priv_sec_buf = CRYPTO.buf_new_secure(CRYPTO.kx_secret_key_bytes());
+        CRYPTO.kx_seed_keypair(&mut pub_sec_buf, &mut priv_sec_buf, seed)?;
         // Convert and encode public key side
         let pub_key_b32 = utils::encode_pub_key(&mut pub_sec_buf, Self::codec())?;
         // Done
@@ -158,7 +158,7 @@ impl KeyPair for EncryptingKeyPair {
     }
 
     fn new_from_self(&mut self) -> HcResult<Self> {
-        Ok(EncryptingKeyPair::new(self.public(), self.private.clone()))
+        Ok(EncryptingKeyPair::new(self.public(), self.private.box_clone()))
     }
 }
 
@@ -176,20 +176,20 @@ impl EncryptingKeyPair {
     /// encrypt some arbitrary data with the signing private key
     /// @param {SecBuf} data - the data to encrypt
     /// @param {output} encrypted_data - result of data encryption
-    pub fn encrypt(&mut self, data: &mut SecBuf, encrypted_data: &mut SecBuf) -> HcResult<()> {
-        let mut nonce = SecBuf::with_insecure(lib3h_sodium::aead::NONCEBYTES);
-        nonce.randomize();
+    pub fn encrypt(&mut self, data: &mut SecBuf, mut encrypted_data: &mut SecBuf) -> HcResult<()> {
+        let mut nonce = CRYPTO.buf_new_insecure(CRYPTO.aead_nonce_bytes());
+        CRYPTO.randombytes_buf(&mut nonce);
 
         //data to represent encryption data length
-        let cipher_length = data.len() + lib3h_sodium::aead::ABYTES;
-        let mut cipher = SecBuf::with_insecure(cipher_length.clone());
+        let cipher_length = data.len() + CRYPTO.aead_auth_bytes();
+        let mut cipher = CRYPTO.buf_new_insecure(cipher_length.clone());
 
         //data is encrypted and cipher is populated
-        lib3h_sodium::aead::enc(data, &mut self.private, None, &mut nonce, &mut cipher)?;
+        CRYPTO.aead_encrypt(&mut cipher, data, None, &mut nonce, &mut self.private)?;
 
         //get read locks from cipher
-        let cipher_slice = &**cipher.read_lock();
-        let nonce_slice = &**nonce.read_lock();
+        let cipher_slice = &*cipher.read_lock();
+        let nonce_slice = &*nonce.read_lock();
 
         //append nonce to cipher
         let cipher_with_nonce_slice = cipher_slice
@@ -197,7 +197,7 @@ impl EncryptingKeyPair {
             .cloned()
             .chain(nonce_slice.into_iter().cloned())
             .collect::<Vec<u8>>();
-        encrypted_data.from_array(&cipher_with_nonce_slice);
+        utils::secbuf_from_array(&mut encrypted_data, &cipher_with_nonce_slice);
 
         Ok(())
     }
@@ -210,17 +210,17 @@ impl EncryptingKeyPair {
         cipher: &mut SecBuf,
         mut decrypted_message: &mut SecBuf,
     ) -> HcResult<()> {
-        let cipher_length = cipher.len() - lib3h_sodium::aead::NONCEBYTES;
+        let cipher_length = cipher.len() - CRYPTO.aead_nonce_bytes();
 
         //get nonce from buffer
-        let mut cipher_slice = &**cipher.read_lock();
-        let mut nonce = SecBuf::with_insecure(lib3h_sodium::aead::NONCEBYTES);
+        let mut cipher_slice = &*cipher.read_lock();
+        let mut nonce = CRYPTO.buf_new_insecure(CRYPTO.aead_nonce_bytes());
         let nonce_slice_from_cipher = cipher_slice
             .iter()
             .skip(cipher_length.clone())
             .cloned()
             .collect::<Vec<u8>>();
-        nonce.from_array(&nonce_slice_from_cipher)?;
+        utils::secbuf_from_array(&mut nonce,&nonce_slice_from_cipher)?;
 
         //get cipher only from buffer
         let cipher_no_nonce_slice = cipher_slice
@@ -228,10 +228,10 @@ impl EncryptingKeyPair {
             .cloned()
             .take(cipher_length)
             .collect::<Vec<u8>>();
-        let mut cipher_no_nonce = SecBuf::with_insecure(cipher_length);
-        cipher_no_nonce.from_array(&cipher_no_nonce_slice)?;
+        let mut cipher_no_nonce = CRYPTO.buf_new_insecure(cipher_length);
+        utils::secbuf_from_array(&mut cipher_no_nonce,&cipher_no_nonce_slice)?;
 
-        lib3h_sodium::aead::dec(
+        CRYPTO.aead_decrypt(
             &mut decrypted_message,
             &mut self.private,
             None,
@@ -260,6 +260,7 @@ pub fn generate_random_enc_keypair() -> HcResult<EncryptingKeyPair> {
 mod tests {
     use super::*;
     use crate::SEED_SIZE;
+    use crate::utils::tests::TEST_CRYPTO;
 
     pub fn test_generate_random_sign_keypair() -> SigningKeyPair {
         generate_random_sign_keypair().unwrap()
@@ -302,27 +303,27 @@ mod tests {
         let mut sign_keys = test_generate_random_sign_keypair();
 
         // Create random data
-        let mut message = SecBuf::with_insecure(16);
-        message.randomize();
+        let mut message = TEST_CRYPTO.buf_new_insecure(16);
+        TEST_CRYPTO.randombytes_buf(&mut message);
 
         // sign it
         let mut signature = sign_keys.sign(&mut message).unwrap();
         println!("signature = {:?}", signature);
         // authentify signature
         let succeeded = sign_keys.verify(&mut message, &mut signature);
-        assert!(succeeded);
+        assert_eq!(succeeded, Ok(true));
 
         // Create random data
-        let mut random_signature = SecBuf::with_insecure(SIGNATURE_SIZE);
-        random_signature.randomize();
+        let mut random_signature = TEST_CRYPTO.buf_new_insecure(SIGNATURE_SIZE);
+        TEST_CRYPTO.randombytes_buf(&mut random_signature);
         // authentify random signature
         let succeeded = sign_keys.verify(&mut message, &mut random_signature);
-        assert!(!succeeded);
+        assert_eq!(succeeded, Ok(false));
 
         // Randomize data again
-        message.randomize();
+        TEST_CRYPTO.randombytes_buf(&mut message);
         let succeeded = sign_keys.verify(&mut message, &mut signature);
-        assert!(!succeeded);
+        assert_eq!(succeeded, Ok(false));
     }
 
 }

--- a/dpki/src/lib.rs
+++ b/dpki/src/lib.rs
@@ -11,11 +11,18 @@ pub const SEED_SIZE: usize = 32;
 pub const AGENT_ID_CTX: [u8; 8] = *b"HCAGNTID";
 pub(crate) const SIGNATURE_SIZE: usize = 64;
 
+pub type SecBuf = Box<dyn Buffer>;
+
+use lib3h_crypto_api::{Buffer, CryptoSystem};
+use lib3h_sodium::SodiumCryptoSystem;
+
 lazy_static! {
     pub static ref CODEC_HCS0: hcid::HcidEncoding =
         hcid::HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with hcs0.");
     pub static ref CODEC_HCK0: hcid::HcidEncoding =
         hcid::HcidEncoding::with_kind("hck0").expect("HCID failed miserably with_hck0.");
+    pub static ref CRYPTO: Box<dyn CryptoSystem> =
+        Box::new(SodiumCryptoSystem::new().set_pwhash_interactive());
 }
 
 pub mod key_blob;

--- a/dpki/src/utils.rs
+++ b/dpki/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::{
-    password_encryption::{pw_dec, pw_enc, EncryptedData, PwHashConfig},
-    CODEC_HCS0, CONTEXT_SIZE, SEED_SIZE,
+    password_encryption::{pw_dec, pw_enc, EncryptedData},
+    SecBuf, CODEC_HCS0, CONTEXT_SIZE, CRYPTO, SEED_SIZE,
 };
 use hcid::*;
 use holochain_core_types::{
@@ -9,7 +9,6 @@ use holochain_core_types::{
     signature::{Provenance, Signature},
 };
 use holochain_persistence_api::cas::content::Address;
-use lib3h_sodium::{kdf, secbuf::SecBuf, sign};
 use std::str;
 
 /// a trait for things that have a provenance that can be verified
@@ -23,6 +22,23 @@ impl Verify for Provenance {
     }
 }
 
+pub(crate) fn secbuf_from_array(buf: &mut SecBuf, data: &[u8]) -> HcResult<()> {
+    if data.len() != buf.len() {
+        return Err(HolochainError::ErrorGeneric(
+            "Input does not have same size as SecBuf".to_string(),
+        ));
+    }
+    buf.write(0, data)?;
+    Ok(())
+}
+
+pub fn secbuf_new_insecure_from_string(data: String) -> SecBuf {
+    let u8_data = data.as_bytes();
+    let mut buf = CRYPTO.buf_new_insecure(u8_data.len());
+    buf.write(0,u8_data).expect("FIXME");
+    buf
+}
+
 /// Decode an HCID-encoded key into a SecBuf
 /// @param {Base32} pub_key_b32 - Public signing key to decode
 /// @param {HcidEncoding} codec - The configured HCID decoder to use
@@ -31,8 +47,8 @@ pub(crate) fn decode_pub_key(pub_key_b32: Base32, codec: &HcidEncoding) -> HcRes
     // Decode Base32 public key
     let pub_key = codec.decode(&pub_key_b32)?;
     // convert to SecBuf
-    let mut pub_key_sec = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
-    pub_key_sec.from_array(&pub_key)?;
+    let mut pub_key_sec = CRYPTO.buf_new_insecure(CRYPTO.sign_public_key_bytes());
+    secbuf_from_array(&mut pub_key_sec, &pub_key)?;
     // Done
     Ok(pub_key_sec)
 }
@@ -52,12 +68,12 @@ pub fn verify(source: Address, data: String, signature: Signature) -> HcResult<b
     let signature_bytes: Vec<u8> = base64::decode(&signature_string)
         .map_err(|_| HolochainError::ErrorGeneric("Signature syntactically invalid".to_string()))?;
 
-    let mut signature_buf = SecBuf::with_insecure(signature_bytes.len());
+    let mut signature_buf = CRYPTO.buf_new_insecure(signature_bytes.len());
     signature_buf
         .write(0, signature_bytes.as_slice())
         .expect("SecBuf must be writeable");
 
-    let mut message_buf = SecBuf::with_insecure_from_string(data);
+    let mut message_buf = secbuf_new_insecure_from_string(data);
     verify_bufs(source.to_string(), &mut message_buf, &mut signature_buf)
 }
 
@@ -72,7 +88,8 @@ pub fn verify_bufs(
     signature: &mut SecBuf,
 ) -> HcResult<bool> {
     let mut pub_key = decode_pub_key(pub_sign_key_b32, &CODEC_HCS0)?;
-    Ok(lib3h_sodium::sign::verify(signature, data, &mut pub_key))
+    let result = CRYPTO.sign_verify(signature, data, &mut pub_key)?;
+    Ok(result)
 }
 
 pub struct SeedContext {
@@ -87,7 +104,7 @@ impl SeedContext {
     }
 
     pub fn to_sec_buf(&self) -> SecBuf {
-        let mut buf = SecBuf::with_insecure(8);
+        let mut buf = CRYPTO.buf_new_insecure(8);
         buf.write(0, &self.inner).expect("SecBuf must be writeable");
         buf
     }
@@ -103,16 +120,16 @@ pub fn generate_derived_seed_buf(
     if index == 0 {
         return Err(HolochainError::ErrorGeneric("Invalid index".to_string()));
     }
-    let mut derived_seed_buf = SecBuf::with_secure(size);
+    let mut derived_seed_buf = CRYPTO.buf_new_secure(size);
     let mut context = seed_context.to_sec_buf();
-    kdf::derive(&mut derived_seed_buf, index, &mut context, &mut src_seed)?;
+    CRYPTO.kdf(&mut derived_seed_buf, index, &mut context, &mut src_seed)?;
     Ok(derived_seed_buf)
 }
 
 /// returns a random buf
 pub fn generate_random_buf(size: usize) -> SecBuf {
-    let mut seed = SecBuf::with_insecure(size);
-    seed.randomize();
+    let mut seed = CRYPTO.buf_new_insecure(size);
+    CRYPTO.randombytes_buf(&mut seed).expect("FIXME");
     seed
 }
 
@@ -125,10 +142,9 @@ pub fn generate_random_seed_buf() -> SecBuf {
 pub fn encrypt_with_passphrase_buf(
     data_buf: &mut SecBuf,
     passphrase: &mut SecBuf,
-    config: Option<PwHashConfig>,
 ) -> HcResult<String> {
     // encrypt buffer
-    let encrypted_blob = pw_enc(data_buf, passphrase, config)?;
+    let encrypted_blob = pw_enc(data_buf, passphrase)?;
     // Serialize and convert to base64
     let serialized_blob = serde_json::to_string(&encrypted_blob).expect("Failed to serialize Blob");
     Ok(base64::encode(&serialized_blob))
@@ -138,7 +154,6 @@ pub fn encrypt_with_passphrase_buf(
 pub fn decrypt_with_passphrase_buf(
     blob: &str,
     passphrase: &mut SecBuf,
-    config: Option<PwHashConfig>,
     size: usize,
 ) -> HcResult<SecBuf> {
     // Decode base64
@@ -147,8 +162,8 @@ pub fn decrypt_with_passphrase_buf(
     let blob_json = str::from_utf8(&blob_b64)?;
     let encrypted_blob: EncryptedData = serde_json::from_str(&blob_json)?;
     // Decrypt
-    let mut decrypted_data = SecBuf::with_secure(size);
-    pw_dec(&encrypted_blob, passphrase, &mut decrypted_data, config)?;
+    let mut decrypted_data = CRYPTO.buf_new_secure(size);
+    pw_dec(&encrypted_blob, passphrase, &mut decrypted_data)?;
     // Check size
     if decrypted_data.len() != size {
         return Err(HolochainError::ErrorGeneric(
@@ -160,15 +175,21 @@ pub fn decrypt_with_passphrase_buf(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use crate::SIGNATURE_SIZE;
-    use lib3h_sodium::{secbuf::SecBuf, sign};
+    use lib3h_crypto_api::CryptoSystem;
+    use lib3h_sodium::SodiumCryptoSystem;
+
+    lazy_static! {
+        pub static ref TEST_CRYPTO: Box<dyn CryptoSystem> =
+            Box::new(SodiumCryptoSystem::new().set_pwhash_interactive());
+    }
 
     #[test]
     fn it_should_hcid_roundtrip() {
-        let mut pub_sec_buf = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
-        pub_sec_buf.randomize();
+        let mut pub_sec_buf = TEST_CRYPTO.buf_new_insecure(TEST_CRYPTO.sign_public_key_bytes());
+        TEST_CRYPTO.randombytes_buf(&mut pub_sec_buf);
 
         let codec = HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with_hcs0");
         let pub_key_b32 = encode_pub_key(&mut pub_sec_buf, &codec).unwrap();
@@ -183,18 +204,22 @@ mod tests {
     fn it_should_verify_bufs() {
         let codec = HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with_hcs0");
         // Create random seed
-        let mut seed = SecBuf::with_insecure(SEED_SIZE);
-        seed.randomize();
+        let mut seed = TEST_CRYPTO.buf_new_insecure(SEED_SIZE);
+        TEST_CRYPTO.randombytes_buf(&mut seed);
         // Create keys
-        let mut public_key = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
-        let mut secret_key = SecBuf::with_secure(sign::SECRETKEYBYTES);
-        lib3h_sodium::sign::seed_keypair(&mut public_key, &mut secret_key, &mut seed).unwrap();
+        let mut public_key = TEST_CRYPTO.buf_new_insecure(TEST_CRYPTO.sign_public_key_bytes());
+        let mut secret_key = TEST_CRYPTO.buf_new_secure(TEST_CRYPTO.sign_secret_key_bytes());
+        TEST_CRYPTO
+            .sign_seed_keypair(&mut public_key, &mut secret_key, &mut seed)
+            .unwrap();
         let pub_key_b32 = encode_pub_key(&mut public_key, &codec).unwrap();
         // Create signing buffers
-        let mut message = SecBuf::with_insecure(42);
-        message.randomize();
-        let mut signature = SecBuf::with_insecure(SIGNATURE_SIZE);
-        lib3h_sodium::sign::sign(&mut message, &mut secret_key, &mut signature).unwrap();
+        let mut message = TEST_CRYPTO.buf_new_insecure(42);
+        TEST_CRYPTO.randombytes_buf(&mut message);
+        let mut signature = TEST_CRYPTO.buf_new_insecure(SIGNATURE_SIZE);
+        TEST_CRYPTO
+            .sign(&mut message, &mut secret_key, &mut signature)
+            .unwrap();
         let res = verify_bufs(pub_key_b32, &mut message, &mut signature);
         assert!(res.unwrap());
     }
@@ -207,13 +232,13 @@ mod tests {
         let mut random_passphrase = generate_random_buf(10);
 
         let encrypted_result =
-            encrypt_with_passphrase_buf(&mut random_data, &mut random_passphrase, None);
+            encrypt_with_passphrase_buf(&mut random_data, &mut random_passphrase);
         assert!(encrypted_result.is_ok());
 
         let encrypted_data = encrypted_result.unwrap();
 
         let decrypted_result =
-            decrypt_with_passphrase_buf(&encrypted_data, &mut random_passphrase, None, data_size);
+            decrypt_with_passphrase_buf(&encrypted_data, &mut random_passphrase, data_size);
         assert!(decrypted_result.is_ok());
         let mut decrypted_data = decrypted_result.unwrap();
 
@@ -221,18 +246,14 @@ mod tests {
 
         // totally bogus data will return an error
         let bogus_encrypted_data = "askdfklasjdasldkfjlkasdjflkasdjfasdf".to_string();
-        let decrypted_result = decrypt_with_passphrase_buf(
-            &bogus_encrypted_data,
-            &mut random_passphrase,
-            None,
-            data_size,
-        );
+        let decrypted_result =
+            decrypt_with_passphrase_buf(&bogus_encrypted_data, &mut random_passphrase, data_size);
         assert!(decrypted_result.is_err());
 
         // a bogus passphrase will not decrypt to the correct data
         let mut bogus_passphrase = generate_random_buf(10);
         let decrypted_result =
-            decrypt_with_passphrase_buf(&encrypted_data, &mut bogus_passphrase, None, data_size);
+            decrypt_with_passphrase_buf(&encrypted_data, &mut bogus_passphrase, data_size);
         assert!(decrypted_result.is_ok());
         let mut decrypted_data = decrypted_result.unwrap();
         assert!(0 != decrypted_data.compare(&mut random_data));

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -9,10 +9,10 @@ tempfile = "=3.0.7"
 
 [dependencies]
 failure = "=0.1.5"
-lib3h = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h" }
-lib3h_protocol = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h_protocol" }
-lib3h_crypto_api = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/crypto_api" }
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
+lib3h_protocol = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
+lib3h_crypto_api = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 holochain_common = { path = "../common" }
 holochain_core_types = { path = "../core_types" }
 holochain_json_derive = "=0.0.17"

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -9,10 +9,10 @@ tempfile = "=3.0.7"
 
 [dependencies]
 failure = "=0.1.5"
-lib3h = "=0.0.10"
-lib3h_protocol = "=0.0.10"
-lib3h_crypto_api = "=0.0.10"
-lib3h_sodium = "=0.0.10"
+lib3h = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h" }
+lib3h_protocol = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h_protocol" }
+lib3h_crypto_api = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/crypto_api" }
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
 holochain_common = { path = "../common" }
 holochain_core_types = { path = "../core_types" }
 holochain_json_derive = "=0.0.17"

--- a/test/deptool/deptool.bash
+++ b/test/deptool/deptool.bash
@@ -9,6 +9,7 @@ function _usage() {
   echo "  lib3h - deptool lib3h <subcmd>"
   echo "    version - deptool lib3h version <version>"
   echo "    branch - deptool lib3h branch <branch-name>"
+  echo "    path - deptool lib3h path <path>"
   echo "options:"
   echo "  -h --help: additional help for command"
   exit 1
@@ -21,6 +22,22 @@ function _lib3h_deps() {
   local __deps=$(find ../.. -maxdepth 2 -mindepth 2 -name Cargo.toml; find ../../app_spec/zomes -maxdepth 3 -mindepth 3 -name Cargo.toml)
   echo "${__deps}"
   sed -i'' "s/\\(lib3h[^[:space:]]*[[:space:]]\\+=[[:space:]]\\+\\).*/\\1${__dep_str//\//\\\/}/" ${__deps}
+}
+
+function _lib3h_path_deps() {
+  local __l3h_path="$(readlink -f ${__pwd}/${1})"
+  local __l3h_lib3h="{ path = \"${__l3h_path}/crates/lib3h\" }"
+  local __l3h_proto="{ path = \"${__l3h_path}/crates/lib3h_protocol\" }"
+  local __l3h_crypto="{ path = \"${__l3h_path}/crates/crypto_api\" }"
+  local __l3h_sodium="{ path = \"${__l3h_path}/crates/sodium\" }"
+  echo "using ${__l3h_lib3h} ${__l3h_proto} ${__l3h_crypto} ${__l3h_sodium}"
+
+  local __deps=$(find ../.. -maxdepth 2 -mindepth 2 -name Cargo.toml; find ../../app_spec/zomes -maxdepth 3 -mindepth 3 -name Cargo.toml)
+  echo "${__deps}"
+  sed -i'' "s/\\(lib3h[[:space:]]\\+=[[:space:]]\\+\\).*/\\1${__l3h_lib3h//\//\\\/}/" ${__deps}
+  sed -i'' "s/\\(lib3h_protocol[[:space:]]\\+=[[:space:]]\\+\\).*/\\1${__l3h_proto//\//\\\/}/" ${__deps}
+  sed -i'' "s/\\(lib3h_crypto_api[[:space:]]\\+=[[:space:]]\\+\\).*/\\1${__l3h_crypto//\//\\\/}/" ${__deps}
+  sed -i'' "s/\\(lib3h_sodium[[:space:]]\\+=[[:space:]]\\+\\).*/\\1${__l3h_sodium//\//\\\/}/" ${__deps}
 }
 
 function _cmd() {
@@ -49,6 +66,16 @@ function _cmd() {
           fi
           _lib3h_deps "{ git = \"https://github.com/holochain/lib3h\", branch = \"${3}\" }"
           ;;
+        path)
+            if [ ${__help} == 1 ]; then
+                echo "deptool lib3h path"
+                echo " - set the various lib3h dep to a local file path"
+                echo " - example: deptool lib3h path ../lib3h"
+                echo "   will set: lib3h = { path = \"../lib3h/crates/...\" }"
+                exit 1
+            fi
+            _lib3h_path_deps "${3}"
+            ;;
         *)
           if [ ${__help} == 1 ]; then
             echo "deptool lib3h"
@@ -83,6 +110,8 @@ function _this_dir() {
 }
 
 function main() {
+  local __pwd="$(pwd)"
+
   _this_dir
 
   local __cmd=""

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 holochain_core_types = { path = "../core_types" }
 holochain_persistence_api = "=0.0.7"
 holochain_net = { path = "../net" }
-lib3h = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h" }
-lib3h_protocol = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h_protocol" }
+lib3h = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
+lib3h_protocol = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 tempfile = "=3.0.7"
 failure = "=0.1.5"

--- a/test_bin/Cargo.toml
+++ b/test_bin/Cargo.toml
@@ -7,14 +7,14 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 holochain_core_types = { path = "../core_types" }
 holochain_persistence_api = "=0.0.7"
 holochain_net = { path = "../net" }
-lib3h = "=0.0.10"
-lib3h_protocol = "=0.0.10"
+lib3h = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h" }
+lib3h_protocol = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/lib3h_protocol" }
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 tempfile = "=3.0.7"
 failure = "=0.1.5"
 lazy_static = "=1.2.0"
 unwrap_to = "=0.1.0"
-backtrace = "=0.3.14"
+backtrace = "=0.3.26"
 multihash = "=0.8.0"
 crossbeam-channel = "=0.3.8"
 bincode = "=1.1.4"

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -12,7 +12,7 @@ holochain_core_types = { path = "../core_types" }
 holochain_dpki = { path = "../dpki" }
 holochain_persistence_api = "=0.0.7"
 holochain_json_api = "=0.0.17"
-lib3h_sodium = "=0.0.10"
+lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
 wabt = "=0.7.4"
 tempfile = "=3.0.7"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -12,7 +12,7 @@ holochain_core_types = { path = "../core_types" }
 holochain_dpki = { path = "../dpki" }
 holochain_persistence_api = "=0.0.7"
 holochain_json_api = "=0.0.17"
-lib3h_sodium = { path = "/home/eric/code/metacurrency/holochain/lib3h/crates/sodium" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "add-compare-to-crypto-system-buf" }
 wabt = "=0.7.4"
 tempfile = "=3.0.7"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }


### PR DESCRIPTION
## PR summary

updates core to use lib3h::crypto_api::CryptoSystem instead of lib3h::sodium::SecBuf

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
