### PR TITLE
Fix hdk_proc_macros

### DIFF
--- a/crates/cli/src/cli/scaffold/rust-proc-macro/Cargo.template.toml
+++ b/crates/cli/src/cli/scaffold/rust-proc-macro/Cargo.template.toml
@@ -9,7 +9,7 @@ serde = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 serde_derive = "=1.0.89"
 hdk = <<VERSION>>
-hdk-proc-macros = <<VERSION>>
+hdk_proc_macros = <<VERSION>>
 holochain_wasm_utils = <<VERSION>>
 holochain_json_derive = "=0.0.17"
 


### PR DESCRIPTION


## PR summary
Has - instead of _ which is wrong for crates.io.
Changed `hdk-proc-macros` to `hdk_proc_macros`
## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [ ] this is not a code change, or doesn't effect anyone outside holochain core development

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
