### PR TITLE
Increase telephone-game test timeout to 2 seconds to fix flaky sim1h

### DIFF
--- a/stress-test/src/telephone-games.ts
+++ b/stress-test/src/telephone-games.ts
@@ -27,7 +27,7 @@ const configBatchSimple = (numConductors, numInstances) => {
 // * postSpawn: after the next agent was spawned, this callback is called with the older one to have it create new
 //              entries/links while the new agent is there
 // * stepCheck:
-const telephoneGame = async (s, t, N, players, functions, timeout = 1000) => {
+const telephoneGame = async (s, t, N, players, functions, timeout = 2000) => {
     const STEP_TIMEOUT_MS = timeout
     let {init, preSpawn, postSpawn, stepCheck} = functions
     console.log("##################################")


### PR DESCRIPTION
## PR summary

We are seeing the stress tests fail non-deterministic for sim1h. This might fix it.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
