### PR TITLE
disable sim1h stress tests on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,8 @@ workflows:
    - cluster-tests
    - cli-tests
    - wasm-conductor-tests
-   - stress-tests-sim1h
+   # @todo this was flakey
+   # - stress-tests-sim1h
    - stress-tests-sim2h
 
  cold.ubuntu:


### PR DESCRIPTION
## PR summary

because we're stress testing a local dev db which is a jar never designed to scale

this would be more meaningful if pointed at a real dynamodb table

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
