### PR TITLE
PR Template: Refactor mutually exclusive checkboxes into a single one

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,11 @@
 
 ## changelog
 
-Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)
+- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 
 
-- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
-- [ ] this is not a code change, or doesn't effect anyone outside holochain core development
+```markdown
+- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
+```
 
 ## documentation
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 ## changelog
 
-- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 
+- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 
 
 ```markdown
 - summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)


### PR DESCRIPTION
## PR summary

### Motivation

Presently, when viewing the PR list on this repo, I see a lot of what GitHub interprets as incomplete subtasks:

[![Screenshot of GitHub pull request tracker][img]][img]

(Notice how it shows "2 of 3")

[img]: https://i.imgur.com/nrm9fDo.png

However, upon further investigation, there are no incomplete tasks. Rather, there are two mutually exclusive tasks in the template, only one of them needing to be checked for a given PR.

### Solution

Combine the two tasks into one: "If applicable, the changelog has been updated"

## testing/benchmarking notes

This template is being tested because this PR uses it.

## followups

None.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
