### PR TITLE
Override sim2h_url with DNA property

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 *  Allows the HC CLI to generate zomes from template repos. This will by default use the default holochain template repos (holochain/rust-zome-template and holochain/rust-proc-zome-template) but can also point to custom templates in remote repos or locally (e.g. `hc generate zomes/my_zome https://github.com/org/some-custom-zome-template`). [#1565](https://github.com/holochain/holochain-rust/pull/1565)
 * Adds option `--property` to `hc hash` that sets DNA properties for hash calculation. [#1807](https://github.com/holochain/holochain-rust/pull/1807)
 * Adds a prelude module to the HDK. Adding the statement `use hdk::prelude::*` should be enough for 90% of zome development [#1816](https://github.com/holochain/holochain-rust/pull/1816)
-
+* Adds a special DNA property sim2h_url that, if set, overrides the conductor wide setting for the network configuration variable sim2h_url. [PR#1828](https://github.com/holochain/holochain-rust/pull/1828)
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -18,5 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+* Fixes handling if DNA properties during `hc package`. DNA properties mentioned in the DNA's JSON manifest are now included in the package. [PR#1828](https://github.com/holochain/holochain-rust/pull/1828)  
+
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "holochain_persistence_file 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_wasm_utils 0.0.35-alpha7",
  "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json-patch 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lib3h_sodium 0.0.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ git2 = "=0.9.1"
 tera = "=0.11.20"
 glob = "=0.3.0"
 rustyline = "=5.0.0"
+json-patch = "=0.2.2"
 
 [dev-dependencies]
 tempfile = "=3.0.7"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,7 @@ extern crate holochain_json_api;
 extern crate holochain_locksmith;
 extern crate holochain_persistence_api;
 extern crate holochain_persistence_file;
+extern crate json_patch;
 extern crate lib3h_sodium;
 extern crate structopt;
 #[macro_use]

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -98,7 +98,7 @@ pub mod test {
         persister::SimplePersister,
         state::{test_store, StateWrapper},
     };
-    use holochain_core_types::agent::AgentId;
+    use holochain_core_types::{agent::AgentId, dna::Dna};
     use holochain_locksmith::RwLock;
     use holochain_net::{connection::net_connection::NetHandler, p2p_config::P2pConfig};
     use holochain_persistence_api::cas::content::{Address, AddressableContent};
@@ -146,7 +146,9 @@ pub mod test {
         let action_wrapper = ActionWrapper::new(Action::InitNetwork(network_settings));
 
         let mut network_state = NetworkState::new();
-        let root_state = test_store(context.clone());
+        let mut root_state = test_store(context.clone());
+        root_state = root_state.reduce(ActionWrapper::new(Action::InitializeChain(Dna::new())));
+
         let result = reduce_init(&mut network_state, &root_state, &action_wrapper);
 
         assert_eq!(result, ());

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -3,16 +3,56 @@ use crate::{
     network::state::NetworkState,
     state::State,
 };
-use holochain_net::{connection::net_connection::NetSend, p2p_network::P2pNetwork};
+use holochain_net::{
+    connection::net_connection::NetSend, p2p_config::BackendConfig, p2p_network::P2pNetwork,
+};
+use holochain_persistence_api::cas::content::AddressableContent;
 use lib3h_protocol::{data_types::SpaceData, protocol_client::Lib3hClientProtocol, Address};
-use log::error;
+use log::{debug, error, info};
 
 pub fn reduce_init(state: &mut NetworkState, root_state: &State, action_wrapper: &ActionWrapper) {
     let action = action_wrapper.action();
     let network_settings = unwrap_to!(action => Action::InitNetwork);
+    let handler = network_settings.handler.clone();
+    let mut p2p_config = network_settings.p2p_config.clone();
+
+    // Handle magic DNA property sim2h_url:
+    // If our DNA sets a property with name "sim2h_url" and if this instance is configured
+    // to use sim2h networking, override the conductor wide sim2h_url setting from the
+    // conductor config with the DNA property's value.
+
+    // Get the property from the DNA:
+    let nucleus = root_state.nucleus();
+    let dna = nucleus
+        .dna
+        .as_ref()
+        .expect("No DNA found when initializing network!");
+    let maybe_sim2h_url_override = dna
+        .properties
+        .as_object()
+        .and_then(|props| props.get("sim2h_url"))
+        .and_then(|sim2h_url_value| sim2h_url_value.as_str())
+        .map(|sim2h_url_str| sim2h_url_str.to_string());
+
+    // If we found a "sim2h_url" property...
+    if let Some(sim2h_url) = maybe_sim2h_url_override {
+        // ..and we're configured to use sim2h...
+        if let BackendConfig::Sim2h(sim2h_config) = &mut p2p_config.backend_config {
+            info!(
+                "Found property 'sim2h_url' in DNA {} - overriding conductor wide sim2h URL with: {}",
+                dna.address(),
+                sim2h_url,
+            );
+            // ..override the conductor wide setting.
+            sim2h_config.sim2h_url = sim2h_url;
+        } else {
+            debug!("DNA has 'sim2h_url' override property set, but it's ignored as we are not running a sim2h network backend");
+        }
+    }
+
     let mut network = P2pNetwork::new(
-        network_settings.handler.clone(),
-        network_settings.p2p_config.clone(),
+        handler,
+        p2p_config,
         Some(Address::from(network_settings.agent_id.clone())),
         Some(root_state.conductor_api.clone()),
     )

--- a/crates/core/src/network/reducers/send_direct_message.rs
+++ b/crates/core/src/network/reducers/send_direct_message.rs
@@ -79,7 +79,7 @@ mod tests {
         },
         state::test_store,
     };
-    use holochain_core_types::error::HolochainError;
+    use holochain_core_types::{dna::Dna, error::HolochainError};
     use holochain_persistence_api::cas::content::Address;
 
     #[test]
@@ -87,6 +87,7 @@ mod tests {
         let netname = Some("reduce_send_direct_message_timeout_test");
         let context = test_context("alice", netname);
         let mut store = test_store(context.clone());
+        store = store.reduce(ActionWrapper::new(Action::InitializeChain(Dna::new())));
 
         let dna_address: Address = "reduce_send_direct_message_timeout_test".into();
         let handler = create_handler(&context, dna_address.to_string());


### PR DESCRIPTION
## PR summary

This adds a special DNA property `sim2h_url` that, if set, overrides the conductor wide setting for the network configuration variable `sim2h_url`.

This enables using different sim2h servers for different DNAs, all running in the same conductor.

Example of setting the DNA property:
```json
{
  "name": "My Example DNA",
  "description": "This DNA shows how to override the conductor wide sim2h URL by DNA",
  "version": "0.1",
  "uuid": "00000000-0000-0000-0000-000000000000",
  "dna_spec_version": "2.0",
  "properties": {
      "sim2h_url": "wss://sim2h.my-example-server.cominvald:9000"
  }
}
```

## Fixed handling of properties

`hc package` was not including DNA properties mentioned in JSON manifest files as shown in the example above. Instead it was overwriting properties with extra properties that could be added during packaging step.

This PR includes a fix that merges both sources.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
