### PR TITLE
Add smarter pending validation resolution

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Pruning the State of old/stale/history data to prevent it from using up a slowly but infinitely growing amount of memory. [#1920](https://github.com/holochain/holochain-rust/pull/1920)
+- Adds smarter ordering of pending validation. Builds a dependency graph and only will try to validate entries that do not have dependencies also awaiting validation as this will always fail. [#1924](https://github.com/holochain/holochain-rust/pull/1924)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1633,7 +1633,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1642,12 +1642,12 @@ dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2142,9 +2142,10 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.19"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2164,7 +2165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2174,7 +2175,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2186,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2523,7 +2524,7 @@ name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3057,7 +3058,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3069,10 +3070,10 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3140,7 +3141,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3154,7 +3155,7 @@ dependencies = [
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3174,7 +3175,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3976,18 +3977,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4008,12 +4009,12 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-executor"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4047,28 +4048,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-reactor"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4080,12 +4081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4106,9 +4107,9 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4124,18 +4125,18 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-timer"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4146,10 +4147,10 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4162,11 +4163,11 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4243,7 +4244,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4662,7 +4663,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4679,7 +4680,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4887,7 +4888,7 @@ dependencies = [
 "checksum holochain_persistence_pickle 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a200265cba8e7c436ea7761b3ff2da3905575198bfbcd7e355bd5a455328417d"
 "checksum holochain_tracing 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "61624e309224fe09d17d3f0efb10dc85df5af33c5b92840b2e37c447b3caa8f4"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
-"checksum http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e06e336150b178206af098a055e3621e8336027e2b4d126bda0bc64824baaf"
+"checksum http 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "2790658cddc82e82b08e25176c431d7015a0adeb1718498715cbd20138a0bf68"
 "checksum http_req 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23fdb3445813f5f5e7fdb9d93df8f1c7e382237f2656b21c42e93e3a63e25c11"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
@@ -4928,7 +4929,7 @@ dependencies = [
 "checksum lmdb-rkv-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7982ba0460e939e26a52ee12c8075deab0ebd44ed21881f656841b70e021b7c8"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
-"checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
+"checksum lock_api 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
@@ -4944,7 +4945,7 @@ dependencies = [
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
-"checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
+"checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum mio-named-pipes 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
@@ -5130,16 +5131,16 @@ dependencies = [
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
-"checksum tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f27ee0e6db01c5f0b2973824547ce7e637b2ed79b891a9677b0de9bd532b6ac"
+"checksum tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-process 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "88e1281e412013f1ff5787def044a9577a0bed059f451e835f1643201f8b777d"
-"checksum tokio-reactor 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c56391be9805bc80163151c0b9e5164ee64f4b0200962c346fea12773158f22d"
+"checksum tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 "checksum tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dd6dc5276ea05ce379a16de90083ec80836440d5ef8a6a39545a3207373b8296"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
-"checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
+"checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-udp 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f02298505547f73e60f568359ef0d016d5acd6e830ab9bc7c4a5b3403440121b"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "87c5890a989fa47ecdc7bcb4c63a77a82c18f306714104b1decfd722db17b39e"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -63,6 +63,7 @@ url = { version = "=2.1.0", features = ["serde"] }
 rand = "0.7.2"
 threadpool = "=1.7.1"
 im = { version = "=14.0.0", features = ["serde"] }
+petgraph = "=0.4.13"
 
 [dev-dependencies]
 wabt = "=0.7.4"

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -561,7 +561,7 @@ pub mod tests {
         assert!(store.has_queued_holding_workflow(&update));
 
         let (next_pending, _) = store.next_queued_holding_workflow().unwrap();
-        assert_eq!(hold_link, *next_pending);
+        assert_eq!(hold_link, next_pending);
 
         let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow(hold_link.clone()));
         let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
@@ -573,7 +573,7 @@ pub mod tests {
         assert!(store.has_queued_holding_workflow(&update));
 
         let (next_pending, _) = store.next_queued_holding_workflow().unwrap();
-        assert_eq!(update, *next_pending);
+        assert_eq!(update, next_pending);
 
         let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow(hold.clone()));
         let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
@@ -583,6 +583,6 @@ pub mod tests {
         assert!(store.has_queued_holding_workflow(&update));
 
         let (next_pending, _) = store.next_queued_holding_workflow().unwrap();
-        assert_eq!(update, *next_pending);
+        assert_eq!(update, next_pending);
     }
 }

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -449,13 +449,4 @@ pub mod tests {
             vec![b, c]
         );
     }
-
-    #[test]
-    #[should_panic(expected = "Cyclic validation dependencies detected!!")]
-    fn test_dependency_resolution_cycle() {
-        // A depends on B, B depends on A. Uh Oh we have a cycle!
-        let a = pending_validation_for_entry(test_entry_a(), vec![test_entry_b().address()]);
-        let b = pending_validation_for_entry(test_entry_b(), vec![test_entry_a().address()]);
-        get_free_dependencies(&vec![a.clone(), b.clone()]);
-    }
 }

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -309,7 +309,7 @@ impl DhtStore {
     }
 }
 
-use petgraph::{algo::is_cyclic_directed, graph::DiGraph, prelude::NodeIndex, Direction::Outgoing};
+use petgraph::{graph::DiGraph, prelude::NodeIndex, Direction::Outgoing};
 use std::collections::HashMap;
 
 fn get_free_dependencies<I>(pending: &I) -> Vec<PendingValidationWithTimeout>
@@ -340,10 +340,7 @@ where
         }
     }
 
