### PR TITLE
Have sim2h let go of nodes when the connection is lost

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -17,6 +17,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Fix lots of deadlocks by managing threads and encapsulating locks [#1852](https://github.com/holochain/holochain-rust/pull/1852)
-
+- Have sim2h let go of nodes if the connection got lost because of an error [#1877](https://github.com/holochain/holochain-rust/pull/1877)
 ### Security
 

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -367,6 +367,11 @@ impl Sim2h {
                         "Transport error occurred on connection to {}: {:?}",
                         uri, error,
                     );
+                    info!("Dropping connection to {} because of error", uri);
+                    if let Err(e) = self.stream_manager.close(&uri) {
+                        error!("Error closing connection to {}: {:?}", uri, e);
+                    }
+                    self.disconnect(&uri.into());
                 }
             }
         }


### PR DESCRIPTION
## PR summary

Sim2h was not letting go of agents that were long gone, if they were lost because of a connection error. That led to some strange behavior when those agents reconnected again.

This fixes that.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
