### PR TITLE
Serialize `ConsistencySignal` before transmitting across signal channel

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+* ConsistencySignal "events" are now serialized to strings before being emitted. [#1691](https://github.com/holochain/holochain-rust/pull/1691)
+
 ### Deprecated
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
  "holochain_conductor_api 0.0.29-alpha2",
  "holochain_core_types 0.0.29-alpha2",
  "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3805,7 +3805,7 @@ dependencies = [
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shrinkwraprs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5f047b90b2ca2d1526ff73d67cba61f86f4cf9a8afddc99dd96702ded8e684"
-"checksum signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a"
+"checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"

--- a/core/src/consistency.rs
+++ b/core/src/consistency.rs
@@ -2,44 +2,26 @@ use crate::{
     action::Action, context::Context, entry::CanPublish,
     network::entry_with_header::EntryWithHeader,
 };
-use holochain_core_types::{entry::Entry, link::link_data::LinkData};
+use holochain_core_types::{agent::AgentId, entry::Entry, link::link_data::LinkData};
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
+use serde::Serialize;
 use std::{collections::HashMap, sync::Arc};
 
-#[derive(Clone)]
-pub struct ConsistencyModel {
-    commit_cache: HashMap<Address, ConsistencySignal>,
-    context: Arc<Context>,
-}
-
-impl ConsistencyModel {
-    pub fn new(context: Arc<Context>) -> Self {
-        Self {
-            commit_cache: HashMap::new(),
-            context,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize)]
-pub struct ConsistencySignal {
-    event: ConsistencyEvent,
-    pending: Vec<PendingConsistency>,
+pub struct ConsistencySignal<E: Serialize> {
+    event: E,
+    pending: Vec<PendingConsistency<E>>,
 }
 
-impl ConsistencySignal {
-    pub fn new_terminal(event: ConsistencyEvent) -> Self {
+impl<E: Serialize> ConsistencySignal<E> {
+    pub fn new_terminal(event: E) -> Self {
         Self {
             event,
             pending: Vec::new(),
         }
     }
 
-    pub fn new_pending(
-        event: ConsistencyEvent,
-        group: ConsistencyGroup,
-        pending_events: Vec<ConsistencyEvent>,
-    ) -> Self {
+    pub fn new_pending(event: E, group: ConsistencyGroup, pending_events: Vec<E>) -> Self {
         let pending = pending_events
             .into_iter()
             .map(|event| PendingConsistency {
@@ -50,6 +32,26 @@ impl ConsistencySignal {
         Self { event, pending }
     }
 }
+
+impl From<ConsistencySignalE> for ConsistencySignal<String> {
+    fn from(signal: ConsistencySignalE) -> ConsistencySignal<String> {
+        let ConsistencySignalE { event, pending } = signal;
+        ConsistencySignal {
+            event: serde_json::to_string(&event)
+                .expect("ConsistencySignal serialization cannot fail"),
+            pending: pending
+                .into_iter()
+                .map(|p| PendingConsistency {
+                    event: serde_json::to_string(&p.event)
+                        .expect("ConsistencySignal serialization cannot fail"),
+                    group: p.group,
+                })
+                .collect(),
+        }
+    }
+}
+
+type ConsistencySignalE = ConsistencySignal<ConsistencyEvent>;
 
 #[derive(Clone, Debug, Serialize)]
 pub enum ConsistencyEvent {
@@ -69,8 +71,8 @@ pub enum ConsistencyEvent {
 }
 
 #[derive(Clone, Debug, Serialize)]
-struct PendingConsistency {
-    event: ConsistencyEvent,
+struct PendingConsistency<E: Serialize> {
+    event: E,
     group: ConsistencyGroup,
 }
 
@@ -80,11 +82,37 @@ pub enum ConsistencyGroup {
     Validators,
 }
 
+#[derive(Clone)]
+pub struct ConsistencyModel {
+    // upon Commit, caches the corresponding ConsistencySignal which will only be emitted
+    // later, when the corresponding Publish has been processed
+    commit_cache: HashMap<Address, ConsistencySignalE>,
+
+    // Stores the AgentId, once it has been committed
+    agent_id: Option<AgentId>,
+
+    // Context needed to examine state and do logging
+    context: Arc<Context>,
+}
+
 impl ConsistencyModel {
-    pub fn process_action(&mut self, action: &Action) -> Option<ConsistencySignal> {
+    pub fn new(context: Arc<Context>) -> Self {
+        Self {
+            commit_cache: HashMap::new(),
+            agent_id: None,
+            context,
+        }
+    }
+
+    pub fn process_action(&mut self, action: &Action) -> Option<ConsistencySignalE> {
         use ConsistencyEvent::*;
         use ConsistencyGroup::*;
         match action {
+            Action::Commit((Entry::AgentId(agent_id), _, _)) => {
+                self.agent_id = Some(agent_id.clone());
+                None
+            }
+
             Action::Commit((entry, crud_link, _)) => {
                 // XXX: Since can_publish relies on a properly initialized Context, there are a few ways
                 // can_publish can fail. If we hit the possiblity of failure, just add the commit to the cache
@@ -123,9 +151,9 @@ impl ConsistencyModel {
                 // Emit the signal that was created when observing the corresponding Commit
                 let maybe_signal = self.commit_cache.remove(address);
                 maybe_signal.or_else(|| {
-                    // TODO: hook up logger
-                    println!(
-                        "warn/consistency: Publishing address that was not previously committed"
+                    log_warn!(
+                        self.context,
+                        "consistency: Publishing address that was not previously committed"
                     );
                     None
                 })

--- a/core/src/instance.rs
+++ b/core/src/instance.rs
@@ -243,12 +243,14 @@ impl Instance {
         }
 
         if let Err(e) = self.save() {
-            log_error!(context,
+            log_error!(
+                context,
                 "instance/process_action: could not save state: {:?}",
                 e
             );
         } else {
-            log_trace!(context,
+            log_trace!(
+                context,
                 "reduce/process_actions: reducing {:?}",
                 action_wrapper
             );
@@ -269,7 +271,8 @@ impl Instance {
             // to prevent emitting too many unneeded signals
             let trace_signal = Signal::Trace(action_wrapper.clone());
             tx.send(trace_signal).unwrap_or_else(|e| {
-                log_warn!(context,
+                log_warn!(
+                    context,
                     "reduce: Signal channel is closed! No signals can be sent ({:?}).",
                     e
                 );
@@ -278,12 +281,14 @@ impl Instance {
             self.consistency_model
                 .process_action(action_wrapper.action())
                 .map(|signal| {
-                    tx.send(Signal::Consistency(signal)).unwrap_or_else(|e| {
-                        log_warn!(context,
-                            "reduce: Signal channel is closed! No signals can be sent ({:?}).",
-                            e
-                        );
-                    });
+                    tx.send(Signal::Consistency(signal.into()))
+                        .unwrap_or_else(|e| {
+                            log_warn!(
+                                context,
+                                "reduce: Signal channel is closed! No signals can be sent ({:?}).",
+                                e
+                            );
+                        });
                 });
         }
     }

--- a/core/src/signal.rs
+++ b/core/src/signal.rs
@@ -10,7 +10,7 @@ use std::thread;
 #[serde(tag = "signal_type")]
 pub enum Signal {
     Trace(ActionWrapper),
-    Consistency(ConsistencySignal),
+    Consistency(ConsistencySignal<String>),
     User(UserSignal),
 }
 


### PR DESCRIPTION
## PR summary

Hachiko expects observable "events" as strings which match up exactly, coming from different sources at different times. Currently the serialization is happening on the JS side via `JSON.stringify`, but this is not great since `JSON.stringify` is not deterministic. This PR uses serde to do the serialization, under the assumption that serde_json is deterministic.

## testing/benchmarking notes

This will probably break current app spec tests since try-o-rama currently does the serialization itself. I need to update the npm package for try-o-rama to not do this for this PR.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
