### PR TITLE
M:N Thread Pool for Futures

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Exchanged [vanilla thread-pool](https://docs.rs/threadpool/1.7.1/threadpool/) with the futures executor thread-pool [from the futures crate](https://docs.rs/futures/0.3.1/futures/executor/index.html). This enables M:N Future:Thread execution which is much less wasteful than having a thread per future. Number of threads in the pool is kept at the default (of that crate) of number of CPUs. [#1915](https://github.com/holochain/holochain-rust/pull/1915) 
+
 ### Deprecated
 
 ### Removed

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -48,8 +48,6 @@ use futures::executor::ThreadPool;
 #[cfg(test)]
 use test_utils::mock_signing::mock_conductor_api;
 
-//const NUM_WORKER_THREADS: usize = 20;
-
 pub struct P2pNetworkWrapper(Arc<Mutex<Option<P2pNetwork>>>);
 
 impl P2pNetworkWrapper {

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -44,9 +44,9 @@ use std::{
     time::Duration,
 };
 
+use futures::executor::ThreadPool;
 #[cfg(test)]
 use test_utils::mock_signing::mock_conductor_api;
-use futures::executor::ThreadPool;
 
 //const NUM_WORKER_THREADS: usize = 20;
 
@@ -153,7 +153,9 @@ impl Context {
             )),
             instance_is_alive: Arc::new(AtomicBool::new(true)),
             state_dump_logging,
-            thread_pool: Arc::new(Mutex::new(ThreadPool::new().expect("Could not create thread pool for futures"))),
+            thread_pool: Arc::new(Mutex::new(
+                ThreadPool::new().expect("Could not create thread pool for futures"),
+            )),
             redux_wants_write: Arc::new(AtomicBool::new(false)),
             metric_publisher,
         }
@@ -188,7 +190,9 @@ impl Context {
             conductor_api: ConductorApi::new(Self::test_check_conductor_api(None, agent_id)),
             instance_is_alive: Arc::new(AtomicBool::new(true)),
             state_dump_logging,
-            thread_pool: Arc::new(Mutex::new(ThreadPool::new().expect("Could not create thread pool for futures"))),
+            thread_pool: Arc::new(Mutex::new(
+                ThreadPool::new().expect("Could not create thread pool for futures"),
+            )),
             redux_wants_write: Arc::new(AtomicBool::new(false)),
             metric_publisher,
         })

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -46,9 +46,9 @@ use std::{
 
 #[cfg(test)]
 use test_utils::mock_signing::mock_conductor_api;
-use threadpool::ThreadPool;
+use futures::executor::ThreadPool;
 
-const NUM_WORKER_THREADS: usize = 20;
+//const NUM_WORKER_THREADS: usize = 20;
 
 pub struct P2pNetworkWrapper(Arc<Mutex<Option<P2pNetwork>>>);
 
@@ -153,7 +153,7 @@ impl Context {
             )),
             instance_is_alive: Arc::new(AtomicBool::new(true)),
             state_dump_logging,
-            thread_pool: Arc::new(Mutex::new(ThreadPool::new(NUM_WORKER_THREADS))),
+            thread_pool: Arc::new(Mutex::new(ThreadPool::new().expect("Could not create thread pool for futures"))),
             redux_wants_write: Arc::new(AtomicBool::new(false)),
             metric_publisher,
         }
@@ -188,7 +188,7 @@ impl Context {
             conductor_api: ConductorApi::new(Self::test_check_conductor_api(None, agent_id)),
             instance_is_alive: Arc::new(AtomicBool::new(true)),
             state_dump_logging,
-            thread_pool: Arc::new(Mutex::new(ThreadPool::new(NUM_WORKER_THREADS))),
+            thread_pool: Arc::new(Mutex::new(ThreadPool::new().expect("Could not create thread pool for futures"))),
             redux_wants_write: Arc::new(AtomicBool::new(false)),
             metric_publisher,
         })
@@ -350,14 +350,14 @@ impl Context {
         }
     }
 
