### PR TITLE
add commands to nix and call from CLI to generate and test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,17 @@ jobs:
       name: test cli
       command: nix-shell --run hc-cli-test
 
+ cli-generate-tests:
+   docker:
+     - image: holochain/holochain-rust:latest
+   steps:
+     - run:
+         name: test hc generate rust template
+         command: nix-shell --run hc-cli-generate-rust-test
+     - run:
+         name: test hc generate rust proc template
+         command: nix-shell --run hc-cli-generate-rust-proc-test
+
  wasm-conductor-tests:
   docker:
    - image: holochain/holochain-rust:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,21 +194,15 @@ jobs:
    - image: holochain/holochain-rust:latest
   steps:
    - checkout
-
    - run:
       name: test cli
       command: nix-shell --run hc-cli-test
-
- cli-generate-tests:
-   docker:
-     - image: holochain/holochain-rust:latest
-   steps:
-     - run:
-         name: test hc generate rust template
-         command: nix-shell --run hc-cli-generate-rust-test
-     - run:
-         name: test hc generate rust proc template
-         command: nix-shell --run hc-cli-generate-rust-proc-test
+   - run:
+      name: test hc generate rust template
+      command: nix-shell --run hc-cli-generate-rust-test
+   - run:
+      name: test hc generate rust proc template
+      command: nix-shell --run hc-cli-generate-rust-proc-test
 
  wasm-conductor-tests:
   docker:

--- a/crates/cli/test/default.nix
+++ b/crates/cli/test/default.nix
@@ -1,14 +1,33 @@
 { pkgs }:
 let
 
-  name = "hc-cli-test";
-
-  script = pkgs.writeShellScriptBin name
+  test_script = pkgs.writeShellScriptBin "hc-cli-test"
   ''
   ( cd crates/cli && cargo test )
   bats crates/cli/test/hc.bats
   '';
+
+  test_gen_rust_script = pkgs.writeShellScriptBin "hc-cli-generate-rust-test"
+  ''
+  	hc init /tmp/test_gen_rust
+	cd /tmp/test_gen_rust
+	hc generate zomes/my_zome rust
+	hc test
+  '';
+
+  test_gen_rust_proc_script = pkgs.writeShellScriptBin "hc-cli-generate-rust-proc-test"
+  ''
+  	hc init /tmp/test_gen_rust_proc
+	cd /tmp/test_gen_rust_proc
+	hc generate zomes/my_zome rust-proc
+	hc test
+  '';
 in
+
 {
- buildInputs = [ script ];
+ buildInputs = [ 
+ 	test_script
+ 	test_gen_rust_script
+ 	test_gen_rust_proc_script
+ ];
 }


### PR DESCRIPTION
## PR summary

There have been random things breaking the `hc generate` command. This adds some nix commands and CI jobs to ensure that `hc generate` produces a valid zome that will pass tests.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
