### PR TITLE
Fix loading

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -14,5 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+* Loading of instances from storage was broken and ended up in partially loaded states. This got fixed with [#1836](https://github.com/holochain/holochain-rust/pull/1836).
+
 ### Security
 

--- a/crates/conductor_lib/src/holochain.rs
+++ b/crates/conductor_lib/src/holochain.rs
@@ -392,7 +392,6 @@ mod tests {
         let temp_filestorage_dir = temp.path().to_str().unwrap();
         let agent = registered_test_agent("persister");
         let (signal_tx, _signal_rx) = signal_channel();
-        //let logger = test_logger();
         let mut dna = create_arbitrary_test_dna();
         dna.name = "TestApp".to_string();
 

--- a/crates/conductor_lib/src/holochain.rs
+++ b/crates/conductor_lib/src/holochain.rs
@@ -431,6 +431,9 @@ mod tests {
         );
 
         let result = Holochain::load(context_load.clone());
+        if let Err(e) = result {
+            panic!("Error during Holochain::load: {:?}", e);
+        }
         assert!(result.is_ok());
         let hc = result.unwrap();
         let instance = hc.instance.as_ref().unwrap();
@@ -442,7 +445,7 @@ mod tests {
         assert_eq!(network_state.agent_id.is_some(), true);
         assert_eq!(network_state.dna_address.is_some(), true);
     }
-    
+
     #[test]
     fn fails_instantiate_if_init_fails() {
         let dna = create_test_dna_with_wat(

--- a/crates/conductor_lib/src/holochain.rs
+++ b/crates/conductor_lib/src/holochain.rs
@@ -387,31 +387,62 @@ mod tests {
     }
 
     #[test]
-    // TODO: This test is not really testing if loading works. But we need a test for that.
-    // Persistence relies completely on the CAS, so the path would need to be used by
-    // creating a FileStorage CAS in the context that is passed to Holochain::load:
+    fn can_persistant_and_load() {
+        let temp = tempdir().unwrap();
+        let temp_filestorage_dir = temp.path().to_str().unwrap();
+        let agent = registered_test_agent("persister");
+        let (signal_tx, _signal_rx) = signal_channel();
+        //let logger = test_logger();
+        let mut dna = create_arbitrary_test_dna();
+        dna.name = "TestApp".to_string();
 
-    //use std::{fs::File, io::prelude::*};
-    #[cfg(feature = "broken-tests")]
-    fn can_load() {
-        let tempdir = tempdir().unwrap();
-        let tempfile = tempdir.path().join("Agentstate.txt");
-        let mut file = File::create(&tempfile).unwrap();
-        file.write_all(b"{\"top_chain_header\":{\"entry_type\":\"AgentId\",\"entry_address\":\"Qma6RfzvZRL127UCEVEktPhQ7YSS1inxEFw7SjEsfMJcrq\",\"sources\":[\"sandwich--------------------------------------------------------------------------AAAEqzh28L\"],\"entry_signatures\":[\"fake-signature\"],\"link\":null,\"link_same_type\":null,\"timestamp\":\"2018-10-11T03:23:38+00:00\"}}").unwrap();
-        //let path = tempdir.path().to_str().unwrap().to_string();
+        {
+            let context_new = Arc::new(
+                ContextBuilder::new()
+                    .with_agent(agent.clone())
+                    .with_signals(signal_tx.clone())
+                    .with_conductor_api(mock_conductor_api(agent.clone()))
+                    .with_file_storage(temp_filestorage_dir)
+                    .unwrap()
+                    .spawn(),
+            );
 
-        let (context, _, _) = test_context("bob");
-        let result = Holochain::load(context.clone());
+            let result = Holochain::new(dna.clone(), context_new.clone());
+            assert!(result.is_ok());
+            let hc = result.unwrap();
+            let instance = hc.instance.as_ref().unwrap();
+            let context = hc.context.as_ref().unwrap().clone();
+            assert_eq!(instance.state().nucleus().dna(), Some(dna.clone()));
+            assert!(!hc.active);
+            assert_eq!(context.agent_id.nick, "persister".to_string());
+            let network_state = context.state().unwrap().network().clone();
+            assert_eq!(network_state.agent_id.is_some(), true);
+            assert_eq!(network_state.dna_address.is_some(), true);
+        }
+
+        let context_load = Arc::new(
+            ContextBuilder::new()
+                .with_agent(agent.clone())
+                .with_signals(signal_tx)
+                .with_conductor_api(mock_conductor_api(agent.clone()))
+                .with_file_storage(temp_filestorage_dir)
+                .unwrap()
+                .spawn(),
+        );
+
+        let result = Holochain::load(context_load.clone());
         assert!(result.is_ok());
-        let loaded_holo = result.unwrap();
-        assert!(!loaded_holo.active);
-        assert_eq!(loaded_holo.context.agent_id.nick, "bob".to_string());
-        let network_state = loaded_holo.context.state().unwrap().network().clone();
-        assert!(network_state.agent_id.is_some());
-        assert!(network_state.dna_address.is_some());
-        assert!(loaded_holo.instance.state().nucleus().has_initialized());
+        let hc = result.unwrap();
+        let instance = hc.instance.as_ref().unwrap();
+        let context = hc.context.as_ref().unwrap().clone();
+        assert_eq!(instance.state().nucleus().dna(), Some(dna));
+        assert!(!hc.active);
+        assert_eq!(context.agent_id.nick, "persister".to_string());
+        let network_state = context.state().unwrap().network().clone();
+        assert_eq!(network_state.agent_id.is_some(), true);
+        assert_eq!(network_state.dna_address.is_some(), true);
     }
-
+    
     #[test]
     fn fails_instantiate_if_init_fails() {
         let dna = create_test_dna_with_wat(

--- a/crates/core/src/workflows/application.rs
+++ b/crates/core/src/workflows/application.rs
@@ -8,7 +8,6 @@ use holochain_core_types::{
     dna::Dna,
     error::{HcResult, HolochainError},
 };
-use log::error;
 use std::sync::Arc;
 
 pub async fn initialize(

--- a/crates/core/src/workflows/application.rs
+++ b/crates/core/src/workflows/application.rs
@@ -37,7 +37,10 @@ pub async fn initialize(
         // No DNA provided as parameter.
         // This is the loading-case - we assume to find a DNA in the Nucleus state:
         context.get_dna().ok_or_else(|| {
-            log_error!(context, "No DNA provided during loading and none found in state");
+            log_error!(
+                context,
+                "No DNA provided during loading and none found in state"
+            );
             HolochainError::DnaMissing
         })?
     };

--- a/crates/core/src/workflows/application.rs
+++ b/crates/core/src/workflows/application.rs
@@ -18,9 +18,24 @@ pub async fn initialize(
 ) -> HcResult<Arc<Context>> {
     let instance_context = instance.initialize_context(context.clone());
 
+    // This function is called in two different cases:
+    // 1. Initializing a brand new instance
+    // 2. Loading a persistent instance from storage
+    //
+    // In the first case, we definitely need maybe_dna to be Some, because that is the DNA
+    // that will seed this instance's Nucleus.
+    // If maybe_dna is None, we expect to find a DNA in the Nucleus (=in the state) already.
     let dna = if let Some(dna) = maybe_dna {
+        // Ok, since maybe_dna is set, we are assuming to seed a new instance.
+        // To make sure that we are not running into a weird state, we are going
+        // to check here if we really deal with a fresh state and no DNA in the Nucleus already:
+        if context.get_dna().is_some() {
+            panic!("Tried to initialize instance that already has a DNA in its Nucleus");
+        }
         dna
     } else {
+        // No DNA provided as parameter.
+        // This is the loading-case - we assume to find a DNA in the Nucleus state:
         context.get_dna().ok_or_else(|| {
             error!("No DNA provided during loading and none found in state");
             HolochainError::DnaMissing

--- a/crates/core/src/workflows/application.rs
+++ b/crates/core/src/workflows/application.rs
@@ -8,15 +8,24 @@ use holochain_core_types::{
     dna::Dna,
     error::{HcResult, HolochainError},
 };
+use log::error;
 use std::sync::Arc;
 
 pub async fn initialize(
     instance: &Instance,
-    dna: Option<Dna>,
+    maybe_dna: Option<Dna>,
     context: Arc<Context>,
 ) -> HcResult<Arc<Context>> {
     let instance_context = instance.initialize_context(context.clone());
-    let dna = dna.ok_or(HolochainError::DnaMissing)?;
+
+    let dna = if let Some(dna) = maybe_dna {
+        dna
+    } else {
+        context.get_dna().ok_or_else(|| {
+            error!("No DNA provided during loading and none found in state");
+            HolochainError::DnaMissing
+        })?
+    };
 
     // 2. Initialize the local chain if not already
     let first_initialization = match get_dna_and_agent(&instance_context).await {

--- a/crates/core/src/workflows/application.rs
+++ b/crates/core/src/workflows/application.rs
@@ -37,7 +37,7 @@ pub async fn initialize(
         // No DNA provided as parameter.
         // This is the loading-case - we assume to find a DNA in the Nucleus state:
         context.get_dna().ok_or_else(|| {
-            error!("No DNA provided during loading and none found in state");
+            log_error!(context, "No DNA provided during loading and none found in state");
             HolochainError::DnaMissing
         })?
     };


### PR DESCRIPTION
## PR summary

Loading of instances was broken.

Two reasons why we didn't notice this right away:
1. The test for this was not really testing loading and got deactivated. Which then allowed a change to happen that broken the loading code in every case.
2. The conductor always first tries to load from the given storage. If that fails, it creates a new instance. This second branch obviously doesn't erase everything in the CAS and was ending up with a partially loaded state. Source chain was loaded correctly. Agent keys are stored in the keystore anyway. So we only missed some things, especially the holding list.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
