### PR TITLE
Have conductor send user signals also to admin interfaces

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+* Custom signals that are emitted from DNA/zome code ("user" signals) are now send to all admin interfaces to enable UI switching logic in Holoscape [#1799](https://github.com/holochain/holochain-rust/pull/1799)
+
 ### Deprecated
 
 ### Removed

--- a/crates/conductor_lib/src/conductor/base.rs
+++ b/crates/conductor_lib/src/conductor/base.rs
@@ -313,10 +313,13 @@ impl Conductor {
                                             .interfaces
                                             .iter()
                                             .filter(|interface_config| {
-                                                interface_config
+                                                let contains_instance = interface_config
                                                     .instances
                                                     .iter()
-                                                    .any(|instance| instance.id == *instance_id)
+                                                    .any(|instance| instance.id == *instance_id);
+                                                let is_admin = interface_config.admin;
+
+                                                contains_instance || is_admin
                                             })
                                             .collect();
                                         println!("INTERFACEs for SIGNAL: {:?}", interfaces);


### PR DESCRIPTION
## PR summary

User signals, i.e. signals emitted by DNA code instead of internal signals, were only send to interfaces that include the according instance.

This change will also send all of those signals to admin interfaces.

That is needed in Holoscape to handle UI window activation and switching from zome code. Holoscape will then use its admin interface to listen for specific signals to automatically show/raise the window of a certain UI.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
