### PR TITLE
Use immutable data-structures to make State cloning much cheaper

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Use the [im crate](https://docs.rs/im/14.0.0/im/) for `HashMap`s and `HashSet`s used in the redux State. This makes cloning the state much cheaper and improves over-all performance. [#1923](https://github.com/holochain/holochain-rust/pull/1923)
+
 ### Deprecated
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,14 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitmaps"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1184,7 @@ dependencies = [
  "holochain_persistence_lmdb 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_mem 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_wasm_utils 0.0.39-alpha4",
+ "im 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-lite 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1688,6 +1697,20 @@ dependencies = [
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "im"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitmaps 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sized-chunks 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2933,6 +2956,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rayon"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3599,6 +3630,15 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sim2h 0.0.39-alpha4",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sized-chunks"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitmaps 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4735,6 +4775,7 @@ dependencies = [
 "checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bip39 0.6.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7059804e226b3ac116519a252d7f5fb985a5ccc0e93255e036a5f7e7283323f4"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum bitmaps 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "81e039a80914325b37fde728ef7693c212f0ac913d5599607d7b95a9484aae0b"
 "checksum blake2b_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b83b7baab1e671718d78204225800d6b170e648188ac7dc992e9d6bddf87d0c0"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -4856,6 +4897,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ad03ca67dc12474ecd91fdb94d758cbd20cb4e7a78ebe831df26a9b7511e1162"
+"checksum im 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1f9b6540e530defef7f2df4ed330d45b739b10450548c74a9913f63ea1acc6b"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -4990,6 +5032,7 @@ dependencies = [
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 "checksum rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43739f8831493b276363637423d3622d4bd6394ab6f0a9c4a552e208aeb7fddd"
 "checksum rayon-core 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8bf17de6f23b05473c437eb958b9c850bfc8af0961fe17b4cc92d5a627b4791"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -5049,6 +5092,7 @@ dependencies = [
 "checksum shrinkwraprs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5f047b90b2ca2d1526ff73d67cba61f86f4cf9a8afddc99dd96702ded8e684"
 "checksum signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4f61c4d59f3aaa9f61bba6450a9b80ba48362fd7d651689e7a10c453b1f6dc68"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
+"checksum sized-chunks 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62db64dd92b3b54314b1e216c274634ca2b3fe8da8b3873be670cb1ac4dad30f"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum slug 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bc762e6a4b6c6fcaade73e77f9ebc6991b676f88bb2358bddb56560f073373"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -62,6 +62,7 @@ env_logger = "=0.6.1"
 url = { version = "=2.1.0", features = ["serde"] }
 rand = "0.7.2"
 threadpool = "=1.7.1"
+im = { version = "=14.0.0", features = ["serde"] }
 
 [dev-dependencies]
 wabt = "=0.7.4"

--- a/crates/core/src/agent/state.rs
+++ b/crates/core/src/agent/state.rs
@@ -24,7 +24,8 @@ use holochain_json_api::{
 };
 use holochain_wasm_utils::api_serialization::crypto::CryptoMethod;
 use serde_json;
-use std::{collections::HashMap, convert::TryFrom, sync::Arc, time::SystemTime};
+use std::{convert::TryFrom, sync::Arc, time::SystemTime};
+use im::HashMap;
 
 /// The state-slice for the Agent.
 /// Holds the agent's source chain and keys.
@@ -315,7 +316,7 @@ pub mod tests {
     use holochain_json_api::json::JsonString;
     use holochain_persistence_api::cas::content::AddressableContent;
     use serde_json;
-    use std::collections::HashMap;
+    use im::HashMap;
     use test_utils::mock_signing::mock_signer;
 
     /// dummy agent state

--- a/crates/core/src/agent/state.rs
+++ b/crates/core/src/agent/state.rs
@@ -23,9 +23,9 @@ use holochain_json_api::{
     json::JsonString,
 };
 use holochain_wasm_utils::api_serialization::crypto::CryptoMethod;
+use im::HashMap;
 use serde_json;
 use std::{convert::TryFrom, sync::Arc, time::SystemTime};
-use im::HashMap;
 
 /// The state-slice for the Agent.
 /// Holds the agent's source chain and keys.
@@ -315,8 +315,8 @@ pub mod tests {
     };
     use holochain_json_api::json::JsonString;
     use holochain_persistence_api::cas::content::AddressableContent;
-    use serde_json;
     use im::HashMap;
+    use serde_json;
     use test_utils::mock_signing::mock_signer;
 
     /// dummy agent state

--- a/crates/core/src/dht/aspect_map.rs
+++ b/crates/core/src/dht/aspect_map.rs
@@ -1,8 +1,8 @@
 use crate::holochain_wasm_utils::holochain_persistence_api::cas::content::AddressableContent;
 use holochain_core_types::network::entry_aspect::EntryAspect;
+use im::{HashMap, HashSet};
 use lib3h_protocol::types::{AspectHash, EntryHash};
 use std::collections::HashMap as StdHashMap;
-use im::{HashMap, HashSet};
 pub type AspectSet = HashSet<AspectHash>;
 
 pub type AspectMapBare = HashMap<EntryHash, AspectSet>;
@@ -144,8 +144,8 @@ impl From<&HashSet<(EntryHash, AspectHash)>> for AspectMap {
 #[cfg(test)]
 mod tests {
 
-    use im::hashset;
     use super::*;
+    use im::hashset;
     use sim1h::aspect::fixture::content_aspect_fresh;
 
     #[test]

--- a/crates/core/src/network/handler/lists.rs
+++ b/crates/core/src/network/handler/lists.rs
@@ -9,12 +9,12 @@ use crate::{
 };
 use holochain_core_types::entry::Entry;
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
+use im::HashSet;
 use lib3h_protocol::{
     data_types::{EntryListData, GetListData},
     types::{AspectHash, EntryHash},
 };
 use std::sync::Arc;
-use im::HashSet;
 
 pub fn handle_get_authoring_list(get_list_data: GetListData, context: Arc<Context>) {
     context.clone().spawn_task(move || {

--- a/crates/core/src/network/handler/lists.rs
+++ b/crates/core/src/network/handler/lists.rs
@@ -13,10 +13,8 @@ use lib3h_protocol::{
     data_types::{EntryListData, GetListData},
     types::{AspectHash, EntryHash},
 };
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::sync::Arc;
+use im::HashSet;
 
 pub fn handle_get_authoring_list(get_list_data: GetListData, context: Arc<Context>) {
     context.clone().spawn_task(move || {
@@ -33,7 +31,7 @@ pub fn handle_get_authoring_list(get_list_data: GetListData, context: Arc<Contex
 }
 
 fn create_authoring_map(context: Arc<Context>) -> AspectMap {
-    let mut address_map: AspectMapBare = HashMap::new();
+    let mut address_map: AspectMapBare = AspectMapBare::new();
     for entry_address in get_all_public_chain_entries(context.clone()) {
         // 1. For every public chain entry we definitely add the content aspect:
         let content_aspect = get_content_aspect(&entry_address, context.clone())
@@ -140,7 +138,7 @@ pub fn handle_get_gossip_list(get_list_data: GetListData, context: Arc<Context>)
             .expect("No state present when trying to respond with gossip list");
         let authoring_map = create_authoring_map(context.clone());
         let holding_map = state.dht().get_holding_map().clone();
-        let address_map = AspectMap::merge(&authoring_map, &holding_map);
+        let address_map = AspectMap::merge(authoring_map, holding_map);
 
         let action = Action::RespondGossipList(EntryListData {
             space_address: get_list_data.space_address,

--- a/crates/core/src/network/state.rs
+++ b/crates/core/src/network/state.rs
@@ -7,7 +7,7 @@ use holochain_core_types::{error::HolochainError, validation::ValidationPackage}
 use holochain_net::p2p_network::P2pNetwork;
 use holochain_persistence_api::cas::content::Address;
 use snowflake;
-use std::collections::HashMap;
+use im::HashMap;
 
 type Actions = HashMap<ActionWrapper, ActionResponse>;
 

--- a/crates/core/src/network/state.rs
+++ b/crates/core/src/network/state.rs
@@ -6,8 +6,8 @@ use boolinator::*;
 use holochain_core_types::{error::HolochainError, validation::ValidationPackage};
 use holochain_net::p2p_network::P2pNetwork;
 use holochain_persistence_api::cas::content::Address;
-use snowflake;
 use im::HashMap;
+use snowflake;
 
 type Actions = HashMap<ActionWrapper, ActionResponse>;
 

--- a/crates/core/src/nucleus/state.rs
+++ b/crates/core/src/nucleus/state.rs
@@ -10,15 +10,12 @@ use holochain_json_api::{
     json::JsonString,
 };
 use holochain_persistence_api::cas::content::{Address, AddressableContent, Content};
+use im::{HashMap, HashSet};
 use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    convert::TryFrom,
-    fmt,
-};
+use std::{collections::VecDeque, convert::TryFrom, fmt};
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, DefaultJson)]
 pub enum NucleusStatus {

--- a/crates/trycp_server/src/main.rs
+++ b/crates/trycp_server/src/main.rs
@@ -12,6 +12,7 @@ use nix::{
     sys::signal::{self, Signal},
     unistd::Pid,
 };
+use regex::Regex;
 use reqwest::{self, Url};
 use serde_json::map::Map;
 use std::{
@@ -23,7 +24,6 @@ use std::{
     sync::{Arc, RwLock},
 };
 use structopt::StructOpt;
-use regex::Regex;
 
 const MAGIC_STRING: &str = "Done. All interfaces started.";
 
@@ -218,9 +218,9 @@ fn get_info_as_json() -> String {
     // poor mans JSON convert
     let re = Regex::new(r"(?P<key>[^:]+):\s+(?P<val>.*)\n").unwrap();
     let result = re.replace_all(&info_str, "\"$key\": \"$val\",");
-    let mut result = format!("{}",result); // pop off the final comma
+    let mut result = format!("{}", result); // pop off the final comma
     result.pop();
-    format!("{{{}}}",result)
+    format!("{{{}}}", result)
 }
 
 fn main() {


### PR DESCRIPTION
## PR summary

The [im crate](https://docs.rs/im/14.0.0/im/) provides drop-in replacements for `HashMap` and `HashSet`. Using those inside our core State makes cloning it much cheaper (which happens a lot).

This was a lot easier than expected :)

## testing/benchmarking notes

Improves performance. See: https://github.com/holochain/holochain-rust/pull/1921.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
