### PR TITLE
Interface instance alias

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Also added the source to the state dump.
   [#1661](https://github.com/holochain/holochain-rust/pull/1661)
 
+* Add `alias` to instance references in interfaces to decouple hard-coded instance references in hApp UIs from conductor configs. [#1676](https://github.com/holochain/holochain-rust/pull/1676)
 ### Changed
 
 ### Deprecated

--- a/cli/src/cli/run.rs
+++ b/cli/src/cli/run.rs
@@ -182,6 +182,7 @@ fn interface_configuration(
         admin: true,
         instances: vec![InstanceReferenceConfiguration {
             id: INSTANCE_CONFIG_ID.into(),
+            alias: None,
         }],
     })
 }
@@ -356,6 +357,7 @@ mod tests {
                 admin: true,
                 instances: vec![InstanceReferenceConfiguration {
                     id: "test-instance".to_string(),
+                    alias: None,
                 }],
             }
         );
@@ -370,6 +372,7 @@ mod tests {
                 admin: true,
                 instances: vec![InstanceReferenceConfiguration {
                     id: "test-instance".to_string(),
+                    alias: None,
                 }],
             }
         );

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -327,6 +327,7 @@ impl ConductorAdmin for Conductor {
                 if interface.id == *interface_id {
                     interface.instances.push(InstanceReferenceConfiguration {
                         id: instance_id.clone(),
+                        alias: None,
                     });
                 }
                 interface

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -48,6 +48,7 @@ pub trait ConductorAdmin {
         &mut self,
         interface_id: &String,
         instance_id: &String,
+        alias: &Option<String>,
     ) -> Result<(), HolochainError>;
     fn remove_instance_from_interface(
         &mut self,
@@ -301,6 +302,7 @@ impl ConductorAdmin for Conductor {
         &mut self,
         interface_id: &String,
         instance_id: &String,
+        alias: &Option<String>,
     ) -> Result<(), HolochainError> {
         let mut new_config = self.config.clone();
 
@@ -327,7 +329,7 @@ impl ConductorAdmin for Conductor {
                 if interface.id == *interface_id {
                     interface.instances.push(InstanceReferenceConfiguration {
                         id: instance_id.clone(),
-                        alias: None,
+                        alias: alias.clone()
                     });
                 }
                 interface

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -1408,7 +1408,8 @@ type = 'http'"#,
         assert_eq!(
             conductor.add_instance_to_interface(
                 &String::from("websocket interface"),
-                &String::from("new-instance-2")
+                &String::from("new-instance-2"),
+                &None,
             ),
             Ok(())
         );

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -1149,22 +1149,24 @@ impl Conductor {
     }
 
     fn make_interface_handler(&self, interface_config: &InterfaceConfiguration) -> IoHandler {
-        let instance_ids: Vec<String> = interface_config
-            .instances
-            .iter()
-            .map(|i| i.id.clone())
-            .collect();
+        let mut conductor_api_builder = ConductorApiBuilder::new();
+        for instance_ref_config in interface_config.instances.iter() {
+            let id = &instance_ref_config.id;
+            let name = instance_ref_config.alias.as_ref().unwrap_or(id).clone();
 
-        let instance_subset: InstanceMap = self
-            .instances
-            .iter()
-            .filter(|(id, _)| instance_ids.contains(&id))
-            .map(|(id, val)| (id.clone(), val.clone()))
-            .collect();
+            let instance = self.instances.get(id);
+            let instance_config = self.config.instance_by_id(id);
+            if instance.is_none() || instance_config.is_none() {
+                continue;
+            }
 
-        let mut conductor_api_builder = ConductorApiBuilder::new()
-            .with_instances(instance_subset)
-            .with_instance_configs(self.config.instances.clone());
+            let instance = instance.unwrap();
+            let instance_config = instance_config.unwrap();
+
+            conductor_api_builder = conductor_api_builder
+                .with_named_instance(name.clone(), instance.clone())
+                .with_named_instance_config(name.clone(), instance_config)
+        }
 
         if interface_config.admin {
             conductor_api_builder = conductor_api_builder

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -709,9 +709,22 @@ pub enum InterfaceDriver {
     Custom(toml::value::Value),
 }
 
+/// An instance reference makes an instance available in the scope
+/// of an interface.
+/// Since UIs usually hard-code the name with which they reference an instance,
+/// we need to decouple that name used by the UI from the internal ID of
+/// the instance. That is what the optional `alias` field provides.
+/// Given that there is 1-to-1 relationship between UIs and interfaces,
+/// by setting an alias for available instances in the UI's interface
+/// each UI can have its own unique handle for shared instances.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct InstanceReferenceConfiguration {
+    /// ID of the instance that is made available in the interface
     pub id: String,
+
+    /// A local name under which the instance gets mounted in the
+    /// interface's scope
+    pub alias: Option<String>,
 }
 
 /// A bridge enables an instance to call zome functions of another instance.

--- a/conductor_api/src/interface.rs
+++ b/conductor_api/src/interface.rs
@@ -412,6 +412,7 @@ impl ConductorApiBuilder {
     ///     Params:
     ///     * `interface_id`: Which interface to add the instance to?
     ///     * `instance_id`: Which instance to add?
+    ///     * `alias`: (Optional) Local name of the instance within this interface
     ///
     ///  * `admin/interface/remove_instance`
     ///     Remove an instance from a given interface.
@@ -630,7 +631,8 @@ impl ConductorApiBuilder {
                 let params_map = Self::unwrap_params_map(params)?;
                 let interface_id = Self::get_as_string("interface_id", &params_map)?;
                 let instance_id = Self::get_as_string("instance_id", &params_map)?;
-                conductor_call!(|c| c.add_instance_to_interface(&interface_id, &instance_id))?;
+                let alias = Self::get_as_string("alias", &params_map).ok();
+                conductor_call!(|c| c.add_instance_to_interface(&interface_id, &instance_id, &alias))?;
                 Ok(json!({"success": true}))
             });
 


### PR DESCRIPTION
## PR summary

This adds an optional `alias` field to the conductor config's `InstanceReferenceConfiguration` which, when set, results in having the instance mounted under a name different to the instance ID.

This is removes a dependency of the hard-coded UI code to the conductor config of the running host, and is needed to implement [self-contained hApp bundles](https://hackmd.io/DwZ-_jLtSaKT63Ms9bV6Sw) and an installation process implemented in [Holoscape](https://github.com/holochain/holoscape) that does not require any manual conductor config editing to meet the needs of a hApp.

## followups

[Use](https://github.com/holochain/holoscape/commit/faf0ff24754363c0e651db04c84b665812086ee3) this in Holoscape

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
