### PR TITLE
Retain Timeout across ZomeApiError/HolochainError conversion

### DIFF
--- a/crates/hdk/src/error.rs
+++ b/crates/hdk/src/error.rs
@@ -23,6 +23,7 @@ impl From<ZomeApiError> for HolochainError {
     fn from(zome_api_error: ZomeApiError) -> Self {
         match zome_api_error {
             ZomeApiError::ValidationFailed(s) => HolochainError::ValidationFailed(s),
+            ZomeApiError::Timeout => HolochainError::Timeout,
             _ => HolochainError::RibosomeFailed(zome_api_error.to_string()),
         }
     }


### PR DESCRIPTION
o It is probably important to retain certain errors across the
  conversion boundary between ZomeApiError and HolochainError,
  if possible.

If Zome validation functions use hdk:: APIs (eg. to look up headers, entries etc. from the DHT), there are certain failures that should cause the DHT Validator to pause and retry, instead of "failing" the validation.  One of these is a HolochainError::Timeout.  Provision appears to have been made in both HolochainError::Timeout and ZomeApiError::Timeout to retain this information, but one of the From<...> Trait implementations was missing this conversion.

## PR summary

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