-    if is_cyclic_directed(&graph) {
-        // this might be expensive..
-        panic!("Cyclic validation dependencies detected!!")
-    }
+    // TODO: Check for cyles in the graph and remove those pending entries
 
     // return only the pending valiations that don't have dependencies that are also pending
     // i.e. the leaf nodes or 'sinks' of the graph

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -269,7 +269,7 @@ impl DhtStore {
         &self,
     ) -> Option<(PendingValidation, Option<Duration>)> {
         // calculate the leaf dependencies (the things we can validate right now)
-        let free_dependencies = get_free_dependencies(self.queued_holding_workflows.clone());
+        let free_dependencies = get_free_dependencies(&self.queued_holding_workflows);
 
         // respect the delays on the leaf nodes
         free_dependencies
@@ -312,12 +312,10 @@ impl DhtStore {
 use petgraph::{graph::DiGraph, prelude::NodeIndex, Direction::Outgoing};
 use std::collections::HashMap;
 
-fn get_free_dependencies<I>(pending: I) -> Vec<PendingValidationWithTimeout>
+fn get_free_dependencies<I>(pending: &I) -> Vec<PendingValidationWithTimeout>
 where
-    I: IntoIterator<Item = PendingValidationWithTimeout>,
+    I: IntoIterator<Item = PendingValidationWithTimeout> + Clone,
 {
-    let pending: Vec<PendingValidationWithTimeout> = pending.into_iter().collect();
-
     let mut graph = DiGraph::<(), ()>::new();
     let mut index_map: HashMap<Address, NodeIndex> = HashMap::new();
     let mut index_reverse_map: HashMap<NodeIndex, PendingValidationWithTimeout> = HashMap::new();
@@ -330,7 +328,7 @@ where
     }
 
     // add the edges
-    for p in pending {
+    for p in pending.clone() {
         let to = index_map
             .get(&p.pending.entry_with_header.entry.address())
             .expect("we literally just added this");

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -266,6 +266,8 @@ impl DhtStore {
     pub(crate) fn next_queued_holding_workflow(
         &self,
     ) -> Option<(&PendingValidation, Option<Duration>)> {
+        // WTODO: This is where we should toposort to find the next thing to validate
+
         self.queued_holding_workflows
             .iter()
             .skip_while(|(_pending, maybe_delay)| {

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -309,7 +309,7 @@ impl DhtStore {
     }
 }
 
-use petgraph::{graph::DiGraph, prelude::NodeIndex, Direction::Outgoing, algo::is_cyclic_directed};
+use petgraph::{algo::is_cyclic_directed, graph::DiGraph, prelude::NodeIndex, Direction::Outgoing};
 use std::collections::HashMap;
 
 fn get_free_dependencies<I>(pending: &I) -> Vec<PendingValidationWithTimeout>
@@ -340,7 +340,8 @@ where
         }
     }
 
-    if is_cyclic_directed(&graph) { // this might be expensive..
+    if is_cyclic_directed(&graph) {
+        // this might be expensive..
         panic!("Cyclic validation dependencies detected!!")
     }
 
@@ -369,9 +370,14 @@ impl AddContent for DhtStore {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::network::entry_with_header::EntryWithHeader;
-    use crate::dht::pending_validations::{PendingValidationStruct, ValidatingWorkflow};
-    use holochain_core_types::{chain_header::test_chain_header_with_sig, entry::{test_entry, test_entry_a, test_entry_b, test_entry_c}};
+    use crate::{
+        dht::pending_validations::{PendingValidationStruct, ValidatingWorkflow},
+        network::entry_with_header::EntryWithHeader,
+    };
+    use holochain_core_types::{
+        chain_header::test_chain_header_with_sig,
+        entry::{test_entry, test_entry_a, test_entry_b, test_entry_c},
+    };
 
     use holochain_persistence_api::{
         cas::storage::ExampleContentAddressableStorage, eav::ExampleEntityAttributeValueStorage,
@@ -394,9 +400,15 @@ pub mod tests {
         assert_eq!(headers, vec![header1, header2]);
     }
 
-    fn pending_validation_for_entry(entry: Entry, dependencies: Vec<Address>) -> PendingValidationWithTimeout {
+    fn pending_validation_for_entry(
+        entry: Entry,
+        dependencies: Vec<Address>,
+    ) -> PendingValidationWithTimeout {
         let header = test_chain_header_with_sig("sig1");
-        let mut pending_struct = PendingValidationStruct::new(EntryWithHeader{entry, header}, ValidatingWorkflow::HoldEntry);
+        let mut pending_struct = PendingValidationStruct::new(
+            EntryWithHeader { entry, header },
+            ValidatingWorkflow::HoldEntry,
+        );
         pending_struct.dependencies = dependencies;
         PendingValidationWithTimeout::new(Arc::new(pending_struct.clone()), None)
     }
@@ -428,7 +440,10 @@ pub mod tests {
     #[test]
     fn test_dependency_resolution_tree() {
         // A depends on B and C. B and C should be free
-        let a = pending_validation_for_entry(test_entry_a(), vec![test_entry_b().address(), test_entry_c().address()]);
+        let a = pending_validation_for_entry(
+            test_entry_a(),
+            vec![test_entry_b().address(), test_entry_c().address()],
+        );
         let b = pending_validation_for_entry(test_entry_b(), vec![]);
         let c = pending_validation_for_entry(test_entry_c(), vec![]);
 

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -267,8 +267,7 @@ impl DhtStore {
         &self,
     ) -> Option<(PendingValidation, Option<Duration>)> {
         // calculate the leaf dependencies (the things we can validate right now)
-        let free_dependencies =
-            get_free_dependencies(self.queued_holding_workflows.clone());
+        let free_dependencies = get_free_dependencies(self.queued_holding_workflows.clone());
 
         // respect the delays on the leaf nodes
         free_dependencies
@@ -309,12 +308,10 @@ impl DhtStore {
     }
 }
 
-use petgraph::{Direction::Outgoing, graph::DiGraph, prelude::NodeIndex};
+use petgraph::{graph::DiGraph, prelude::NodeIndex, Direction::Outgoing};
 use std::collections::HashMap;
 
-fn get_free_dependencies<I>(
-    pending: I,
-) -> Vec<(PendingValidation, Option<(SystemTime, Duration)>)>
+fn get_free_dependencies<I>(pending: I) -> Vec<(PendingValidation, Option<(SystemTime, Duration)>)>
 where
     I: IntoIterator<Item = (PendingValidation, Option<(SystemTime, Duration)>)>,
 {
@@ -350,7 +347,8 @@ where
 
     // return only the pending valiations that don't have dependencies that are also pending
     // i.e. the leaf nodes or 'sinks' of the graph
-    graph.externals(Outgoing)
+    graph
+        .externals(Outgoing)
         .map(|i| index_reverse_map.get(&i).unwrap().clone())
         .collect()
 }
@@ -396,7 +394,5 @@ pub mod tests {
     }
 
     #[test]
-    fn test_dependency_resolution() {
-
-    }
+    fn test_dependency_resolution() {}
 }

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -10,7 +10,12 @@ use holochain_core_types::{
 use holochain_json_api::{error::JsonError, json::JsonString};
 use holochain_persistence_api::cas::content::Address;
 use snowflake::ProcessUniqueId;
-use std::{convert::TryFrom, fmt, sync::Arc};
+use std::{
+    convert::TryFrom,
+    fmt,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 pub type PendingValidation = Arc<PendingValidationStruct>;
 
@@ -159,5 +164,38 @@ impl From<PendingValidationStruct> for EntryAspect {
                 EntryAspect::Deletion(pending.entry_with_header.header.clone())
             }
         }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidationTimeout {
+    pub time_of_dispatch: SystemTime,
+    pub delay: Duration,
+}
+
+impl ValidationTimeout {
+    pub fn new(time_of_dispatch: SystemTime, delay: Duration) -> Self {
+        Self {
+            time_of_dispatch,
+            delay,
+        }
+    }
+}
+
+impl From<(SystemTime, Duration)> for ValidationTimeout {
+    fn from(tuple: (SystemTime, Duration)) -> Self {
+        Self::new(tuple.0, tuple.1)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PendingValidationWithTimeout {
+    pub pending: PendingValidation,
+    pub timeout: Option<ValidationTimeout>,
+}
+
+impl PendingValidationWithTimeout {
+    pub fn new(pending: PendingValidation, timeout: Option<ValidationTimeout>) -> Self {
+        Self { pending, timeout }
     }
 }

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -1,6 +1,6 @@
 use crate::{
-    network::entry_with_header::EntryWithHeader,
     entry::validation_dependencies::ValidationDependencies,
+    network::entry_with_header::EntryWithHeader,
 };
 use holochain_core_types::{
     entry::{deletion_entry::DeletionEntry, Entry},

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -167,7 +167,7 @@ impl From<PendingValidationStruct> for EntryAspect {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ValidationTimeout {
     pub time_of_dispatch: SystemTime,
     pub delay: Duration,
@@ -188,7 +188,7 @@ impl From<(SystemTime, Duration)> for ValidationTimeout {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PendingValidationWithTimeout {
     pub pending: PendingValidation,
     pub timeout: Option<ValidationTimeout>,

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -88,6 +88,8 @@ impl PendingValidationStruct {
 impl TryFrom<EntryAspect> for PendingValidationStruct {
     type Error = HolochainError;
     fn try_from(aspect: EntryAspect) -> Result<PendingValidationStruct, HolochainError> {
+        // WTODO: this is where the dependencies can be calculated
+
         match aspect {
             EntryAspect::Content(entry, header) => Ok(PendingValidationStruct::new(
                 EntryWithHeader::try_from_entry_and_header(entry, header)?,

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -1,4 +1,7 @@
-use crate::network::entry_with_header::EntryWithHeader;
+use crate::{
+    network::entry_with_header::EntryWithHeader,
+    entry::validation_dependencies::ValidationDependencies,
+};
 use holochain_core_types::{
     entry::{deletion_entry::DeletionEntry, Entry},
     error::HolochainError,
@@ -70,9 +73,10 @@ pub struct PendingValidationStruct {
 
 impl PendingValidationStruct {
     pub fn new(entry_with_header: EntryWithHeader, workflow: ValidatingWorkflow) -> Self {
+        let dependencies = entry_with_header.get_validation_dependencies();
         Self {
             entry_with_header,
-            dependencies: Vec::new(),
+            dependencies,
             workflow,
             uuid: ProcessUniqueId::new(),
         }
@@ -88,8 +92,6 @@ impl PendingValidationStruct {
 impl TryFrom<EntryAspect> for PendingValidationStruct {
     type Error = HolochainError;
     fn try_from(aspect: EntryAspect) -> Result<PendingValidationStruct, HolochainError> {
-        // WTODO: this is where the dependencies can be calculated
-
         match aspect {
             EntryAspect::Content(entry, header) => Ok(PendingValidationStruct::new(
                 EntryWithHeader::try_from_entry_and_header(entry, header)?,

--- a/crates/core/src/entry/mod.rs
+++ b/crates/core/src/entry/mod.rs
@@ -1,5 +1,7 @@
 //! This module extends Entry and EntryType with the CanPublish trait.
 
+pub mod validation_dependencies;
+
 use holochain_core_types::entry::entry_type::EntryType;
 
 use crate::context::Context;

--- a/crates/core/src/entry/validation_dependencies.rs
+++ b/crates/core/src/entry/validation_dependencies.rs
@@ -32,7 +32,7 @@ impl ValidationDependencies for EntryWithHeader {
                     .map(|prev_addr| vec![prev_addr])
                     .unwrap_or_else(Vec::new)
             }
-            // link remove? deletion? etc?
+            // TODO: link remove? deletion? etc?
             _ => Vec::new(),
         }
     }

--- a/crates/core/src/entry/validation_dependencies.rs
+++ b/crates/core/src/entry/validation_dependencies.rs
@@ -11,8 +11,12 @@ impl ValidationDependencies for EntryWithHeader {
         match &self.entry {
             Entry::App(_, _) => {
                 // in the future an entry should be dependent on its header but
-                // for now it can require nothing
-                Vec::new()
+                // for now it can require nothing by default.
+                // If it is an update, require that the original entry is validated
+                match self.header.link_update_delete() {
+                    Some(entry_to_update) => vec![entry_to_update],
+                    None => Vec::new(),
+                }
             }
             Entry::LinkAdd(link_data) | Entry::LinkRemove((link_data, _)) => {
                 // A link or link remove depends on its base and target being validated

--- a/crates/core/src/entry/validation_dependencies.rs
+++ b/crates/core/src/entry/validation_dependencies.rs
@@ -10,18 +10,17 @@ impl ValidationDependencies for EntryWithHeader {
     fn get_validation_dependencies(&self) -> Vec<Address> {
         match &self.entry {
             Entry::App(_, _) => {
-                // in the future an entry should be dependent on its header but 
+                // in the future an entry should be dependent on its header but
                 // for now it can require nothing
                 Vec::new()
             }
-            Entry::LinkAdd(link_data) 
-            | Entry::LinkRemove((link_data, _)) => {
+            Entry::LinkAdd(link_data) | Entry::LinkRemove((link_data, _)) => {
                 // A link or link remove depends on its base and target being validated
                 vec![
                     link_data.link.base().clone(),
                     link_data.link.target().clone(),
                 ]
-            },
+            }
             Entry::ChainHeader(chain_header) => {
                 // A chain header entry is dependent on its previous header
                 // unless it is the genesis header (link is None)
@@ -29,7 +28,7 @@ impl ValidationDependencies for EntryWithHeader {
                     .link()
                     .map(|prev_addr| vec![prev_addr])
                     .unwrap_or_else(Vec::new)
-            },
+            }
             Entry::Deletion(deletion) => {
                 // a deletion depends on the thing being deleted
                 vec![deletion.deleted_entry_address().clone()]
@@ -68,10 +67,7 @@ pub mod tests {
     fn test_get_validation_dependencies_app_entry() {
         let entry = Entry::App("entry_type".into(), "content".into());
         let entry_wh = entry_with_header_from_entry(entry);
-        assert_eq!(
-            entry_wh.get_validation_dependencies(),
-            Vec::new(),
-        )
+        assert_eq!(entry_wh.get_validation_dependencies(), Vec::new(),)
     }
 
     #[test]

--- a/crates/core/src/entry/validation_dependencies.rs
+++ b/crates/core/src/entry/validation_dependencies.rs
@@ -10,10 +10,12 @@ impl ValidationDependencies for EntryWithHeader {
     fn get_validation_dependencies(&self) -> Vec<Address> {
         match &self.entry {
             Entry::App(_, _) => {
-                // in the future an entry should be dependent on its header but
+                // In the future an entry should be dependent its previous header but
                 // for now it can require nothing by default.
-                // If it is an update, require that the original entry is validated
+                // There is also potential to add a WASM function for determining dependencies as a function
+                // of the entry content.
                 match self.header.link_update_delete() {
+                    // If it is an update, require that the original entry is validated
                     Some(entry_to_update) => vec![entry_to_update],
                     None => Vec::new(),
                 }

--- a/crates/core/src/entry/validation_dependencies.rs
+++ b/crates/core/src/entry/validation_dependencies.rs
@@ -1,0 +1,114 @@
+use crate::network::entry_with_header::EntryWithHeader;
+use holochain_core_types::entry::Entry;
+use holochain_persistence_api::cas::content::Address;
+
+pub trait ValidationDependencies {
+    fn get_validation_dependencies(&self) -> Vec<Address>;
+}
+
+impl ValidationDependencies for EntryWithHeader {
+    fn get_validation_dependencies(&self) -> Vec<Address> {
+        match &self.entry {
+            Entry::App(_, _) => {
+                // an app entry is dependent on its previous header being validated
+                // QUESTION: Should this be its own header??
+                self.header
+                    .link()
+                    .map(|prev_addr| vec![prev_addr])
+                    .unwrap_or_else(Vec::new)
+            }
+            Entry::LinkAdd(link_data) => {
+                // A link depends on its base and target being validated
+                vec![
+                    link_data.link.base().clone(),
+                    link_data.link.target().clone(),
+                ]
+            }
+            Entry::ChainHeader(chain_header) => {
+                // A chain header entry is dependent on its previous header
+                // unless it is the genesis header (link is None)
+                chain_header
+                    .link()
+                    .map(|prev_addr| vec![prev_addr])
+                    .unwrap_or_else(Vec::new)
+            }
+            // link remove? deletion? etc?
+            _ => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use holochain_core_types::{
+        agent::AgentId, chain_header::ChainHeader, link::link_data::LinkData, time::Iso8601,
+    };
+    use holochain_persistence_api::cas::content::AddressableContent;
+
+    fn test_header_for_entry(entry: &Entry) -> ChainHeader {
+        ChainHeader::new(
+            &entry.entry_type(),
+            &entry.address(),
+            &Vec::new(),                                       // provenences
+            &Some(Address::from("QmEntryPreviousHeaderHash")), // link
+            &None,                                             // link same type
+            &None,                                             // link update/delete
+            &Iso8601::from(0),
+        )
+    }
+
+    fn entry_with_header_from_entry(entry: Entry) -> EntryWithHeader {
+        let header = test_header_for_entry(&entry);
+        EntryWithHeader::new(entry, header)
+    }
+
+    #[test]
+    fn test_get_validation_dependencies_app_entry() {
+        let entry = Entry::App("entry_type".into(), "content".into());
+        let entry_wh = entry_with_header_from_entry(entry);
+        assert_eq!(
+            entry_wh.get_validation_dependencies(),
+            vec![Address::from("QmEntryPreviousHeaderHash")],
+        )
+    }
+
+    #[test]
+    fn test_get_validation_dependencies_link_add_entry() {
+        let entry = Entry::LinkAdd(LinkData::new_add(
+            &Address::from("QmBaseAddress"),
+            &Address::from("QmTargetAddress"),
+            "some tag",
+            "some type",
+            test_header_for_entry(&Entry::App("".into(), "".into())),
+            AgentId::new("HcAgentId", "key".into()),
+        ));
+        let entry_wh = entry_with_header_from_entry(entry);
+        assert_eq!(
+            entry_wh.get_validation_dependencies(),
+            vec![
+                Address::from("QmBaseAddress"),
+                Address::from("QmTargetAddress")
+            ],
+        )
+    }
+
+    #[test]
+    fn test_get_validation_dependencies_header_entry() {
+        let header_entry_conent = ChainHeader::new(
+            &"some type".into(),
+            &Address::from("QmAddressOfEntry"),
+            &Vec::new(),                                     // provenences
+            &Some(Address::from("QmPreviousHeaderAddress")), // link
+            &None,                                           // link same type
+            &None,                                           // link update/delete
+            &Iso8601::from(0),
+        );
+        let entry = Entry::ChainHeader(header_entry_conent);
+        let entry_wh = entry_with_header_from_entry(entry);
+        assert_eq!(
+            entry_wh.get_validation_dependencies(),
+            vec![Address::from("QmPreviousHeaderAddress")],
+        )
+    }
+}

--- a/crates/core/src/network/handler/store.rs
+++ b/crates/core/src/network/handler/store.rs
@@ -34,7 +34,6 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
             return;
         }
         match PendingValidationStruct::try_from(aspect) {
-            // WTODO: This is where pending validation is first added
             Err(e) => log_error!(
                 context,
                 "net/handle: handle_store: received bad aspect: {:?}",

--- a/crates/core/src/network/handler/store.rs
+++ b/crates/core/src/network/handler/store.rs
@@ -34,6 +34,7 @@ pub fn handle_store(dht_data: StoreEntryAspectData, context: Arc<Context>) {
             return;
         }
         match PendingValidationStruct::try_from(aspect) {
+            // WTODO: This is where pending validation is first added
             Err(e) => log_error!(
                 context,
                 "net/handle: handle_store: received bad aspect: {:?}",

--- a/crates/core/src/nucleus/validation/mod.rs
+++ b/crates/core/src/nucleus/validation/mod.rs
@@ -157,7 +157,7 @@ pub fn entry_to_validation_data(
                 })
             }),
         Entry::Deletion(deletion_entry) => {
-            let deletion_address = deletion_entry.clone().deleted_entry_address();
+            let deletion_address = deletion_entry.deleted_entry_address().clone();
             get_entry_with_header(context.clone(), &deletion_address)
                 .map(|entry_with_header| {
                     Ok(EntryValidationData::Delete {

--- a/crates/core/src/nucleus/validation/remove_entry.rs
+++ b/crates/core/src/nucleus/validation/remove_entry.rs
@@ -20,7 +20,7 @@ pub async fn validate_remove_entry(
 ) -> ValidationResult {
     let dna = context.get_dna().expect("Callback called without DNA set");
     let deletion_entry = unwrap_to!(entry=>Entry::Deletion);
-    let deletion_address = deletion_entry.clone().deleted_entry_address();
+    let deletion_address = deletion_entry.deleted_entry_address().clone();
     let entry_to_delete = get_entry_from_dht(&context.clone(), &deletion_address)
         .map_err(|_| ValidationError::UnresolvedDependencies(vec![deletion_address.clone()]))?
         .ok_or_else(|| {

--- a/crates/core/src/scheduled_jobs/state_dump.rs
+++ b/crates/core/src/scheduled_jobs/state_dump.rs
@@ -1,5 +1,6 @@
 use crate::{
     context::Context,
+    dht::pending_validations::PendingValidationWithTimeout,
     state_dump::{address_to_content_and_type, StateDump},
 };
 use holochain_core_types::chain_header::ChainHeader;
@@ -48,13 +49,13 @@ pub fn state_dump(context: Arc<Context>) {
     let queued_holding_workflows_strings = dump
         .queued_holding_workflows
         .iter()
-        .map(|(pending_validation, _maybe_delay)| {
+        .map(|PendingValidationWithTimeout { pending, .. }| {
             format!(
                 "<{}> [{}] {}: {}",
-                pending_validation.workflow.to_string(),
-                pending_validation.entry_with_header.header.entry_type(),
-                pending_validation.entry_with_header.entry.address(),
-                pending_validation.entry_with_header.entry.content(),
+                pending.workflow.to_string(),
+                pending.entry_with_header.header.entry_type(),
+                pending.entry_with_header.entry.address(),
+                pending.entry_with_header.entry.content(),
             )
         })
         .collect::<Vec<String>>();

--- a/crates/core/src/state_dump.rs
+++ b/crates/core/src/state_dump.rs
@@ -1,19 +1,14 @@
 use crate::{
     action::QueryKey,
     context::Context,
-    dht::{aspect_map::AspectMapBare, pending_validations::PendingValidation},
+    dht::{aspect_map::AspectMapBare, pending_validations::PendingValidationWithTimeout},
     network::direct_message::DirectMessage,
     nucleus::{ZomeFnCall, ZomeFnCallState},
 };
 use holochain_core_types::{chain_header::ChainHeader, entry::Entry, error::HolochainError};
 use holochain_json_api::json::JsonString;
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
-use std::{
-    collections::VecDeque,
-    convert::TryInto,
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{collections::VecDeque, convert::TryInto, sync::Arc};
 
 #[derive(Serialize)]
 pub struct StateDump {
@@ -23,7 +18,7 @@ pub struct StateDump {
     pub query_flows: Vec<QueryKey>,
     pub validation_package_flows: Vec<Address>,
     pub direct_message_flows: Vec<(String, DirectMessage)>,
-    pub queued_holding_workflows: VecDeque<(PendingValidation, Option<(SystemTime, Duration)>)>,
+    pub queued_holding_workflows: VecDeque<PendingValidationWithTimeout>,
     pub held_aspects: AspectMapBare,
     pub source_chain: Vec<ChainHeader>,
 }

--- a/crates/core_types/src/entry/deletion_entry.rs
+++ b/crates/core_types/src/entry/deletion_entry.rs
@@ -17,8 +17,8 @@ impl DeletionEntry {
         }
     }
 
-    pub fn deleted_entry_address(self) -> Address {
-        self.deleted_entry_address
+    pub fn deleted_entry_address(&self) -> &Address {
+        &self.deleted_entry_address
     }
 }
 

--- a/crates/core_types/src/entry/deletion_entry.rs
+++ b/crates/core_types/src/entry/deletion_entry.rs
@@ -37,7 +37,7 @@ pub mod tests {
     fn deletion_entry_smoke_test() {
         assert_eq!(
             test_entry_a().address(),
-            test_deletion_entry().deleted_entry_address()
+            test_deletion_entry().deleted_entry_address().clone()
         );
     }
 }


### PR DESCRIPTION
## PR summary

Adds a sorting stage to the process of selecting the next pending validation to reduce the probability of blocking indefinitely.

This sort must take into account the dependency graph of entries (if entry A depends on entry B we should always try and validate B first). To build the dependency graph this adds a new trait `ValidationDependencies` which is implemented by `EntryWithHeader`. Links depend on their target and base, header entries depend on the previous header, entries also depend on the previous header.

The dependencies are stored with the pending validations and only leaf nodes/sinks are considered when selecting the next entry to validate. It also keeps the delay logic from before so it won't thrash trying to validate something impossible.

## Remaining tasks

- [x] Write tests for `get_free_dependencies` and `next_queued_holding_workflow` 
- [x] There are still some serious optimizations to do. The `get_free_dependencies` function makes no attempt at all to be efficient. Cloning everywhere
- [x] Refactor with types rather than tuples `(PendingValidation, Option<(SystemTime, Duration)>)` 
- [x] It is still possible to state something to be validated even though we can tell before it will fail (because there are sleeping un-validated dependencies). Fixed by selecting only leaves

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
