### PR TITLE
Revert CAS default back to PickleDB

### DIFF
--- a/crates/conductor_lib/src/conductor/admin.rs
+++ b/crates/conductor_lib/src/conductor/admin.rs
@@ -201,14 +201,13 @@ impl ConductorAdmin for Conductor {
             id: id.to_string(),
             dna: dna_id.to_string(),
             agent: agent_id.to_string(),
-            storage: StorageConfiguration::Lmdb {
+            storage: StorageConfiguration::Pickle {
                 path: storage_path
                     .to_str()
                     .ok_or_else(|| {
                         HolochainError::ConfigError(format!("invalid path {:?}", storage_path))
                     })?
                     .into(),
-                initial_mmap_bytes: None,
             },
         };
         new_config.instances.push(new_instance_config);

--- a/crates/conductor_lib/src/conductor/admin.rs
+++ b/crates/conductor_lib/src/conductor/admin.rs
@@ -1170,7 +1170,7 @@ id = 'new-instance'"#,
         toml = add_block(
             toml,
             format!(
-                "[instances.storage]\npath = '{}'\ntype = 'lmdb'",
+                "[instances.storage]\npath = '{}'\ntype = 'pickle'",
                 storage_path_string
             ),
         );
@@ -1462,7 +1462,7 @@ id = 'new-instance-2'"#,
         toml = add_block(
             toml,
             format!(
-                "[instances.storage]\npath = '{}'\ntype = 'lmdb'",
+                "[instances.storage]\npath = '{}'\ntype = 'pickle'",
                 storage_path_string
             ),
         );


### PR DESCRIPTION
## PR summary

We encountered some size/limits issues with our LMDB CAS implementation. Reverting back default to PickleDB for now.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