-    pub fn spawn_task<F>(&self, f: F)
+    pub fn spawn_task<Fut>(&self, f: Fut)
     where
-        F: FnOnce() + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
     {
         self.thread_pool
             .lock()
             .expect("Couldn't get lock on Context::thread_pool")
-            .execute(f);
+            .run(f);
     }
 
     /// returns the public capability token (if any)

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -38,7 +38,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-//const HOLDING_WORKFLOW_THREADS: usize = 10;
 pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
 pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(500);
 pub const RETRY_VALIDATION_DURATION_MAX: Duration = Duration::from_secs(60 * 60);

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -37,9 +37,8 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use threadpool::ThreadPool;
 
-const HOLDING_WORKFLOW_THREADS: usize = 10;
+//const HOLDING_WORKFLOW_THREADS: usize = 10;
 pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
 pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(500);
 pub const RETRY_VALIDATION_DURATION_MAX: Duration = Duration::from_secs(60 * 60);
@@ -280,7 +279,6 @@ impl Instance {
     fn start_holding_loop(&mut self, context: Arc<Context>) {
         let (kill_sender, kill_receiver) = crossbeam_channel::unbounded();
         self.kill_switch_holding = Some(kill_sender);
-        let threadpool = ThreadPool::new(HOLDING_WORKFLOW_THREADS);
         thread::Builder::new()
             .name(format!(
                 "holding_loop/{}",
@@ -304,10 +302,10 @@ impl Instance {
                                 context.clone(),
                             ));
 
-                            let context = context.clone();
+                            let c = context.clone();
                             let pending = pending.clone();
-                            threadpool.execute(move || {
-                                match run_holding_workflow(pending.clone(), context.clone()) {
+                            let closure = async move || {
+                                match run_holding_workflow(pending.clone(), c.clone()).await {
                                     // If we couldn't run the validation due to unresolved dependencies,
                                     // we have to re-add this entry at the end of the queue:
                                     Err(HolochainError::ValidationPending) => {
@@ -325,23 +323,24 @@ impl Instance {
                                             delay = RETRY_VALIDATION_DURATION_MAX
                                         }
 
-                                        context.block_on(queue_holding_workflow(
+                                        queue_holding_workflow(
                                             Arc::new(pending.same()),
                                             Some(delay),
-                                            context.clone(),
-                                        ))
+                                            c.clone(),
+                                        )
+                                        .await
                                     }
                                     Err(e) => log_error!(
-                                        context,
+                                        c,
                                         "Error running holding workflow for {:?}: {:?}",
                                         pending,
                                         e,
                                     ),
-                                    Ok(()) => {
-                                        log_info!(context, "Successfully processed: {:?}", pending)
-                                    }
+                                    Ok(()) => log_info!(c, "Successfully processed: {:?}", pending),
                                 }
-                            });
+                            };
+                            let future = closure();
+                            context.spawn_task(future);
                         } else {
                             break;
                         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,5 @@
 //! The library implementing the holochain pattern of validation rules + local source chain + DHT
-#![feature(arbitrary_self_types, async_await)]
+#![feature(arbitrary_self_types, async_await, async_closure)]
 #![warn(unused_extern_crates)]
 #[macro_use]
 extern crate serde_derive;

--- a/crates/core/src/network/actions/custom_send.rs
+++ b/crates/core/src/network/actions/custom_send.rs
@@ -62,16 +62,18 @@ impl Future for SendResponseFuture {
         if let Some(err) = self.context.action_channel_error("SendResponseFuture") {
             return Poll::Ready(Err(err));
         }
+
+        //
+        // TODO: connect the waker to state updates for performance reasons
+        // See: https://github.com/holochain/holochain-rust/issues/314
+        //
+        cx.waker().clone().wake();
+
         if let Some(state) = self.context.try_state() {
             let state = state.network();
             if let Err(error) = state.initialized() {
                 return Poll::Ready(Err(HolochainError::ErrorGeneric(error.to_string())));
             }
-            //
-            // TODO: connect the waker to state updates for performance reasons
-            // See: https://github.com/holochain/holochain-rust/issues/314
-            //
-            cx.waker().clone().wake();
             match state.custom_direct_message_replys.get(&self.id) {
                 Some(result) => Poll::Ready(result.clone()),
                 _ => Poll::Pending,

--- a/crates/core/src/network/actions/get_validation_package.rs
+++ b/crates/core/src/network/actions/get_validation_package.rs
@@ -52,16 +52,18 @@ impl Future for GetValidationPackageFuture {
             return Poll::Ready(Err(err));
         }
 
+        //
+        // TODO: connect the waker to state updates for performance reasons
+        // See: https://github.com/holochain/holochain-rust/issues/314
+        //
+        cx.waker().clone().wake();
+
         if let Some(state) = self.context.try_state() {
             let state = state.network();
             if let Err(error) = state.initialized() {
                 return Poll::Ready(Err(error));
             }
-            //
-            // TODO: connect the waker to state updates for performance reasons
-            // See: https://github.com/holochain/holochain-rust/issues/314
-            //
-            cx.waker().clone().wake();
+
             match state.get_validation_package_results.get(&self.address) {
                 Some(Some(result)) => Poll::Ready(result.clone()),
                 _ => Poll::Pending,

--- a/crates/core/src/network/actions/publish.rs
+++ b/crates/core/src/network/actions/publish.rs
@@ -38,16 +38,19 @@ impl Future for PublishFuture {
         if let Some(err) = self.context.action_channel_error("PublishFuture") {
             return Poll::Ready(Err(err));
         }
+
+        //
+        // TODO: connect the waker to state updates for performance reasons
+        // See: https://github.com/holochain/holochain-rust/issues/314
+        //
+        cx.waker().clone().wake();
+
         if let Some(state) = self.context.try_state() {
             let state = state.network();
             if let Err(error) = state.initialized() {
                 return Poll::Ready(Err(error));
             }
-            //
-            // TODO: connect the waker to state updates for performance reasons
-            // See: https://github.com/holochain/holochain-rust/issues/314
-            //
-            cx.waker().clone().wake();
+
             match state.actions().get(&self.action) {
                 Some(ActionResponse::Publish(result)) => match result {
                     Ok(address) => Poll::Ready(Ok(address.to_owned())),

--- a/crates/core/src/network/actions/publish_header_entry.rs
+++ b/crates/core/src/network/actions/publish_header_entry.rs
@@ -38,16 +38,18 @@ impl Future for PublishHeaderEntryFuture {
         {
             return Poll::Ready(Err(err));
         }
+
+        //
+        // TODO: connect the waker to state updates for performance reasons
+        // See: https://github.com/holochain/holochain-rust/issues/314
+        //
+        cx.waker().clone().wake();
+
         if let Some(state) = self.context.try_state() {
             let state = state.network();
             if let Err(error) = state.initialized() {
                 return Poll::Ready(Err(error));
             }
-            //
-            // TODO: connect the waker to state updates for performance reasons
-            // See: https://github.com/holochain/holochain-rust/issues/314
-            //
-            cx.waker().clone().wake();
             match state.actions().get(&self.action) {
                 Some(ActionResponse::PublishHeaderEntry(result)) => match result {
                     Ok(address) => Poll::Ready(Ok(address.to_owned())),

--- a/crates/core/src/network/actions/query.rs
+++ b/crates/core/src/network/actions/query.rs
@@ -98,15 +98,16 @@ impl Future for QueryFuture {
             return Poll::Ready(Err(err));
         }
 
+        //
+        // TODO: connect the waker to state updates for performance reasons
+        // See: https://github.com/holochain/holochain-rust/issues/314
+        //
+        cx.waker().clone().wake();
+
         if let Some(state) = self.context.try_state() {
             if let Err(error) = state.network().initialized() {
                 return Poll::Ready(Err(error));
             }
-            //
-            // TODO: connect the waker to state updates for performance reasons
-            // See: https://github.com/holochain/holochain-rust/issues/314
-            //
-            cx.waker().clone().wake();
             match state.network().get_query_results.get(&self.key) {
                 Some(Some(result)) => Poll::Ready(result.clone()),
                 _ => Poll::Pending,

--- a/crates/core/src/network/actions/shutdown.rs
+++ b/crates/core/src/network/actions/shutdown.rs
@@ -36,15 +36,15 @@ impl Future for ShutdownFuture {
     type Output = HcResult<()>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
+        //
+        // TODO: connect the waker to state updates for performance reasons
+        // See: https://github.com/holochain/holochain-rust/issues/314
+        //
+        cx.waker().clone().wake();
         self.state
             .try_read()
             .map(|state| {
                 if state.network().network.is_some() {
-                    //
-                    // TODO: connect the waker to state updates for performance reasons
-                    // See: https://github.com/holochain/holochain-rust/issues/314
-                    //
-                    cx.waker().clone().wake();
                     Poll::Pending
                 } else {
                     Poll::Ready(Ok(()))

--- a/crates/core/src/network/handler/lists.rs
+++ b/crates/core/src/network/handler/lists.rs
@@ -19,7 +19,8 @@ use std::{
 };
 
 pub fn handle_get_authoring_list(get_list_data: GetListData, context: Arc<Context>) {
-    context.clone().spawn_task(move || {
+    let c = context.clone();
+    let closure = async move || {
         let address_map = create_authoring_map(context.clone());
 
         let action = Action::RespondAuthoringList(EntryListData {
@@ -29,7 +30,10 @@ pub fn handle_get_authoring_list(get_list_data: GetListData, context: Arc<Contex
             address_map: address_map.into(),
         });
         dispatch_action(context.action_channel(), ActionWrapper::new(action));
-    });
+    };
+
+    let future = closure();
+    c.spawn_task(future);
 }
 
 fn create_authoring_map(context: Arc<Context>) -> AspectMap {
@@ -134,7 +138,8 @@ fn get_all_public_chain_entries(context: Arc<Context>) -> Vec<Address> {
 }
 
 pub fn handle_get_gossip_list(get_list_data: GetListData, context: Arc<Context>) {
-    context.clone().spawn_task(move || {
+    let c = context.clone();
+    let closure = async move || {
         let state = context
             .state()
             .expect("No state present when trying to respond with gossip list");
@@ -149,7 +154,9 @@ pub fn handle_get_gossip_list(get_list_data: GetListData, context: Arc<Context>)
             address_map: address_map.into(),
         });
         dispatch_action(context.action_channel(), ActionWrapper::new(action));
-    });
+    };
+    let future = closure();
+    c.spawn_task(future);
 }
 
 #[cfg(test)]

--- a/crates/core/src/network/handler/send.rs
+++ b/crates/core/src/network/handler/send.rs
@@ -45,12 +45,10 @@ pub fn handle_send_message(message_data: DirectMessageData, context: Arc<Context
                     message_data.request_id,
                     custom_direct_message,
                     c.clone(),
-                ).await {
-                    log_error!(
-                        c,
-                        "net: Error handling custom direct message: {:?}",
-                        error
-                    );
+                )
+                .await
+                {
+                    log_error!(c, "net: Error handling custom direct message: {:?}", error);
                 }
             };
             let future = closure();
@@ -61,13 +59,15 @@ pub fn handle_send_message(message_data: DirectMessageData, context: Arc<Context
             // I don't want to wait for this workflow to finish here as it would block the
             // network thread, so I use block_on to poll the async function but do that in
             // another thread:
-            context.clone().spawn_task(respond_validation_package_request(
-                message_data.from_agent_id.into(),
-                message_data.request_id,
-                address,
-                context.clone(),
-                vec![],
-            ));
+            context
+                .clone()
+                .spawn_task(respond_validation_package_request(
+                    message_data.from_agent_id.into(),
+                    message_data.request_id,
+                    address,
+                    context.clone(),
+                    vec![],
+                ));
         }
         DirectMessage::ValidationPackage(_) => {
             log_error!(context,

--- a/crates/core/src/network/handler/send.rs
+++ b/crates/core/src/network/handler/send.rs
@@ -55,19 +55,19 @@ pub fn handle_send_message(message_data: DirectMessageData, context: Arc<Context
             context.clone().spawn_task(future);
         }
         DirectMessage::RequestValidationPackage(address) => {
-            // Async functions only get executed when they are polled.
-            // I don't want to wait for this workflow to finish here as it would block the
-            // network thread, so I use block_on to poll the async function but do that in
-            // another thread:
-            context
-                .clone()
-                .spawn_task(respond_validation_package_request(
-                    message_data.from_agent_id.into(),
-                    message_data.request_id,
-                    address,
-                    context.clone(),
-                    vec![],
-                ));
+            // TODO: run this function with an async block spawned to the pool too, like above.
+            // This currently doesn't work, I believe because this function is not async so
+            // we wouldn't have any await in this async block.
+            // Though I did expect that to work. Maybe this is a pull for actually jumping to
+            // rust 1.39 where async/await is part of stable (currently we are using unstable
+            // feature for this).
+            respond_validation_package_request(
+                message_data.from_agent_id.into(),
+                message_data.request_id,
+                address,
+                context,
+                vec![],
+            );
         }
         DirectMessage::ValidationPackage(_) => {
             log_error!(context,

--- a/crates/core/src/nucleus/actions/build_validation_package.rs
+++ b/crates/core/src/nucleus/actions/build_validation_package.rs
@@ -199,11 +199,8 @@ mod tests {
         // commit entry to build validation package for
         let chain_header = commit(test_entry_package_entry(), &context);
 
-        let maybe_validation_package = build_validation_package(
-            &test_entry_package_entry(),
-            context.clone(),
-            &vec![],
-        );
+        let maybe_validation_package =
+            build_validation_package(&test_entry_package_entry(), context.clone(), &vec![]);
         println!("{:?}", maybe_validation_package);
         assert!(maybe_validation_package.is_ok());
 
@@ -288,11 +285,8 @@ mod tests {
         // commit entry to build validation package for
         let chain_header = commit(test_entry_package_chain_full(), &context);
 
-        let maybe_validation_package = build_validation_package(
-            &test_entry_package_chain_full(),
-            context.clone(),
-            &vec![],
-        );
+        let maybe_validation_package =
+            build_validation_package(&test_entry_package_chain_full(), context.clone(), &vec![]);
         assert!(maybe_validation_package.is_ok());
 
         let headers = all_chain_headers_before_header(&context, &chain_header);

--- a/crates/core/src/nucleus/actions/build_validation_package.rs
+++ b/crates/core/src/nucleus/actions/build_validation_package.rs
@@ -17,7 +17,7 @@ use holochain_core_types::{
 };
 use std::{sync::Arc, vec::Vec};
 
-pub async fn build_validation_package<'a>(
+pub fn build_validation_package<'a>(
     entry: &'a Entry,
     context: Arc<Context>,
     provenances: &'a Vec<Provenance>,
@@ -199,11 +199,11 @@ mod tests {
         // commit entry to build validation package for
         let chain_header = commit(test_entry_package_entry(), &context);
 
-        let maybe_validation_package = context.block_on(build_validation_package(
+        let maybe_validation_package = build_validation_package(
             &test_entry_package_entry(),
             context.clone(),
             &vec![],
-        ));
+        );
         println!("{:?}", maybe_validation_package);
         assert!(maybe_validation_package.is_ok());
 
@@ -228,11 +228,11 @@ mod tests {
         // commit entry to build validation package for
         let chain_header = commit(test_entry_package_chain_entries(), &context);
 
-        let maybe_validation_package = context.block_on(build_validation_package(
+        let maybe_validation_package = build_validation_package(
             &test_entry_package_chain_entries(),
             context.clone(),
             &vec![],
-        ));
+        );
         println!("{:?}", maybe_validation_package);
         assert!(maybe_validation_package.is_ok());
 
@@ -260,11 +260,11 @@ mod tests {
         // commit entry to build validation package for
         let chain_header = commit(test_entry_package_chain_headers(), &context);
 
-        let maybe_validation_package = context.block_on(build_validation_package(
+        let maybe_validation_package = build_validation_package(
             &test_entry_package_chain_headers(),
             context.clone(),
             &vec![],
-        ));
+        );
         assert!(maybe_validation_package.is_ok());
 
         let expected = ValidationPackage {
@@ -288,11 +288,11 @@ mod tests {
         // commit entry to build validation package for
         let chain_header = commit(test_entry_package_chain_full(), &context);
 
-        let maybe_validation_package = context.block_on(build_validation_package(
+        let maybe_validation_package = build_validation_package(
             &test_entry_package_chain_full(),
             context.clone(),
             &vec![],
-        ));
+        );
         assert!(maybe_validation_package.is_ok());
 
         let headers = all_chain_headers_before_header(&context, &chain_header);

--- a/crates/core/src/workflows/author_entry.rs
+++ b/crates/core/src/workflows/author_entry.rs
@@ -45,7 +45,7 @@ pub async fn author_entry<'a>(
     }
 
     // 1. Build the context needed for validation of the entry
-    let validation_package = build_validation_package(&entry, context.clone(), provenances).await?;
+    let validation_package = build_validation_package(&entry, context.clone(), provenances)?;
     let validation_data = ValidationData {
         package: validation_package,
         lifecycle: EntryLifecycle::Chain,

--- a/crates/core/src/workflows/mod.rs
+++ b/crates/core/src/workflows/mod.rs
@@ -80,7 +80,6 @@ async fn try_make_local_validation_package(
                     context.clone(),
                     entry_with_header.header.provenances(),
                 )
-                .await
             } else {
                 Err(HolochainError::ErrorGeneric(String::from(
                     "Can't create validation package locally",

--- a/crates/core/src/workflows/mod.rs
+++ b/crates/core/src/workflows/mod.rs
@@ -110,30 +110,25 @@ async fn validation_package(
 
 /// Runs the given pending validation using the right holding workflow
 /// as specified by PendingValidationStruct::workflow.
-pub fn run_holding_workflow(
+pub async fn run_holding_workflow(
     pending: PendingValidation,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
     match pending.workflow {
-        ValidatingWorkflow::HoldLink => context.block_on(hold_link_workflow(
-            &pending.entry_with_header,
-            context.clone(),
-        )),
-        ValidatingWorkflow::HoldEntry => context.block_on(hold_entry_workflow(
-            &pending.entry_with_header,
-            context.clone(),
-        )),
-        ValidatingWorkflow::RemoveLink => context.block_on(remove_link_workflow(
-            &pending.entry_with_header,
-            context.clone(),
-        )),
-        ValidatingWorkflow::UpdateEntry => context.block_on(hold_update_workflow(
-            &pending.entry_with_header,
-            context.clone(),
-        )),
-        ValidatingWorkflow::RemoveEntry => context.block_on(hold_remove_workflow(
-            &pending.entry_with_header,
-            context.clone(),
-        )),
+        ValidatingWorkflow::HoldLink => {
+            hold_link_workflow(&pending.entry_with_header, context.clone()).await
+        }
+        ValidatingWorkflow::HoldEntry => {
+            hold_entry_workflow(&pending.entry_with_header, context.clone()).await
+        }
+        ValidatingWorkflow::RemoveLink => {
+            remove_link_workflow(&pending.entry_with_header, context.clone()).await
+        }
+        ValidatingWorkflow::UpdateEntry => {
+            hold_update_workflow(&pending.entry_with_header, context.clone()).await
+        }
+        ValidatingWorkflow::RemoveEntry => {
+            hold_remove_workflow(&pending.entry_with_header, context.clone()).await
+        }
     }
 }

--- a/crates/core/src/workflows/respond_validation_package_request.rs
+++ b/crates/core/src/workflows/respond_validation_package_request.rs
@@ -22,7 +22,6 @@ pub async fn respond_validation_package_request(
     let maybe_validation_package =
         match get_entry_from_agent_chain(&context, &requested_entry_address) {
             Ok(Some(entry)) => build_validation_package(&entry, context.clone(), &provenances)
-                .await
                 .ok(),
             _ => None,
         };

--- a/crates/core/src/workflows/respond_validation_package_request.rs
+++ b/crates/core/src/workflows/respond_validation_package_request.rs
@@ -12,7 +12,7 @@ use holochain_core_types::signature::Provenance;
 use holochain_persistence_api::cas::content::Address;
 use std::{sync::Arc, vec::Vec};
 
-pub async fn respond_validation_package_request(
+pub fn respond_validation_package_request(
     to_agent_id: Address,
     msg_id: String,
     requested_entry_address: Address,

--- a/crates/core/src/workflows/respond_validation_package_request.rs
+++ b/crates/core/src/workflows/respond_validation_package_request.rs
@@ -21,8 +21,7 @@ pub fn respond_validation_package_request(
 ) {
     let maybe_validation_package =
         match get_entry_from_agent_chain(&context, &requested_entry_address) {
-            Ok(Some(entry)) => build_validation_package(&entry, context.clone(), &provenances)
-                .ok(),
+            Ok(Some(entry)) => build_validation_package(&entry, context.clone(), &provenances).ok(),
             _ => None,
         };
 

--- a/crates/core/src/workflows/respond_validation_package_request.rs
+++ b/crates/core/src/workflows/respond_validation_package_request.rs
@@ -17,11 +17,11 @@ pub async fn respond_validation_package_request(
     msg_id: String,
     requested_entry_address: Address,
     context: Arc<Context>,
-    provenances: &Vec<Provenance>,
+    provenances: Vec<Provenance>,
 ) {
     let maybe_validation_package =
         match get_entry_from_agent_chain(&context, &requested_entry_address) {
-            Ok(Some(entry)) => build_validation_package(&entry, context.clone(), provenances)
+            Ok(Some(entry)) => build_validation_package(&entry, context.clone(), &provenances)
                 .await
                 .ok(),
             _ => None,

--- a/crates/trycp_server/src/main.rs
+++ b/crates/trycp_server/src/main.rs
@@ -12,6 +12,7 @@ use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
+use regex::Regex;
 use reqwest::{self, Url};
 use serde_json::map::Map;
 use std::{
@@ -23,7 +24,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 use structopt::StructOpt;
-use regex::Regex;
 
 const MAGIC_STRING: &str = "Done. All interfaces started.";
 
@@ -218,9 +218,9 @@ fn get_info_as_json() -> String {
     // poor mans JSON convert
     let re = Regex::new(r"(?P<key>[^:]+):\s+(?P<val>.*)\n").unwrap();
     let result = re.replace_all(&info_str, "\"$key\": \"$val\",");
-    let mut result = format!("{}",result); // pop off the final comma
+    let mut result = format!("{}", result); // pop off the final comma
     result.pop();
-    format!("{{{}}}",result)
+    format!("{{{}}}", result)
 }
 
 fn main() {


### PR DESCRIPTION
## PR summary

Currently, we execute futures mostly in their own threads.
But we do actually have quite some logical dependencies which leads to threads spawning threads just to wait on the children to finish, which can be seen in @freesig's profiling result:

![](https://storage.googleapis.com/holo-hackmd/upload_0d15285f4b1d98adc0455a4a611f2810.png)

Here we (finally) use a standard (!= our `context.block_on()`) future executor namely the [ThreadPool](https://docs.rs/futures/0.3.1/futures/executor/struct.ThreadPool.html) from the futures lib that does [M:N task scheduling](https://docs.rs/futures/0.3.1/futures/executor/index.html#using-a-thread-pool-mn-task-scheduling):
> Most of the time tasks should be executed on a thread pool. A small set of worker threads can handle a very large set of spawned tasks (which are much lighter weight than threads). 

## testing/benchmarking notes

Improves performance. See: https://github.com/holochain/holochain-rust/pull/1921.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
