### PR TITLE
Use FakeServer for stream_manager to avoid binding to port, for now

### DIFF
--- a/crates/sim2h/src/websocket/streams.rs
+++ b/crates/sim2h/src/websocket/streams.rs
@@ -223,8 +223,9 @@ impl<T: Read + Write + std::fmt::Debug> StreamManager<T> {
 
     fn priv_process_accept(&mut self) -> DidWork {
         match &mut self.acceptor {
-            Err(err) => {
-                warn!("acceptor in error state: {:?}", err);
+            Err(_err) => {
+                // TODO: turn back on
+                // warn!("acceptor in error state: {:?}", err);
                 false
             }
             Ok(acceptor) => (acceptor)()


### PR DESCRIPTION
## PR summary

I heard that Sim2hWorker is binding to a port that it never uses. This switches the stream manager to not do that. The reason is that the port binding is random and interferes with the conductor interface port which must be chosen explicitly and passed as config. The worker port gets bound before the interface port does, so there is a chance of collisions, and we see this often in CI tests.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
