### PR TITLE
Fix threadpool deadlock

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -87,7 +87,7 @@ pub struct Context {
     pub(crate) signal_tx: Option<Sender<Signal>>,
     pub(crate) instance_is_alive: Arc<AtomicBool>,
     pub state_dump_logging: bool,
-    thread_pool: Arc<Mutex<ThreadPool>>,
+    thread_pool: ThreadPool,
     pub redux_wants_write: Arc<AtomicBool>,
     pub metric_publisher: Arc<RwLock<dyn MetricPublisher>>,
 }
@@ -151,9 +151,7 @@ impl Context {
             )),
             instance_is_alive: Arc::new(AtomicBool::new(true)),
             state_dump_logging,
-            thread_pool: Arc::new(Mutex::new(
-                ThreadPool::new().expect("Could not create thread pool for futures"),
-            )),
+            thread_pool: ThreadPool::new().expect("Could not create thread pool for futures"),
             redux_wants_write: Arc::new(AtomicBool::new(false)),
             metric_publisher,
         }
@@ -188,9 +186,7 @@ impl Context {
             conductor_api: ConductorApi::new(Self::test_check_conductor_api(None, agent_id)),
             instance_is_alive: Arc::new(AtomicBool::new(true)),
             state_dump_logging,
-            thread_pool: Arc::new(Mutex::new(
-                ThreadPool::new().expect("Could not create thread pool for futures"),
-            )),
+            thread_pool: ThreadPool::new().expect("Could not create thread pool for futures"),
             redux_wants_write: Arc::new(AtomicBool::new(false)),
             metric_publisher,
         })
@@ -356,10 +352,7 @@ impl Context {
     where
         Fut: Future<Output = ()> + Send + 'static,
     {
-        self.thread_pool
-            .lock()
-            .expect("Couldn't get lock on Context::thread_pool")
-            .spawn_ok(f);
+        self.thread_pool.spawn_ok(f);
     }
 
     /// returns the public capability token (if any)


### PR DESCRIPTION
## PR summary

Threadpool doesn't need to be wrapped by a Mutex, is Sync and Send already. The `spawn_ok` functions locks mutexes and sends on channels, and somehow our lock becomes immortal sometimes.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
