### PR TITLE
Timeout refactoring

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Replace naive timeout implementation (for network queries / direct messages) that uses a thread per timeout with a scheduled job that polls the State and sends timeout actions when needed (reduces number of used threads and thus memory footprint) [#1916](https://github.com/holochain/holochain-rust/pull/1916).
+
 ### Deprecated
 
 ### Removed

--- a/crates/core/src/action.rs
+++ b/crates/core/src/action.rs
@@ -144,10 +144,11 @@ pub enum Action {
     /// Note that the given address is that of the entry NOT the address of the header itself
     PublishHeaderEntry(Address),
 
-    ///Performs a Network Query Action based on the key and payload, used for links and Entries
-    Query((QueryKey, QueryPayload)),
+    /// Performs a Network Query Action based on the key and payload, used for links and Entries.
+    /// Includes the timeout information: system time of dispatch and duration until it timeouts.
+    Query((QueryKey, QueryPayload, Option<(SystemTime, Duration)>)),
 
-    ///Performs a Query Timeout Action which times out based the values given
+    ///Performs a Query Timeout Action which times out the query given by the key.
     QueryTimeout(QueryKey),
 
     /// Lets the network module respond to a Query request.
@@ -163,7 +164,8 @@ pub enum Action {
 
     /// Makes the network module send a direct (node-to-node) message
     /// to the address given in [DirectMessageData](struct.DirectMessageData.html)
-    SendDirectMessage(DirectMessageData),
+    /// Includes the timeout information: system time of dispatch and duration until it timeouts.
+    SendDirectMessage((DirectMessageData, Option<(SystemTime, Duration)>)),
 
     /// Makes the direct message connection with the given ID timeout by adding an
     /// Err(HolochainError::Timeout) to NetworkState::custom_direct_message_replys.
@@ -314,6 +316,7 @@ pub mod tests {
                 id: String::from("test-id"),
             }),
             QueryPayload::Entry,
+            None,
         ))
     }
 
@@ -335,6 +338,7 @@ pub mod tests {
                 id: snowflake::ProcessUniqueId::new().to_string(),
             }),
             QueryPayload::Entry,
