### PR TITLE
Add ability to set storage backend from RPC methods

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Adds a retry if a net worker cannot be spawned on startup [#1870](https://github.com/holochain/holochain-rust/pull/1870)
 - Add hdk::version_hash, returning MD5 hash of HDK build environment [#1869](https://github.com/holochain/holochain-rust/pull/1869)
+- Ability to set storage backend for new instances over RPC [#1900](https://github.com/holochain/holochain-rust/pull/1900)
 
 ### Changed
 

--- a/crates/conductor_lib/src/conductor/admin.rs
+++ b/crates/conductor_lib/src/conductor/admin.rs
@@ -197,35 +197,32 @@ impl ConductorAdmin for Conductor {
         storage: Option<&str>,
     ) -> Result<(), HolochainError> {
         let mut new_config = self.config.clone();
-        let storage_path = self.instance_storage_dir_path().join(id.clone()).to_str()
+        let storage_path = self
+            .instance_storage_dir_path()
+            .join(id.clone())
+            .to_str()
             .ok_or_else(|| {
-                HolochainError::ConfigError(
-                    format!("invalid path {:?}", self.instance_storage_dir_path().join(id.clone()))
-                )
+                HolochainError::ConfigError(format!(
+                    "invalid path {:?}",
+                    self.instance_storage_dir_path().join(id.clone())
+                ))
             })?
             .into();
 
         fs::create_dir_all(&storage_path)?;
         let storage_config = match storage {
             Some("memory") => StorageConfiguration::Memory,
-            Some("file") => {
-                StorageConfiguration::File{
-                    path: storage_path
-                }
-            }
-            Some("pickle") => {
-                StorageConfiguration::Pickle {
-                    path: storage_path,
-                }
-            }
-            None | Some("lmdb") => {
-                StorageConfiguration::Lmdb {
-                    path: storage_path,
-                    initial_mmap_bytes: None,
-                } 
-            }
+            Some("file") => StorageConfiguration::File { path: storage_path },
+            Some("pickle") => StorageConfiguration::Pickle { path: storage_path },
+            None | Some("lmdb") => StorageConfiguration::Lmdb {
+                path: storage_path,
+                initial_mmap_bytes: None,
+            },
             Some(s) => {
-                return Err(HolochainError::ConfigError(format!("Invalid storage option: {}", s)))
+                return Err(HolochainError::ConfigError(format!(
+                    "Invalid storage option: {}",
+                    s
+                )))
             }
         };
 

--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -531,7 +531,12 @@ impl ConductorApiBuilder {
             let dna_id = Self::get_as_string("dna_id", &params_map)?;
             let agent_id = Self::get_as_string("agent_id", &params_map)?;
             let storage = Self::get_as_string("storage", &params_map).ok();
-            conductor_call!(|c| c.add_instance(&id, &dna_id, &agent_id, storage.as_ref().map(String::as_str)))?;
+            conductor_call!(|c| c.add_instance(
+                &id,
+                &dna_id,
+                &agent_id,
+                storage.as_ref().map(String::as_str)
+            ))?;
             Ok(json!({"success": true}))
         });
 

--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -530,7 +530,8 @@ impl ConductorApiBuilder {
             let id = Self::get_as_string("id", &params_map)?;
             let dna_id = Self::get_as_string("dna_id", &params_map)?;
             let agent_id = Self::get_as_string("agent_id", &params_map)?;
-            conductor_call!(|c| c.add_instance(&id, &dna_id, &agent_id))?;
+            let storage = Self::get_as_string("storage", &params_map).ok();
+            conductor_call!(|c| c.add_instance(&id, &dna_id, &agent_id, storage.as_ref().map(String::as_str)))?;
             Ok(json!({"success": true}))
         });
 


### PR DESCRIPTION
## PR summary

Adds an optional parameter `storage`to `admin/instance/add` which can be one of 'lmdb', 'pickle', 'memory' or 'file'. This allows the setting of different storage back ends for experimentation in Holoscape.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
