### PR TITLE
Update test agent config with correct public_address

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 * Adds EncryptedSeed and seed.encrypt() allow for easy passphrase encrypting/decrypting of any of the existing seed types. Adds the MnemonicableSeed trait allows seeds to be converted to/from BIP39 mnemonics. [#1687](https://github.com/holochain/holochain-rust/pull/1687) 
-- added nix for `hc-conductor-install` and `hc-conductor-uninstall` based on `cargo`
+* added nix for `hc-conductor-install` and `hc-conductor-uninstall` based on `cargo`
+* When loading a hand-written or generated conductor config containing a TestAgent (`test_agent = true`), rewrite the config file so that the test agent's `public_address` is correct, rather than the arbitrary value that was specified before the `public_address` was actually known. [#1692](https://github.com/holochain/holochain-rust/pull/1692)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
  "holochain_conductor_api 0.0.29-alpha2",
  "holochain_core_types 0.0.29-alpha2",
  "lib3h_sodium 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3805,7 +3805,7 @@ dependencies = [
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shrinkwraprs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5f047b90b2ca2d1526ff73d67cba61f86f4cf9a8afddc99dd96702ded8e684"
-"checksum signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a"
+"checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"

--- a/conductor_api/src/conductor/admin.rs
+++ b/conductor_api/src/conductor/admin.rs
@@ -211,7 +211,7 @@ impl ConductorAdmin for Conductor {
         };
         new_config.instances.push(new_instance_config);
         new_config.check_consistency(&mut self.dna_loader)?;
-        let instance = self.instantiate_from_config(id, Some(&new_config))?;
+        let instance = self.instantiate_from_config(id, Some(&mut new_config))?;
         self.instances
             .insert(id.clone(), Arc::new(RwLock::new(instance)));
         self.config = new_config;
@@ -329,7 +329,7 @@ impl ConductorAdmin for Conductor {
                 if interface.id == *interface_id {
                     interface.instances.push(InstanceReferenceConfiguration {
                         id: instance_id.clone(),
-                        alias: alias.clone()
+                        alias: alias.clone(),
                     });
                 }
                 interface

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -710,9 +710,15 @@ impl Conductor {
                 let agent_id = &instance_config.agent;
                 let agent_config = config.agent_by_id(agent_id).unwrap();
                 let agent_address = self.agent_config_to_id(&agent_config)?;
-                config.update_agent_address_by_id(agent_id, &agent_address);
-                self.config = config.clone();
-                self.save_config()?;
+                if agent_config.test_agent.unwrap_or_default() {
+                    // Modify the config so that the public_address is correct.
+                    // (The public_address is simply ignored for test_agents, as
+                    // it is generated from the agent's name instead of read from
+                    // a physical keyfile)
+                    config.update_agent_address_by_id(agent_id, &agent_address);
+                    self.config = config.clone();
+                    self.save_config()?;
+                }
 
                 context_builder = context_builder.with_agent(agent_address.clone());
 

--- a/conductor_api/src/conductor/base.rs
+++ b/conductor_api/src/conductor/base.rs
@@ -636,7 +636,7 @@ impl Conductor {
             self.p2p_config = Some(self.initialize_p2p_config());
         }
 
-        let config = self.config.clone();
+        let mut config = self.config.clone();
         self.shutdown().map_err(|e| e.to_string())?;
 
         self.start_signal_multiplexer();
@@ -647,14 +647,14 @@ impl Conductor {
             // which will be the case at least for the DPKI instance which got started
             // specifically in `self.dpki_bootstrap()` above.
             if !self.instances.contains_key(&id) {
-                let instance =
-                    self.instantiate_from_config(&id, Some(&config))
-                        .map_err(|error| {
-                            format!(
-                                "Error while trying to create instance \"{}\": {}",
-                                id, error
-                            )
-                        })?;
+                let instance = self
+                    .instantiate_from_config(&id, Some(&mut config))
+                    .map_err(|error| {
+                        format!(
+                            "Error while trying to create instance \"{}\": {}",
+                            id, error
+                        )
+                    })?;
 
                 self.instances
                     .insert(id.clone(), Arc::new(RwLock::new(instance)));
@@ -693,10 +693,10 @@ impl Conductor {
     pub fn instantiate_from_config(
         &mut self,
         id: &String,
-        maybe_config: Option<&Configuration>,
+        maybe_config: Option<&mut Configuration>,
     ) -> Result<Holochain, String> {
-        let self_config = self.config.clone();
-        let config = maybe_config.unwrap_or(&self_config);
+        let mut self_config = self.config.clone();
+        let config = maybe_config.unwrap_or(&mut self_config);
         let _ = config.check_consistency(&mut self.dna_loader)?;
 
         config
@@ -707,10 +707,14 @@ impl Conductor {
                 let mut context_builder = ContextBuilder::new();
 
                 // Agent:
-                let agent_config = config.agent_by_id(&instance_config.agent).unwrap();
-                let agent_id = self.agent_config_to_id(&agent_config)?;
+                let agent_id = &instance_config.agent;
+                let agent_config = config.agent_by_id(agent_id).unwrap();
+                let agent_address = self.agent_config_to_id(&agent_config)?;
+                config.update_agent_address_by_id(agent_id, &agent_address);
+                self.config = config.clone();
+                self.save_config()?;
 
-                context_builder = context_builder.with_agent(agent_id.clone());
+                context_builder = context_builder.with_agent(agent_address.clone());
 
                 context_builder = context_builder.with_p2p_config(self.get_p2p_config());
 

--- a/conductor_api/src/conductor/test_admin.rs
+++ b/conductor_api/src/conductor/test_admin.rs
@@ -36,7 +36,7 @@ impl ConductorTestAdmin for Conductor {
         new_config.check_consistency(&mut self.dna_loader)?;
         self.config = new_config;
         self.add_agent_keystore(id.clone(), keystore);
-        // self.save_config()?; we don't actually want to save it for tests
+        self.save_config()?;
         notify(format!("Added agent \"{}\"", id));
         Ok(public_address)
     }

--- a/conductor_api/src/config.rs
+++ b/conductor_api/src/config.rs
@@ -456,6 +456,15 @@ impl Configuration {
         self.agents.iter().find(|ac| &ac.id == id).cloned()
     }
 
+    /// Returns the agent configuration with the given ID if present
+    pub fn update_agent_address_by_id(&mut self, id: &str, agent_id: &AgentId) {
+        self.agents.iter_mut().for_each(|ac| {
+            if &ac.id == id {
+                ac.public_address = agent_id.pub_sign_key.clone()
+            }
+        })
+    }
+
     /// Returns the DNA configuration with the given ID if present
     pub fn dna_by_id(&self, id: &str) -> Option<DnaConfiguration> {
         self.dnas.iter().find(|dc| &dc.id == id).cloned()


### PR DESCRIPTION
## PR summary

Modify the config so that the public_address is correct. When loading from config, the public_address is simply ignored for test_agents, as it is generated from the agent's name instead of read from a physical keyfile. However, `admin/agent/list` uses the value from the config, which is, in general, wrong. So, this makes the value in the config right so that the admin method can report the right value.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
