### PR TITLE
Add stdout to signal interfaces have started

### DIFF
--- a/crates/holochain/src/main.rs
+++ b/crates/holochain/src/main.rs
@@ -81,6 +81,9 @@ fn main() {
                     .expect("Could not start instances!");
                 println!("Starting interfaces...");
                 conductor.start_all_interfaces();
+                // NB: the following println is very important!
+                // Others are using it as an easy way to know that the interfaces have started.
+                // Leave it as is!
                 println!("Done. All interfaces started.");
                 println!("Starting UI servers");
                 conductor

--- a/crates/holochain/src/main.rs
+++ b/crates/holochain/src/main.rs
@@ -81,7 +81,7 @@ fn main() {
                     .expect("Could not start instances!");
                 println!("Starting interfaces...");
                 conductor.start_all_interfaces();
-                println!("Done.");
+                println!("Done. All interfaces started.");
                 println!("Starting UI servers");
                 conductor
                     .start_all_static_servers()


### PR DESCRIPTION
## PR summary

Try-o-rama uses a particular line of stdout to signal that the interfaces are ready to connect to. However, that line comes right *before* the interfaces actually start. It still works for websockets because we have robust clients that retry connections, but might not work well for domain sockets. So this adds a println *after* the interfaces have started.

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
