### PR TITLE
fix trycp docker to pull from develop

### DIFF
--- a/crates/trycp_server/docker/Dockerfile.trycp
+++ b/crates/trycp_server/docker/Dockerfile.trycp
@@ -18,7 +18,7 @@ ENV NIX_PATH nixpkgs=https://github.com/NixOs/nixpkgs-channels/tarball/8634c3b61
 ENV HC_TARGET_PREFIX /tmp/holochain
 
 # get latest develop
-ADD https://github.com/holochain/holochain-rust/archive/trycp.tar.gz develop.tar.gz
+ADD https://github.com/holochain/holochain-rust/archive/develop.tar.gz develop.tar.gz
 RUN tar --strip-components=1 -zxvf develop.tar.gz
 # ADD . .
 


### PR DESCRIPTION
## PR summary

Now that the `trycp` branch has been merged into develop the Docker file used to build the trycp image needs to refer to develop!

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
