### PR TITLE
add network boot retry logic

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Adds a retry if a net worker cannot be spawned on startup [#1870](https://github.com/holochain/holochain-rust/pull/1870)
+
 ### Changed
 
 ### Deprecated

--- a/crates/net/src/connection/net_connection_thread.rs
+++ b/crates/net/src/connection/net_connection_thread.rs
@@ -20,7 +20,6 @@ const TICK_SLEEP_MIN_US: u64 = 100;
 const TICK_SLEEP_MAX_US: u64 = 10_000;
 const TICK_SLEEP_STARTUP_RETRY_MS: u64 = 3_000;
 
-
 /// Struct for holding a network connection running on a separate thread.
 /// It is itself a NetSend, and spawns a NetWorker.
 #[derive(Clone)]
@@ -62,10 +61,15 @@ impl NetConnectionThread {
                 // Try to create a worker. Keep retrying if unsuccessful
                 let mut worker = loop {
                     match worker_factory(handler.clone()) {
-                        Ok(worker) => { break worker; }
+                        Ok(worker) => {
+                            break worker;
+                        }
                         Err(e) => {
                             debug!("Error occured in p2p network module, on startup: {:?}", e);
-                            debug!("Waiting {} milliseconds to retry", TICK_SLEEP_STARTUP_RETRY_MS);
+                            debug!(
+                                "Waiting {} milliseconds to retry",
+                                TICK_SLEEP_STARTUP_RETRY_MS
+                            );
                         }
                     }
                     thread::sleep(time::Duration::from_millis(TICK_SLEEP_STARTUP_RETRY_MS));

--- a/crates/net/src/connection/net_connection_thread.rs
+++ b/crates/net/src/connection/net_connection_thread.rs
@@ -18,6 +18,8 @@ use lib3h_protocol::protocol_client::Lib3hClientProtocol;
 
 const TICK_SLEEP_MIN_US: u64 = 100;
 const TICK_SLEEP_MAX_US: u64 = 10_000;
+const TICK_SLEEP_STARTUP_RETRY_MS: u64 = 3_000;
+
 
 /// Struct for holding a network connection running on a separate thread.
 /// It is itself a NetSend, and spawns a NetWorker.
@@ -57,8 +59,17 @@ impl NetConnectionThread {
                 ProcessUniqueId::new().to_string()
             ))
             .spawn(move || {
-                // Create worker
-                let mut worker = worker_factory(handler).expect("able to create worker");
+                // Try to create a worker. Keep retrying if unsuccessful
+                let mut worker = loop {
+                    match worker_factory(handler.clone()) {
+                        Ok(worker) => { break worker; }
+                        Err(e) => {
+                            debug!("Error occured in p2p network module, on startup: {:?}", e);
+                            debug!("Waiting {} milliseconds to retry", TICK_SLEEP_STARTUP_RETRY_MS);
+                        }
+                    }
+                    thread::sleep(time::Duration::from_millis(TICK_SLEEP_STARTUP_RETRY_MS));
+                };
                 // Get endpoint and send it to owner (NetConnectionThread)
                 send_endpoint
                     .send((worker.endpoint(), worker.p2p_endpoint()))


### PR DESCRIPTION
## PR summary

Tiny fix. Instead of panic!-ing when the conductor starts and cannot spawn a worker (because the network is unavailable for example) it will keep retrying every 3 seconds until it works.

## testing/benchmarking notes

Tricky to test but I manually confirmed that the conductor built with the following works as expected

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
