### PR TITLE
fix hc-test

### DIFF
--- a/crates/hdk/src/meta.rs
+++ b/crates/hdk/src/meta.rs
@@ -348,14 +348,12 @@ pub extern "C" fn __hdk_get_json_definition(
 
 #[cfg(test)]
 pub mod tests {
-    use crate::prelude::*;
-    use crate::ValidationPackageDefinition;
+    use crate::{meta::PartialZome, prelude::*, ValidationPackageDefinition};
     use holochain_core_types::dna::{
         entry_types::Sharing,
         zome::{ZomeFnDeclarations, ZomeTraits},
     };
     use holochain_json_api::{error::JsonError, json::JsonString};
-    use crate::meta::PartialZome;
     use std::collections::BTreeMap;
 
     // Adding empty zome_setup() so that the cfg(test) build can link.

--- a/crates/sim1h/src/dht/bbdht/dynamodb/api/table/exist.rs
+++ b/crates/sim1h/src/dht/bbdht/dynamodb/api/table/exist.rs
@@ -16,9 +16,7 @@ pub fn table_exists(
     let table_description_result = describe_table(log_context, client, table_name);
     match table_description_result {
         Ok(table_description) => Ok(match table_description.table_status {
-            Some(status) => {
-                status == "ACTIVE"
-            }
+            Some(status) => status == "ACTIVE",
             _ => false,
         }),
         Err(err) => match err {

--- a/crates/sim1h/src/workflow/to_client_response/handle_query_entry_result.rs
+++ b/crates/sim1h/src/workflow/to_client_response/handle_query_entry_result.rs
@@ -2,9 +2,7 @@ use crate::{
     trace::{tracer, LogContext},
     workflow::state::Sim1hState,
 };
-use lib3h_protocol::{
-    data_types::QueryEntryResultData, protocol::ClientToLib3hResponse,
-};
+use lib3h_protocol::{data_types::QueryEntryResultData, protocol::ClientToLib3hResponse};
 
 impl Sim1hState {
     /// Response to a `HandleQueryEntry` request
@@ -23,9 +21,7 @@ impl Sim1hState {
         // request is yourself, ultimately. Query requests are intercepted, they trigger Holds
         // on entry aspects, which triggers a HandleQuery request, which ultimately triggers
         // this mirroring you're seeing here.
-        if data.space_address == self.space_hash
-            && data.requester_agent_id == self.agent_id
-        {
+        if data.space_address == self.space_hash && data.requester_agent_id == self.agent_id {
             self.client_response_outbox
                 .push(ClientToLib3hResponse::QueryEntryResult(data.clone()))
         }

--- a/rust/test/default.nix
+++ b/rust/test/default.nix
@@ -4,7 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-  hc-rust-wasm-compile && HC_SIMPLE_LOGGER_MUTE=1 RUST_BACKTRACE=1 cargo test --all --target-dir "$HC_TARGET_PREFIX"target "$1" -- --test-threads=${holonix.rust.test.threads};
+  hc-rust-wasm-compile && HC_SIMPLE_LOGGER_MUTE=1 RUST_BACKTRACE=1 cargo test --all --exclude sim1h --target-dir "$HC_TARGET_PREFIX"target "$1" -- --test-threads=${holonix.rust.test.threads};
   '';
 in
 {

--- a/rust/wasm/compile/default.nix
+++ b/rust/wasm/compile/default.nix
@@ -14,7 +14,7 @@ let
  ''
  set -euxo pipefail
  export WASM_PATH=${path}/
- cargo build --release --target wasm32-unknown-unknown --manifest-path "$WASM_PATH"Cargo.toml --target-dir "$HC_TARGET_PREFIX"/"$WASM_PATH"target;
+ cargo build --release --target wasm32-unknown-unknown --manifest-path "$WASM_PATH"Cargo.toml --target-dir "''${HC_TARGET_PREFIX:-.}"/"$WASM_PATH"target;
  '';
 
  script = pkgs.writeShellScriptBin name

--- a/test/default.nix
+++ b/test/default.nix
@@ -8,7 +8,6 @@ let
   hc-test-fmt
   hn-rust-clippy
   hc-rust-test
-  hc-app-spec-test
   '';
 in
 {

--- a/test/fmt/default.nix
+++ b/test/fmt/default.nix
@@ -11,6 +11,7 @@ let
  script = pkgs.writeShellScriptBin name
  ''
  echo "checking rust formatting";
+ local __fmtexit=0
  for p in \
   cli \
   common \
@@ -29,8 +30,9 @@ let
   wasm_utils
  do
   echo "checking ''${p}"
-  ( cd "crates/$p" && cargo fmt -- --check )
+  if ! ( cd "crates/$p" && cargo fmt -- --check ); then echo "BAA"; __fmtexit=1; fi
  done
+ exit ''${__fmtexit}
  '';
 in
 {

--- a/test/fmt/default.nix
+++ b/test/fmt/default.nix
@@ -30,7 +30,7 @@ let
   wasm_utils
  do
   echo "checking ''${p}"
-  if ! ( cd "crates/$p" && cargo fmt -- --check ); then echo "BAA"; __fmtexit=1; fi
+  if ! ( cd "crates/$p" && cargo fmt -- --check ); then __fmtexit=1; fi
  done
  exit ''${__fmtexit}
  '';


### PR DESCRIPTION
## PR summary

- fixes `hc-test-fmt` - it was failing to return an error code on format diff (also ran `cargo fmt`)
- `hc-rust-test` was running sim1h tests which don't work without dynamo - added `--exclude sim1h`
- `hc-rust-wasm-compile` was breaking due to unset HC_TARGET_PREFIX environment variable
- removed call to `hc-app-spec-test` which no longer exists

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

Please check one of the following, relating to the [CHANGELOG-UNRELEASED.md](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md)

- [ ] this is a code change that effects some consumer (e.g. zome developers) of holochain core so it is added to the CHANGELOG-UNRELEASED.md (linked above), with the format `- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)`
- [x] this is not a code change, or doesn't effect anyone outside holochain core development

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
