### PR TITLE
(un)install conductor

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- added nix for `hc-conductor-install` and `hc-conductor-uninstall` based on `cargo`
+
 ### Changed
 
 ### Deprecated
@@ -15,4 +17,3 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 ### Security
-

--- a/conductor/default.nix
+++ b/conductor/default.nix
@@ -1,0 +1,7 @@
+{ pkgs, config }:
+{
+ buildInputs = []
+ ++ (pkgs.callPackage ./install { }).buildInputs
+ ++ (pkgs.callPackage ./uninstall { }).buildInputs
+ ;
+}

--- a/conductor/install/default.nix
+++ b/conductor/install/default.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+let
+  name = "hc-conductor-install";
+
+  script = pkgs.writeShellScriptBin name
+  ''
+  cargo install -f --path conductor
+  '';
+in
+{
+ buildInputs = [ script ];
+}

--- a/conductor/uninstall/default.nix
+++ b/conductor/uninstall/default.nix
@@ -1,0 +1,13 @@
+{ pkgs }:
+let
+  name = "hc-conductor-uninstall";
+
+  script = pkgs.writeShellScriptBin name
+  ''
+   echo "dropping holochain conductor binary from cargo home directory"
+   rm -f $CARGO_HOME/bin/holochain
+  '';
+in
+{
+ buildInputs = [ script ];
+}

--- a/default.nix
+++ b/default.nix
@@ -35,6 +35,10 @@ with holonix.pkgs;
     pkgs = holonix.pkgs;
    }).buildInputs
 
+   ++ (holonix.pkgs.callPackage ./conductor {
+    pkgs = holonix.pkgs;
+   }).buildInputs
+
    ++ (holonix.pkgs.callPackage ./conductor_wasm {
     pkgs = holonix.pkgs;
    }).buildInputs


### PR DESCRIPTION
## PR summary

reinstates the conductor install/uninstall from holonix

see https://forum.holochain.org/t/fyi-hc-conductor-rust-commands-were-dropped-from-holonix/728/2

```
[nix-shell:~/holochain-rust]$ which holochain
/nix/store/x5fvm8k15glw3qzcjfqy07pvyiib3273-holochain/bin/holochain

[nix-shell:~/holochain-rust]$ hc-conductor-install 
  Installing holochain v0.0.29-alpha2 (/home/thedavidmeister/holochain-rust/conductor)
    Updating crates.io index
    Updating git repository `https://github.com/holochain/jsonrpc`
    Finished release [optimized] target(s) in 5.38s
  Installing /home/thedavidmeister/holochain-rust/.cargo/bin/holochain
   Installed package `holochain v0.0.29-alpha2 (/home/thedavidmeister/holochain-rust/conductor)` (executable `holochain`)

[nix-shell:~/holochain-rust]$ which holochain 
/home/thedavidmeister/holochain-rust/.cargo/bin/holochain

[nix-shell:~/holochain-rust]$ hc-conductor-uninstall 
dropping holochain conductor binary from cargo home directory

[nix-shell:~/holochain-rust]$ which holochain
/nix/store/x5fvm8k15glw3qzcjfqy07pvyiib3273-holochain/bin/holochain
```

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
