### PR TITLE
add one-liner to publish agent entry on startup

### DIFF
--- a/core/src/workflows/application.rs
+++ b/core/src/workflows/application.rs
@@ -24,7 +24,7 @@ pub async fn initialize(
     let dna = dna.ok_or(HolochainError::DnaMissing)?;
     if let Err(err) = await!(get_dna_and_agent(&instance_context)) {
         log_warn!(context,
-            "dna/initialize: Couldn't get DNA and agent from chain: {:?}",
+            "dna/initialize: No DNA and agent in chain so assuming uninitialized: {:?}",
             err
         );
         log_info!(context, "dna/initialize: Initializing new chain from given DNA...");

--- a/core/src/workflows/application.rs
+++ b/core/src/workflows/application.rs
@@ -1,13 +1,17 @@
 use crate::{
     context::{get_dna_and_agent, Context},
     instance::Instance,
-    network::actions::initialize_network::initialize_network,
+    network::actions::{
+        initialize_network::initialize_network,
+        publish::publish,
+    },
     nucleus::actions::{call_init::call_init, initialize::initialize_chain},
 };
 use holochain_core_types::{
     dna::Dna,
     error::{HcResult, HolochainError},
 };
+use holochain_persistence_api::cas::content::AddressableContent;
 
 use std::sync::Arc;
 
@@ -28,5 +32,7 @@ pub async fn initialize(
     }
     await!(initialize_network(&instance_context))?;
     await!(call_init(dna, &instance_context))?;
+    // publish this agents AgentId
+    await!(publish(context.agent_id.address(), &context))?;
     Ok(instance_context)
 }


### PR DESCRIPTION
## PR summary

Adds publishing of agent in the initialization workflow. Hoping this will reduce some of the flaky failures of `base not found` where the base is the agent entry hash.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
