### PR TITLE
hc hash --property

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 *  Allows the HC CLI to generate zomes from template repos. This will by default use the default holochain template repos (holochain/rust-zome-template and holochain/rust-proc-zome-template) but can also point to custom templates in remote repos or locally (e.g. `hc generate zomes/my_zome https://github.com/org/some-custom-zome-template`). [#1565](https://github.com/holochain/holochain-rust/pull/1565)
-
+* Adds option `--property` to `hc hash` that sets DNA properties for hash calculation. [#1807](https://github.com/holochain/holochain-rust/pull/1807)
 ### Changed
 
 ### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,8 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_common 0.0.34-alpha1",
  "holochain_conductor_lib 0.0.34-alpha1",
  "holochain_core 0.0.34-alpha1",
@@ -947,7 +949,7 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2720,6 +2722,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,6 +3663,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "structopt"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "structopt-derive"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,6 +3680,18 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4852,6 +4885,7 @@ dependencies = [
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 "checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+"checksum proc-macro-error 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aeccfe4d5d8ea175d5f0e4a2ad0637e0f4121d63bd99d356fb1f39ab2e7c6097"
 "checksum proc-macro-hack 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "463bf29e7f11344e58c9e01f171470ab15c925c6822ad75028cc1c0e1d1eb63b"
 "checksum proc-macro-hack-impl 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "38c47dcb1594802de8c02f3b899e2018c78291168a22c281be21ea0fb4796842"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
@@ -4944,7 +4978,9 @@ dependencies = [
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
+"checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+"checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
 "checksum syn 0.15.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b4cfac95805274c6afdb12d8f770fa2d27c045953e7b630a81801953699a9a"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ holochain_json_api = "=0.0.17"
 holochain_persistence_api = "=0.0.10"
 holochain_persistence_file = "=0.0.10"
 holochain_wasm_utils = { path = "../wasm_utils" }
-structopt = "=0.2.15"
+structopt = "=0.3.3"
 failure = "=0.1.5"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"

--- a/crates/cli/src/cli/hash_dna.rs
+++ b/crates/cli/src/cli/hash_dna.rs
@@ -2,10 +2,13 @@ use error::DefaultResult;
 use failure::err_msg;
 use holochain_conductor_lib::conductor::Conductor;
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
-use std::path::PathBuf;
 use serde_json::Map;
+use std::path::PathBuf;
 
-pub fn hash_dna(dna_file_path: &PathBuf, properties: Option<Vec<String>>) -> DefaultResult<Address> {
+pub fn hash_dna(
+    dna_file_path: &PathBuf,
+    properties: Option<Vec<String>>,
+) -> DefaultResult<Address> {
     let mut dna = Conductor::load_dna(dna_file_path)?;
     let mut map = if let serde_json::Value::Object(map) = dna.properties {
         map.clone()
@@ -13,12 +16,17 @@ pub fn hash_dna(dna_file_path: &PathBuf, properties: Option<Vec<String>>) -> Def
         Map::new()
     };
 
-
     if let Some(properties) = properties {
         for property_string in properties {
-            let mut parts = property_string.split("=").map(String::from).collect::<Vec<String>>();
+            let mut parts = property_string
+                .split("=")
+                .map(String::from)
+                .collect::<Vec<String>>();
             if parts.len() != 2 {
-                return Err(err_msg(format!("Can't parse property: {}", property_string)))
+                return Err(err_msg(format!(
+                    "Can't parse property: {}",
+                    property_string
+                )));
             }
             let value = parts.pop().unwrap();
             let name = parts.pop().unwrap();

--- a/crates/cli/src/cli/hash_dna.rs
+++ b/crates/cli/src/cli/hash_dna.rs
@@ -19,7 +19,7 @@ pub fn hash_dna(
     if let Some(properties) = properties {
         for property_string in properties {
             let mut parts = property_string
-                .split("=")
+                .split('=')
                 .map(String::from)
                 .collect::<Vec<String>>();
             if parts.len() != 2 {

--- a/crates/cli/src/cli/hash_dna.rs
+++ b/crates/cli/src/cli/hash_dna.rs
@@ -1,9 +1,31 @@
 use error::DefaultResult;
+use failure::err_msg;
 use holochain_conductor_lib::conductor::Conductor;
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
 use std::path::PathBuf;
+use serde_json::Map;
 
-pub fn hash_dna(dna_file_path: &PathBuf) -> DefaultResult<Address> {
-    let dna = Conductor::load_dna(dna_file_path)?;
+pub fn hash_dna(dna_file_path: &PathBuf, properties: Option<Vec<String>>) -> DefaultResult<Address> {
+    let mut dna = Conductor::load_dna(dna_file_path)?;
+    let mut map = if let serde_json::Value::Object(map) = dna.properties {
+        map.clone()
+    } else {
+        Map::new()
+    };
+
+
+    if let Some(properties) = properties {
+        for property_string in properties {
+            let mut parts = property_string.split("=").map(String::from).collect::<Vec<String>>();
+            if parts.len() != 2 {
+                return Err(err_msg(format!("Can't parse property: {}", property_string)))
+            }
+            let value = parts.pop().unwrap();
+            let name = parts.pop().unwrap();
+            map.insert(name, serde_json::Value::String(value));
+        }
+    }
+
+    dna.properties = serde_json::Value::Object(map);
     Ok(dna.address())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -192,6 +192,12 @@ enum Cli {
             help = "Path to .dna.json file [default: dist/<dna-name>.dna.json]"
         )]
         path: Option<PathBuf>,
+        #[structopt(
+            long,
+            short = "x",
+            help = "Property (in the from 'name=value') that gets set/overwritten before calculating hash"
+        )]
+        property: Option<Vec<String>>,
     },
 }
 
@@ -313,11 +319,11 @@ fn run() -> HolochainResult<()> {
                     .map_err(|e| HolochainError::Default(format_err!("{}", e)))?;
             }
         },
-        Cli::HashDna { path } => {
+        Cli::HashDna { path, property } => {
             let dna_path = path
                 .unwrap_or(util::std_package_path(&project_path).map_err(HolochainError::Default)?);
 
-            let dna_hash = cli::hash_dna(&dna_path)
+            let dna_hash = cli::hash_dna(&dna_path, property)
                 .map_err(|e| HolochainError::Default(format_err!("{}", e)))?;
             println!("DNA Hash: {}", dna_hash);
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -195,7 +195,7 @@ enum Cli {
         #[structopt(
             long,
             short = "x",
-            help = "Property (in the from 'name=value') that gets set/overwritten before calculating hash"
+            help = "Property (in the form 'name=value') that gets set/overwritten before calculating hash"
         )]
         property: Option<Vec<String>>,
     },


### PR DESCRIPTION
## PR summary

Add option "property" to hc hash that sets DNA properties for hash calculation.

```
USAGE:
    hc hash [OPTIONS]

OPTIONS:
    -p, --path <path>               Path to .dna.json file [default: dist/<dna-name>.dna.json]
    -x, --property <property>...    Property (in the from 'name=value') that gets set/overwritten before calculating
                                    hash
```
Like so:

```
[nix-shell:~]$ hc hash --path identity-manager.dna.json --property agent_id=HcSc82gf923hd
Reading DNA from QmZUhssczL8RdBUjKLrtFyV9co2BCHubmJTdj4oeMaUYki.dna.json
DNA Hash: QmWPhCUU3Gib9kTHs2gtiD1VFnwrvqX1zcKFf1WNNnD6mk
```
## followups

Use this in Holoscape to be able to detect installed instances even if they were installed with specific/unique properties (such as identity manager).

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [x] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