+            None,
         )))
     }
 

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -76,6 +76,9 @@ impl Instance {
         scheduler
             .every(10.seconds())
             .run(scheduled_jobs::create_state_dump_callback(context.clone()));
+        scheduler
+            .every(1.second())
+            .run(scheduled_jobs::create_timeout_callback(context.clone()));
         self.scheduler_handle = Some(Arc::new(scheduler.watch_thread(Duration::from_millis(10))));
 
         self.persister = Some(context.persister.clone());

--- a/crates/core/src/network/reducers/handle_get_result.rs
+++ b/crates/core/src/network/reducers/handle_get_result.rs
@@ -11,4 +11,8 @@ pub fn reduce_handle_get_result(
     network_state
         .get_query_results
         .insert(key.clone(), Some(Ok(payload.clone())));
+
+    network_state
+        .query_timeouts
+        .remove(key);
 }

--- a/crates/core/src/network/reducers/handle_get_result.rs
+++ b/crates/core/src/network/reducers/handle_get_result.rs
@@ -12,7 +12,5 @@ pub fn reduce_handle_get_result(
         .get_query_results
         .insert(key.clone(), Some(Ok(payload.clone())));
 
-    network_state
-        .query_timeouts
-        .remove(key);
+    network_state.query_timeouts.remove(key);
 }

--- a/crates/core/src/network/reducers/resolve_direct_connection.rs
+++ b/crates/core/src/network/reducers/resolve_direct_connection.rs
@@ -9,4 +9,5 @@ pub fn reduce_resolve_direct_connection(
     let id = unwrap_to!(action => crate::action::Action::ResolveDirectConnection);
 
     network_state.direct_message_connections.remove(id);
+    network_state.direct_message_timeouts.remove(id);
 }

--- a/crates/core/src/network/state.rs
+++ b/crates/core/src/network/state.rs
@@ -7,7 +7,10 @@ use holochain_core_types::{error::HolochainError, validation::ValidationPackage}
 use holochain_net::p2p_network::P2pNetwork;
 use holochain_persistence_api::cas::content::Address;
 use snowflake;
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
 
 type Actions = HashMap<ActionWrapper, ActionResponse>;
 
@@ -33,6 +36,7 @@ pub struct NetworkState {
 
     // Here are the results of every get action
     pub get_query_results: HashMap<QueryKey, GetResults>,
+    pub query_timeouts: HashMap<QueryKey, (SystemTime, Duration)>,
 
     /// Here we store the results of get validation package processes.
     /// None means that we are still waiting for a result from the network.
@@ -41,6 +45,7 @@ pub struct NetworkState {
     /// This stores every open (= waiting for response) node-to-node messages.
     /// Entries get removed when we receive an answer through Action::ResolveDirectConnection.
     pub direct_message_connections: HashMap<String, DirectMessage>,
+    pub direct_message_timeouts: HashMap<String, (SystemTime, Duration)>,
 
     pub custom_direct_message_replys: HashMap<String, Result<String, HolochainError>>,
 
@@ -61,8 +66,10 @@ impl NetworkState {
             dna_address: None,
             agent_id: None,
             get_query_results: HashMap::new(),
+            query_timeouts: HashMap::new(),
             get_validation_package_results: HashMap::new(),
             direct_message_connections: HashMap::new(),
+            direct_message_timeouts: HashMap::new(),
             custom_direct_message_replys: HashMap::new(),
 
             id: snowflake::ProcessUniqueId::new(),

--- a/crates/core/src/scheduled_jobs/mod.rs
+++ b/crates/core/src/scheduled_jobs/mod.rs
@@ -1,4 +1,5 @@
 pub mod state_dump;
+mod timeouts;
 
 use crate::context::Context;
 use std::sync::Arc;
@@ -9,5 +10,11 @@ pub fn create_state_dump_callback(context: Arc<Context>) -> impl 'static + FnMut
         if context.state_dump_logging {
             state_dump::state_dump(context.clone());
         }
+    }
+}
+
+pub fn create_timeout_callback(context: Arc<Context>) -> impl 'static + FnMut() + Sync + Send {
+    move || {
+        timeouts::check_network_processes_for_timeouts(context.clone());
     }
 }

--- a/crates/core/src/scheduled_jobs/timeouts.rs
+++ b/crates/core/src/scheduled_jobs/timeouts.rs
@@ -1,0 +1,31 @@
+use crate::{
+    action::{Action, ActionWrapper},
+    context::Context,
+    instance::dispatch_action,
+};
+use std::sync::Arc;
+
+pub fn check_network_processes_for_timeouts(context: Arc<Context>) {
+    let state = context.state().expect("Couldn't get state in timeout job");
+    for (key, (time, duration)) in state.network().query_timeouts.iter() {
+        if let Ok(elapsed) = time.elapsed() {
+            if elapsed > *duration {
+                dispatch_action(
+                    context.action_channel(),
+                    ActionWrapper::new(Action::QueryTimeout(key.clone())),
+                );
+            }
+        }
+    }
+
+    for (key, (time, duration)) in state.network().direct_message_timeouts.iter() {
+        if let Ok(elapsed) = time.elapsed() {
+            if elapsed > *duration {
+                dispatch_action(
+                    context.action_channel(),
+                    ActionWrapper::new(Action::SendDirectMessageTimeout(key.clone())),
+                );
+            }
+        }
+    }
+}

--- a/crates/core/src/scheduled_jobs/timeouts.rs
+++ b/crates/core/src/scheduled_jobs/timeouts.rs
@@ -48,7 +48,9 @@ mod tests {
         let context = test_context("alex", netname);
         let dna = test_utils::create_test_dna_with_wat("test_zome", None);
         let mut instance = Instance::new(context.clone());
-        let context = instance.initialize(Some(dna.clone()), context.clone()).unwrap();
+        let context = instance
+            .initialize(Some(dna.clone()), context.clone())
+            .unwrap();
 
         let custom_direct_message = DirectMessage::Custom(CustomDirectMessage {
             zome: String::from("test"),

--- a/crates/core/src/scheduled_jobs/timeouts.rs
+++ b/crates/core/src/scheduled_jobs/timeouts.rs
@@ -29,3 +29,55 @@ pub fn check_network_processes_for_timeouts(context: Arc<Context>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        action::{Action, ActionWrapper, DirectMessageData},
+        instance::{dispatch_action, tests::test_context, Instance},
+        network::direct_message::{CustomDirectMessage, DirectMessage},
+    };
+    use bitflags::_core::time::Duration;
+    use holochain_core_types::error::HolochainError;
+    use holochain_persistence_api::cas::content::Address;
+    use std::time::SystemTime;
+
+    #[test]
+    pub fn reduce_send_direct_message_timeout_test() {
+        let netname = Some("can_commit_dna");
+        let context = test_context("alex", netname);
+        let dna = test_utils::create_test_dna_with_wat("test_zome", None);
+        let mut instance = Instance::new(context.clone());
+        let context = instance.initialize(Some(dna.clone()), context.clone()).unwrap();
+
+        let custom_direct_message = DirectMessage::Custom(CustomDirectMessage {
+            zome: String::from("test"),
+            payload: Ok(String::from("test")),
+        });
+        let msg_id = String::from("any");
+        let direct_message_data = DirectMessageData {
+            address: Address::from("bogus"),
+            message: custom_direct_message,
+            msg_id: msg_id.clone(),
+            is_response: false,
+        };
+        let action_wrapper = ActionWrapper::new(Action::SendDirectMessage((
+            direct_message_data,
+            Some((SystemTime::now(), Duration::from_millis(500))),
+        )));
+
+        dispatch_action(context.action_channel(), action_wrapper);
+
+        std::thread::sleep(Duration::from_secs(1));
+
+        let maybe_reply = context
+            .state()
+            .unwrap()
+            .network()
+            .custom_direct_message_replys
+            .get(&msg_id.clone())
+            .cloned();
+
+        assert_eq!(maybe_reply, Some(Err(HolochainError::Timeout)));
+    }
+}

--- a/crates/core/src/workflows/handle_custom_direct_message.rs
+++ b/crates/core/src/workflows/handle_custom_direct_message.rs
@@ -50,7 +50,7 @@ pub async fn handle_custom_direct_message(
         is_response: true,
     };
 
-    let action_wrapper = ActionWrapper::new(Action::SendDirectMessage(direct_message_data));
+    let action_wrapper = ActionWrapper::new(Action::SendDirectMessage((direct_message_data, None)));
     dispatch_action(context.action_channel(), action_wrapper);
     Ok(())
 }

--- a/crates/core/src/workflows/respond_validation_package_request.rs
+++ b/crates/core/src/workflows/respond_validation_package_request.rs
@@ -48,6 +48,6 @@ pub async fn respond_validation_package_request(
         is_response: true,
     };
 
-    let action_wrapper = ActionWrapper::new(Action::SendDirectMessage(direct_message_data));
+    let action_wrapper = ActionWrapper::new(Action::SendDirectMessage((direct_message_data, None)));
     dispatch_action(context.action_channel(), action_wrapper);
 }

--- a/crates/trycp_server/src/main.rs
+++ b/crates/trycp_server/src/main.rs
@@ -12,6 +12,7 @@ use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
+use regex::Regex;
 use reqwest::{self, Url};
 use serde_json::map::Map;
 use std::{
@@ -23,7 +24,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 use structopt::StructOpt;
-use regex::Regex;
 
 const MAGIC_STRING: &str = "Done. All interfaces started.";
 
@@ -218,9 +218,9 @@ fn get_info_as_json() -> String {
     // poor mans JSON convert
     let re = Regex::new(r"(?P<key>[^:]+):\s+(?P<val>.*)\n").unwrap();
     let result = re.replace_all(&info_str, "\"$key\": \"$val\",");
-    let mut result = format!("{}",result); // pop off the final comma
+    let mut result = format!("{}", result); // pop off the final comma
     result.pop();
-    format!("{{{}}}",result)
+    format!("{{{}}}", result)
 }
 
 fn main() {


### PR DESCRIPTION
## PR summary

We had a very naive implementation for query and DM timeouts: just spawning a thread, letting it sleep for the timeout and then dispatch an action.

This PR replaces that with a proper timeout handling where queries and direct messages store the time of creation and a duration in the state and a *scheduled job* polls this info every second and dispatches actions if a timeouts get hit.

## testing/benchmarking notes

Improves performance. See: https://github.com/holochain/holochain-rust/pull/1921.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
