### PR TITLE
Can annotate lock guards so when they go immortal, we get some context

### DIFF
--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -151,7 +151,10 @@ impl ConductorApiBuilder {
             .ok_or_else(|| jsonrpc_core::Error::invalid_params("unknown instance"))?;
         let hc_lock = instance.clone();
         let hc_lock_inner = hc_lock.clone();
-        let hc = hc_lock_inner.read().unwrap();
+        let hc = hc_lock_inner
+            .read()
+            .unwrap()
+            .annotate(format!("RPC method_call: {:?}", params_map));
 
         let cap_request = {
             let context = hc.context()


### PR DESCRIPTION
## PR summary

Add `.annotate()` to the result of any `lock()`, `.read()` or `.write()`, so that if that guard goes immortal, we get the annotation in the immortal guard lock output. 

Hoping this will help give us visibility into the remaining deadlock we see only in manual testing, during zome calls. I added an annotation onto the immortal read guard, including the params of the zome call.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development
