### PR TITLE
State invariants

### DIFF
--- a/app_spec/test/package.json
+++ b/app_spec/test/package.json
@@ -3,7 +3,7 @@
     "standard": "^14.3.1"
   },
   "dependencies": {
-    "@holochain/tryorama": "^0.2.0-rc.4",
+    "@holochain/tryorama": "^0.2.1-rc.1",
     "faucet": "0.0.1",
     "json3": "^3.3.3",
     "sleep": "^6.1.0",

--- a/stress-test/package.json
+++ b/stress-test/package.json
@@ -15,8 +15,8 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "@holochain/tryorama": "^0.2.0-rc.4",
-    "@holochain/tryorama-stress-utils": "0.0.2",
+    "@holochain/tryorama": "^0.2.1-rc.1",
+    "@holochain/tryorama-stress-utils": "0.0.3",
     "ramda": "^0.26.1",
     "tape": "^4.11.0",
     "sleep": "^6.1.0"

--- a/stress-test/src/all-on.ts
+++ b/stress-test/src/all-on.ts
@@ -12,7 +12,7 @@ module.exports = (scenario, N, M) => {
 
     // Make every instance of every conductor commit an entry
 
-    const commitResults = await batch.mapInstances(instance =>
+    const commitResults = await batch.mapInstances<any>(instance =>
       instance.call('main', 'commit_entry', { content: trace(`entry-${instance.player.name}-${instance.id}`) })
     )
     const hashes = commitResults.map(x => x.Ok)
@@ -41,7 +41,7 @@ module.exports = (scenario, N, M) => {
 
     // Make each other instance getLinks on the base hash
 
-    const getLinksResults = await batch.mapInstances(instance => instance.call('main', 'get_links', { base: baseHash }))
+    const getLinksResults = await batch.mapInstances<any>(instance => instance.call('main', 'get_links', { base: baseHash }))
 
     // All getLinks results contain the full set
     t.deepEqual(getLinksResults.map(r => r.Ok.links.length), R.repeat(N * M, N * M))
@@ -51,7 +51,7 @@ module.exports = (scenario, N, M) => {
     const players = R.values(await s.players(configBatchSimple(N, M), true))
     const batch = new Batch(players).iteration('parallel')
 
-    const commitResults = await batch.mapInstances(instance =>
+    const commitResults = await batch.mapInstances<any>(instance =>
       instance.call('main', 'commit_entry', { content: trace(`entry-${instance.player.name}-${instance.id}`) })
     )
     const hashes = commitResults.map(x => x.Ok)
@@ -74,7 +74,7 @@ module.exports = (scenario, N, M) => {
 
     await s.consistency()
 
-    const getLinksResults = await batch.mapInstances(instance => instance.call('main', 'get_links', { base: baseHash }))
+    const getLinksResults = await batch.mapInstances<any>(instance => instance.call('main', 'get_links', { base: baseHash }))
 
     // All getLinks results contain the full set
     t.deepEqual(getLinksResults.map(r => r.Ok.links.length), R.repeat(N * M, N * M))

--- a/stress-test/src/config.ts
+++ b/stress-test/src/config.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda'
 import { Config } from '@holochain/tryorama'
 
 
-export const networkType = process.env.APP_SPEC_NETWORK_TYPE || 'sim1h'
+export const networkType = process.env.APP_SPEC_NETWORK_TYPE || 'sim2h'
 
 const logger = {
   type: 'debug',

--- a/stress-test/src/holdem.ts
+++ b/stress-test/src/holdem.ts
@@ -1,0 +1,32 @@
+import * as R from 'ramda'
+import { Batch } from '@holochain/tryorama-stress-utils'
+import {configBatchSimple} from './config'
+
+const trace = R.tap(x => console.log('{T}', x))
+const delay = ms => new Promise(r => setTimeout(r, ms))
+
+module.exports = (scenario, N, M) => {
+
+  scenario.only('all instances hold the same aspects after startup (smooth)', async (s, t) => {
+    const players = R.values(await s.players(configBatchSimple(N, M), true))
+
+    await delay(10000)
+    
+    const batch = new Batch(players).iteration('series')
+
+    const holds = await batch.mapInstances(async instance => {
+      const dump = await instance.stateDump()
+      const hashes = Object.keys(dump.held_aspects)
+      return hashes.length
+    })
+
+    // We expect to hold 6 entries for each instance in the network:
+    // - DNA
+    // - AgentId
+    // - CapToken
+    // and headers for each of these
+    const expected = (N * M) * 6
+    t.deepEqual(holds, R.repeat(expected, N * M))
+  })
+
+}

--- a/stress-test/src/index.ts
+++ b/stress-test/src/index.ts
@@ -32,6 +32,7 @@ const M = parseInt(process.argv[3], 10) || 1
 
 console.log(`Running stress tests with N=${N}, M=${M}`)
 
+require('./holdem')(orchestrator.registerScenario, N, M)
 require('./all-on')(orchestrator.registerScenario, N, M)
 require('./telephone-games')(orchestrator.registerScenario, N, M)
 

--- a/stress-test/src/index.ts
+++ b/stress-test/src/index.ts
@@ -32,7 +32,7 @@ const M = parseInt(process.argv[3], 10) || 1
 
 console.log(`Running stress tests with N=${N}, M=${M}`)
 
-require('./holdem')(orchestrator.registerScenario, N, M)
+require('./state-invariants')(orchestrator.registerScenario, N, M)
 require('./all-on')(orchestrator.registerScenario, N, M)
 require('./telephone-games')(orchestrator.registerScenario, N, M)
 

--- a/stress-test/src/state-invariants.ts
+++ b/stress-test/src/state-invariants.ts
@@ -7,9 +7,10 @@ const delay = ms => new Promise(r => setTimeout(r, ms))
 
 module.exports = (scenario, N, M) => {
 
-  scenario.only('all instances hold the same aspects after startup (smooth)', async (s, t) => {
+  scenario('all instances hold the same aspects after startup (smooth)', async (s, t) => {
     const players = R.values(await s.players(configBatchSimple(N, M), true))
 
+    // TODO: we shouldn't even need this delay
     await delay(10000)
     
     const batch = new Batch(players).iteration('series')


### PR DESCRIPTION
## PR summary

Adds new failing tests, which make assertions on conductor state dumps at certain moments in time. I'd like to add various tests here to enforce our basic assumptions of key concepts like authoring and holding lists.

Tests:

* After starting up N instances, we expect each instance to hold aspects for N * 6 entries

## testing/benchmarking notes

This branch is about adding tests which fail. We can start new branches based on this branch with the work to make the tests pass, then merge them in when they pass.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
