### PR TITLE
[WIP] add a clean option to the admin/instance/remove method

### DIFF
--- a/crates/conductor_lib/src/conductor/admin.rs
+++ b/crates/conductor_lib/src/conductor/admin.rs
@@ -40,7 +40,7 @@ pub trait ConductorAdmin {
         dna_id: &String,
         agent_id: &String,
     ) -> Result<(), HolochainError>;
-    fn remove_instance(&mut self, id: &String) -> Result<(), HolochainError>;
+    fn remove_instance(&mut self, id: &String, clean: bool) -> Result<(), HolochainError>;
     fn add_interface(&mut self, new_instance: InterfaceConfiguration)
         -> Result<(), HolochainError>;
     fn remove_interface(&mut self, id: &String) -> Result<(), HolochainError>;
@@ -244,6 +244,9 @@ impl ConductorAdmin for Conductor {
         }
         if let Some(instance) = self.instances.remove(id) {
             instance.write().unwrap().kill();
+            if clean == true {
+                remove_dir_all(instance.storage.path)?;
+            }
         }
         let _ = self.start_signal_multiplexer();
 
@@ -1185,14 +1188,62 @@ id = 'new-instance'"#,
 
     #[test]
     /// Tests if the removed instance is gone from the config file
-    /// as well as the mentions of the removed instance are gone from the interfaces
+    /// as well as the mentions of the removed instance are gone from the interfaces.
     /// (to not render the config invalid).
-    fn test_remove_instance() {
+    fn test_remove_instance_clean_false() {
         let test_name = "test_remove_instance";
         let mut conductor = create_test_conductor(test_name, 3002);
 
         assert_eq!(
-            conductor.remove_instance(&String::from("test-instance-1")),
+            conductor.remove_instance(&String::from("test-instance-1"), false),
+            Ok(()),
+        );
+
+        let mut config_contents = String::new();
+        let mut file =
+            File::open(&conductor.config_path()).expect("Could not open temp config file");
+        file.read_to_string(&mut config_contents)
+            .expect("Could not read temp config file");
+
+        let mut toml = header_block(test_name);
+
+        toml = add_block(toml, agent1());
+        toml = add_block(toml, agent2());
+        toml = add_block(toml, dna());
+        //toml = add_block(toml, instance1());
+        toml = add_block(toml, instance2());
+        toml = add_block(
+            toml,
+            String::from(
+                r#"[[interfaces]]
+admin = true
+id = 'websocket interface'
+[[interfaces.instances]]
+id = 'test-instance-2'
+[interfaces.driver]
+port = 3002
+type = 'websocket'"#,
+            ),
+        );
+        toml = add_block(toml, logger());
+        toml = add_block(toml, passphrase_service());
+        toml = add_block(toml, signals());
+        toml = format!("{}\n", toml);
+
+        assert_eq!(config_contents, toml,);
+    }
+
+    #[test]
+    /// Tests if the removed instance is gone from the config file
+    /// as well as the mentions of the removed instance are gone from the interfaces
+    /// (to not render the config invalid). If the clean arg is true, tests that the storage of
+    /// the instance has been cleared,
+    fn test_remove_instance_clean_true() {
+        let test_name = "test_remove_instance";
+        let mut conductor = create_test_conductor(test_name, 3002);
+
+        assert_eq!(
+            conductor.remove_instance(&String::from("test-instance-1"), true),
             Ok(()),
         );
 

--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -66,7 +66,7 @@ macro_rules! conductor_call {
                 // with conductor_api::conductor::mount_conductor_from_config(config: Configuration).
                 // There are cases in which we don't want to treat the conductor as a singleton such as
                 // holochain_nodejs and tests in particular. In those cases, calling admin functions via
-                // interfaces (websockt/http) won't work, but also we don't need that.
+                // interfaces (websocket/http) won't work, but also we don't need that.
                 let mut error = jsonrpc_core::Error::internal_error();
                 error.message = String::from(
                     "Admin conductor function called without a conductor mounted as singleton!",
@@ -526,7 +526,8 @@ impl ConductorApiBuilder {
         self.io.add_method("admin/instance/remove", move |params| {
             let params_map = Self::unwrap_params_map(params)?;
             let id = Self::get_as_string("id", &params_map)?;
-            conductor_call!(|c| c.remove_instance(&id))?;
+            let clean = Self::get_as_bool("clean", &params_map)?;
+            conductor_call!(|c| c.remove_instance(&id), clean)?;
             Ok(json!({"success": true}))
         });
 


### PR DESCRIPTION
## PR summary

Work on #1303, going with the first option to add a clean option to the "admin/instance/remove" method, and if this option is true, remove the instance's storage. These changes are adapted to the latest reorg, as compared to #1047 

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )
Adds a test `test_remove_instance_clean_true`, which currently is failing due to 89 errors (E0432, E0599, E0658) from futures-io-preview.

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
