### PR TITLE
Don't filter out locksmith logs! And make them a little quieter

### DIFF
--- a/crates/locksmith/src/sync.rs
+++ b/crates/locksmith/src/sync.rs
@@ -18,10 +18,10 @@ const IMMORTAL_TIMEOUT_SECS: u64 = 60;
 const LOCK_TIMEOUT_SECS: u64 = 100;
 
 // This is how often we check the elapsed time of guards
-const GUARD_WATCHER_POLL_INTERVAL_MS: u64 = 1000;
+const GUARD_WATCHER_POLL_INTERVAL_MS: u64 = 5000;
 
 // We filter out any guards alive less than this long
-const ACTIVE_GUARD_MIN_ELAPSED_MS: i64 = 500;
+const ACTIVE_GUARD_MIN_ELAPSED_MS: i64 = GUARD_WATCHER_POLL_INTERVAL_MS as i64;
 
 // How often to retry getting a lock after receiving a WouldBlock error
 // during try_lock

--- a/stress-test/src/index.ts
+++ b/stress-test/src/index.ts
@@ -65,10 +65,6 @@ const orchestrator = new Orchestrator({
           },
           {
             exclude: true,
-            pattern: '.*::sync.*'
-          },
-          {
-            exclude: true,
             pattern: '.*rpc.*'
           }
         ]


### PR DESCRIPTION
## PR summary

An exclusion rule snuck into our LogRules and has been there for a while which filters out logs from our locksmith mutex watcher. This includes the IMMORTAL lock guard notice. This PR removes that filter, and makes the locksmith logs a little less noisy, only reporting on active locks every 5 seconds rather than every 500 ms.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
