### PR TITLE
Remove unused app spec imports

### DIFF
--- a/app_spec/zomes/blog/code/src/lib.rs
+++ b/app_spec/zomes/blog/code/src/lib.rs
@@ -9,25 +9,16 @@ extern crate serde_json;
 #[macro_use]
 extern crate holochain_json_derive;
 
-
 pub mod blog;
 pub mod memo;
 pub mod post;
 
 use blog::Env;
 use hdk::{
-    AGENT_ADDRESS, DNA_ADDRESS, PUBLIC_TOKEN,
     error::ZomeApiResult,
-    holochain_persistence_api::{
-        cas::content::Address
-    },
-    holochain_json_api::{
-        error::JsonError, json::JsonString,
-    },
-    holochain_core_types::{
-        entry::Entry,
-        signature::Provenance
-    },
+    holochain_core_types::{entry::Entry, signature::Provenance},
+    holochain_json_api::{error::JsonError, json::JsonString},
+    holochain_persistence_api::cas::content::Address,
     holochain_wasm_utils::api_serialization::{
         get_entry::{EntryHistory, GetEntryResult},
         get_links::GetLinksResult,


### PR DESCRIPTION
## PR summary

CI is breaking because of unused imports, this removes them

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
