### PR TITLE
Explicitly exclude some logs, to prevent ignoring other important output

### DIFF
--- a/crates/conductor_lib/src/logger.rs
+++ b/crates/conductor_lib/src/logger.rs
@@ -25,9 +25,28 @@ impl Default for LogRules {
         let mut rules = LogRules::new();
         // Filtering out all the logs from our dependencies
         rules
-            .add_rule(".*", true, None)
+            .add_rule("^parity", true, None)
             .expect("Invalid logging rule.");
-        // Add back in our own logs
+        rules
+            .add_rule("^mio", true, None)
+            .expect("Invalid logging rule.");
+        rules
+            .add_rule("^tokio", true, None)
+            .expect("Invalid logging rule.");
+        rules
+            .add_rule("^hyper", true, None)
+            .expect("Invalid logging rule.");
+        rules
+            .add_rule("^rusoto_core", true, None)
+            .expect("Invalid logging rule.");
+        rules
+            .add_rule("^want", true, None)
+            .expect("Invalid logging rule.");
+        rules
+            .add_rule("^rpc", true, None)
+            .expect("Invalid logging rule.");
+
+        // Ensure our own logs are included.
         rules
             .add_rule("^holochain", false, None)
             .expect("Invalid logging rule.");


### PR DESCRIPTION
## PR summary

The current default LogRules will exclude hdk::debug output and who knows what else. Let's disable undesirable logs explicitly.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
