### PR TITLE
remove core_types dependency on lib3h_protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,6 @@ dependencies = [
  "holochain_persistence_api 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lib3h_crypto_api 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "lib3h_protocol 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mashup 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/network/reducers/publish_header_entry.rs
+++ b/core/src/network/reducers/publish_header_entry.rs
@@ -5,7 +5,7 @@ use crate::{
         actions::ActionResponse,
         entry_aspect::EntryAspect,
         entry_with_header::{fetch_entry_with_header, EntryWithHeader},
-        reducers::send,
+        reducers::{publish::entry_data_to_entry_aspect_data, send},
         state::NetworkState,
     },
     state::State,
@@ -35,7 +35,10 @@ fn publish_header(
             provider_agent_id: network_state.agent_id.clone().unwrap().into(),
             entry: EntryData {
                 entry_address: entry.address().clone(),
-                aspect_list: vec![EntryAspect::Content(entry.clone(), header).into()],
+                aspect_list: vec![entry_data_to_entry_aspect_data(&EntryAspect::Content(
+                    entry.clone(),
+                    header,
+                ))],
             },
         }),
     )

--- a/core/src/network/reducers/respond_fetch.rs
+++ b/core/src/network/reducers/respond_fetch.rs
@@ -1,7 +1,10 @@
 use crate::{
     action::ActionWrapper,
     network::{
-        actions::ActionResponse, entry_aspect::EntryAspect, reducers::send, state::NetworkState,
+        actions::ActionResponse,
+        entry_aspect::EntryAspect,
+        reducers::{publish::entry_data_to_entry_aspect_data, send},
+        state::NetworkState,
     },
     state::State,
 };
@@ -28,8 +31,10 @@ fn reduce_respond_fetch_data_inner(
             provider_agent_id: network_state.agent_id.clone().unwrap().into(),
             entry: EntryData {
                 entry_address: fetch_data.entry_address.clone(),
-                aspect_list: aspects.iter().map(|a| a.to_owned().into()).collect(),
-
+                aspect_list: aspects
+                    .iter()
+                    .map(|a| entry_data_to_entry_aspect_data(a))
+                    .collect(),
             },
         }),
     )

--- a/core_types/Cargo.toml
+++ b/core_types/Cargo.toml
@@ -41,7 +41,6 @@ regex = "=1.1.2"
 shrinkwraprs = "=0.2.1"
 crossbeam-channel = "=0.3.8"
 lib3h_crypto_api = "=0.0.16"
-lib3h_protocol = "=0.0.16"
 parking_lot ="=0.9.0"
 log = "=0.4.8"
 holochain_logging = { version="=0.0.1", path = "../logging" }

--- a/core_types/src/lib.rs
+++ b/core_types/src/lib.rs
@@ -34,7 +34,6 @@ extern crate maplit;
 // #[macro_use]
 // extern crate shrinkwraprs;
 extern crate hcid;
-extern crate lib3h_protocol;
 extern crate parking_lot;
 extern crate wasmi;
 pub mod chain_header;

--- a/core_types/src/network/entry_aspect.rs
+++ b/core_types/src/network/entry_aspect.rs
@@ -1,8 +1,6 @@
 use crate::{chain_header::ChainHeader, entry::Entry, link::link_data::LinkData};
-use chrono::{offset::FixedOffset, DateTime};
 use holochain_json_api::{error::JsonError, json::JsonString};
 use holochain_persistence_api::cas::content::{Address, AddressableContent, Content};
-use lib3h_protocol::data_types::EntryAspectData;
 use std::{
     convert::{Into, TryFrom},
     fmt,
@@ -95,21 +93,6 @@ impl EntryAspect {
     }
 }
 
-impl Into<EntryAspectData> for EntryAspect {
-    fn into(self) -> EntryAspectData {
-        let type_hint = self.type_hint();
-        let aspect_address = self.address();
-        let ts: DateTime<FixedOffset> = self.header().timestamp().into();
-        let aspect_json: JsonString = self.into();
-        EntryAspectData {
-            type_hint,
-            aspect_address,
-            aspect: aspect_json.to_bytes().into(),
-            publish_ts: ts.timestamp() as u64,
-        }
-    }
-}
-
 fn format_header(header: &ChainHeader) -> String {
     format!(
         "Header[type: {}, crud_link: {:?}]",
@@ -157,25 +140,5 @@ impl fmt::Debug for EntryAspect {
                 write!(f, "EntryAspect::Deletion({})", format_header(header))
             }
         }
-    }
-}
-
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-    use crate::chain_header::test_chain_header;
-    use chrono::{offset::FixedOffset, DateTime};
-
-    #[test]
-    fn can_convert_into_entry_aspect_data() {
-        let chain_header = test_chain_header();
-        let aspect = EntryAspect::Header(chain_header.clone());
-        let aspect_data: EntryAspectData = aspect.clone().into();
-        let aspect_json: JsonString = aspect.clone().into();
-        let ts: DateTime<FixedOffset> = chain_header.timestamp().into();
-        assert_eq!(aspect_data.type_hint, aspect.type_hint());
-        assert_eq!(aspect_data.aspect_address, aspect.address());
-        assert_eq!(*aspect_data.aspect, aspect_json.to_bytes());
-        assert_eq!(aspect_data.publish_ts, ts.timestamp() as u64);
     }
 }


### PR DESCRIPTION
## PR summary

core types was depending on lib3h_protocol so it could implement an into for EntryData -> EntryAspectData

This PR removes this dependency by simply creating an old-fashion converter function.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
