### PR TITLE
Add lighter version of can_clone_instance from 35919a0

### DIFF
--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -662,6 +662,17 @@ pub mod tests {
         dna.uuid = "2297b5bc-ef75-4702-8e15-66e0545f3482".into();
         test_instance(dna, None).expect("Blank instance could not be initialized!")
     }
+    
+    #[test]
+    pub fn can_clone_instance() {
+        let instance = test_instance_blank();
+        {
+            let instance2 = instance.clone();
+        }
+        // wait for the action thread to receive kill signal, if applicable
+        std::thread::sleep(Duration::from_secs(2));
+        instance.action_channel().send(ActionWrapper::new(Action::Ping)).unwrap();
+    }
 
     #[test]
     /// This tests calling `process_action`

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -667,7 +667,7 @@ pub mod tests {
     pub fn can_clone_instance() {
         let instance = test_instance_blank();
         {
-            let instance2 = instance.clone();
+            let _instance2 = instance.clone();
         }
         // wait for the action thread to receive kill signal, if applicable
         std::thread::sleep(Duration::from_secs(2));


### PR DESCRIPTION
## PR summary

I just want to test as per https://github.com/holochain/holochain-rust/pull/1782. Edit: I can get `cargo build` to run without freezing my laptop, so don't need to do this.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog
N/A
- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
