### PR TITLE
add HC_TARGET_PREFIX from holonix and rename

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,12 @@ with holonix.pkgs;
 {
  dev-shell = stdenv.mkDerivation (holonix.shell // {
   name = "dev-shell";
+  shellHook = holonix.pkgs.lib.concatStrings
+    [
+      holonix.shell.shellHook
+      ''export HC_TARGET_PREFIX=~/.holochain-compile-cache/
+      ''
+    ];
 
   buildInputs = [ ]
    ++ holonix.shell.buildInputs


### PR DESCRIPTION
## PR summary

Holonix used to set the directory where HC incremental compilation went to `nix-holochain` that value should really be set in this repo.  Also renamed it to something more reasonable: `.holochain-compile-cache`

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
