### PR TITLE
add BUILD_DATE to holochain -i output

### DIFF
--- a/crates/core_types/Cargo.toml
+++ b/crates/core_types/Cargo.toml
@@ -43,3 +43,6 @@ holochain_logging = "=0.0.4"
 [dev-dependencies]
 test_utils = { version = "=0.0.40-alpha1", path = "../../test_utils"}
 maplit = "=1.0.2"
+
+[build-dependencies]
+chrono = "=0.4.6"

--- a/crates/core_types/build.rs
+++ b/crates/core_types/build.rs
@@ -1,4 +1,7 @@
-use std::{env, path::Path, process::Command};
+use std::{env, path::Path, process::Command, time::SystemTime};
+extern crate chrono;
+use chrono::{offset::Utc, DateTime};
+
 /// Detect details about the HDK Version being built, to make available as hdk::HDK_VERSION variable
 /// - Use supplied "HDK_VERSION" or "CARGO_PKG_VERSION" environment variables
 ///   - Should match the nearest upstream Git "tag", eg. "v0.0.32-alpha2-3-g3f9f2f5e0", but
@@ -56,4 +59,11 @@ fn main() {
         let git_branch = String::from_utf8(output.stdout).unwrap();
         println!("cargo:rustc-env=GIT_BRANCH={}", git_branch);
     }
+
+    let system_time = SystemTime::now();
+    let datetime: DateTime<Utc> = system_time.into();
+    println!(
+        "cargo:rustc-env=BUILD_DATE={}",
+        datetime.format("%d/%m/%Y %T")
+    );
 }

--- a/crates/core_types/src/lib.rs
+++ b/crates/core_types/src/lib.rs
@@ -67,6 +67,7 @@ pub const HDK_HASH: &str = env!(
 // may be empty because code isn't always built from git repo
 pub const GIT_HASH: &str = env!("GIT_HASH", "");
 pub const GIT_BRANCH: &str = env!("GIT_BRANCH", "");
+pub const BUILD_DATE: &str = env!("BUILD_DATE", "");
 
 #[cfg(test)]
 mod test_hash {

--- a/crates/holochain/src/main.rs
+++ b/crates/holochain/src/main.rs
@@ -27,7 +27,7 @@ use holochain_conductor_lib::{
     config::{self, load_configuration, Configuration},
 };
 use holochain_core_types::{
-    error::HolochainError, hdk_version::HDK_VERSION, GIT_BRANCH, GIT_HASH, HDK_HASH,
+    error::HolochainError, hdk_version::HDK_VERSION, BUILD_DATE, GIT_BRANCH, GIT_HASH, HDK_HASH,
 };
 use holochain_locksmith::spawn_locksmith_guard_watcher;
 #[cfg(unix)]
@@ -78,6 +78,9 @@ fn main() {
         }
         if GIT_BRANCH != "" {
             println!("GIT_BRANCH: {}", GIT_BRANCH);
+        }
+        if BUILD_DATE != "" {
+            println!("BUILD_DATE: {}", BUILD_DATE);
         }
         return;
     }


### PR DESCRIPTION
## PR summary

``` 
$ holochain -i
HDK_VERSION: 0.0.40-alpha1
HDK_HASH: mh94ckjds4dni171sykgh1njknr186h6
GIT_HASH: 294c46199c7a581ad695ed81f1a139da1a2cb2ec
GIT_BRANCH: timestamp-in-hcinfo
BUILD_DATE: 03/12/2019 17:22:50
```

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
