### PR TITLE
Output DnaWasm as gzip-compressed, base-64 encoded list of Strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,6 @@ name = "hc"
 version = "0.0.40-alpha1"
 dependencies = [
  "assert_cmd 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1293,6 +1292,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hcid 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,7 +26,6 @@ serde_derive = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 toml = "=0.5.0"
 semver = { version = "0.9.0", features = ["serde"] }
-base64 = "=0.10.1"
 colored = "=1.7.0"
 ignore = "=0.4.6"
 rpassword = "=2.1.0"

--- a/crates/cli/src/cli/package.rs
+++ b/crates/cli/src/cli/package.rs
@@ -1,5 +1,4 @@
 use crate::{config_files::Build, error::DefaultResult, util};
-use base64;
 use colored::*;
 use holochain_core::nucleus::ribosome::{run_dna, WasmCallData};
 use holochain_core_types::dna::Dna;
@@ -13,7 +12,6 @@ use std::{
     fs::{self, File},
     io::Read,
     path::PathBuf,
-    sync::Arc,
 };
 
 use holochain_core_types::hdk_version::{HDKVersion, HDK_VERSION};
@@ -184,13 +182,12 @@ impl Packager {
                 {
                     let build = Build::from_file(dir_with_code.join(BUILD_CONFIG_FILE_NAME))?;
                     let wasm = build.run(&dir_with_code)?;
-                    let wasm_binary = Arc::new(base64::decode(&wasm)?);
 
                     let json_string = run_dna(
                         Some("{}".as_bytes().to_vec()),
                         WasmCallData::DirectCall(
                             "__hdk_get_json_definition".to_string(),
-                            wasm_binary.clone(),
+                            wasm.code.clone(), // An Arc<Vec<u8>>
                         ),
                     )?;
 
@@ -244,10 +241,11 @@ impl Packager {
                         });
                     }
 
-                    let wasm = build.run(&node)?;
+                    // A DnaWasm is serializable into JSON
+                    let dna_wasm = build.run(&node)?;
 
                     // here insert the wasm itself
-                    main_tree.insert(file_name.clone(), json!({ "code": wasm }));
+                    main_tree.insert(file_name.clone(), json!(dna_wasm));
                 } else {
                     let sub_tree_content = self.bundle_recurse(&node)?;
                     main_tree.insert(file_name.clone(), sub_tree_content.into());

--- a/crates/cli/src/config_files/build.rs
+++ b/crates/cli/src/config_files/build.rs
@@ -1,11 +1,12 @@
 use crate::{error::DefaultResult, util};
-use base64;
 use serde_json;
 use std::{
     fs::File,
     io::Read,
     path::{Path, PathBuf},
 };
+
+use holochain_core_types::dna::wasm::DnaWasm;
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BuildStep {
@@ -29,8 +30,8 @@ impl Build {
         Ok(build)
     }
 
-    /// Starts the build using the supplied build steps and returns the contents of the artifact
-    pub fn run(&self, base_path: &PathBuf) -> DefaultResult<String> {
+    /// Starts the build using the supplied build steps and returns the contents of the artifact as DnaWasm
+    pub fn run(&self, base_path: &PathBuf) -> DefaultResult<DnaWasm> {
         for build_step in &self.steps {
             let slice_vec: Vec<_> = build_step.arguments.iter().map(|e| e.as_str()).collect();
             util::run_cmd(
@@ -46,7 +47,7 @@ impl Build {
             let mut wasm_buf = Vec::new();
             File::open(&artifact_path)?.read_to_end(&mut wasm_buf)?;
 
-            Ok(base64::encode(&wasm_buf))
+            Ok(DnaWasm::from_bytes(wasm_buf))
         } else {
             bail!(
                 "artifact path {} either doesn't point to a file or doesn't exist",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,7 +14,6 @@ extern crate structopt;
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;
-extern crate base64;
 extern crate colored;
 extern crate semver;
 #[macro_use]

--- a/crates/core_types/Cargo.toml
+++ b/crates/core_types/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "=1.0.89"
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 lazy_static = "=1.2.0"
 multihash = "=0.8.0"
+flate2 = "=1.0.12"
 mashup = "0.1.9"
 wasmi = "=0.4.4"
 hcid = "=0.0.6"

--- a/crates/core_types/src/dna/wasm.rs
+++ b/crates/core_types/src/dna/wasm.rs
@@ -56,7 +56,7 @@ where
     S: Serializer,
 {
     let buf_reader = BufReader::new(data.as_slice());
-    let mut gz = GzEncoder::new(buf_reader, Compression::default());
+    let mut gz = GzEncoder::new(buf_reader, Compression::best());
     let mut buf = Vec::new();
     gz.read_to_end(&mut buf).map_err(S::Error::custom)?;
     let b64 = base64::encode(&buf);

--- a/crates/core_types/src/dna/wasm.rs
+++ b/crates/core_types/src/dna/wasm.rs
@@ -63,11 +63,11 @@ where
     let b64 = base64::encode(&buf);
     println!("WASM of {} bytes gzipped to {} bytes, base-64 encoded to {} bytes", data.len(), buf.len(), b64.len());
     let cnt = ( b64.len() + 127 ) / 128;
-    if cnt <= 1 {
-        // For small WASMs (and backward-compatibility) emit them as a simple *un-compressed* "string"
-        let b64 = base64::encode(data.as_ref());
-        println!("Encoding {}-byte base-64 uncompressed WASM to a String", b64.len());
-        s.serialize_str(&b64)
+    if cnt <= 10 {
+        // For small WASMs (and backward-compatibility) emit them as a simple *un-compressed* String
+        let b64_uncompressed = base64::encode(data.as_ref());
+        println!("Encoding {}-byte base-64 uncompressed WASM to a String", b64_uncompressed.len());
+        s.serialize_str(&b64_uncompressed)
     } else {
         // Output the base-64 encoded compressed WASM in (1024*5/4)/10 == 128-symbol chunks
         let mut seq = s.serialize_seq(Some(cnt)).map_err(S::Error::custom)?;

--- a/crates/core_types/src/dna/zome.rs
+++ b/crates/core_types/src/dna/zome.rs
@@ -154,7 +154,7 @@ pub mod tests {
         zome::{entry_types::EntryTypeDef, Zome},
     };
     use serde_json;
-    use std::{collections::BTreeMap, convert::TryFrom};
+    use std::{collections::BTreeMap, convert::TryFrom, sync::Arc};
 
     pub fn test_zome() -> Zome {
         Zome::empty()
@@ -199,6 +199,137 @@ pub mod tests {
         assert_eq!(
             zome,
             Zome::try_from(JsonString::from_json(expected)).unwrap(),
+        );
+
+        // Ensure that compressed large WASM gets round-tripped to [String, ...]
+        zome.code.code = Arc::new(vec![
+                0x40, 0x35, 0xe0, 0x39, 0xa6, 0x27, 0x8a, 0x62, 0x9f, 0xa8, 0x2b, 0x2b, 0x7e, 0xbb, 0xed, 0xdb,
+                0xb0, 0x90, 0x01, 0xf4, 0x07, 0xa6, 0xe2, 0xd5, 0xd1, 0x30, 0x1f, 0xe8, 0x77, 0x1b, 0xf0, 0x08,
+                0x14, 0x0b, 0x09, 0xf3, 0xfc, 0xec, 0x1f, 0x76, 0x3e, 0xcd, 0x94, 0xe0, 0xe3, 0xbc, 0xe6, 0xe4,
+                0x36, 0xd1, 0x7e, 0x77, 0xd7, 0xc4, 0x89, 0x8d, 0x6f, 0x78, 0x9d, 0x0b, 0xba, 0xa4, 0x53, 0xc7,
+                0x37, 0x76, 0xd1, 0xf8, 0x5e, 0x62, 0x29, 0xc2, 0x2d, 0x3f, 0x9a, 0x8d, 0xb0, 0x1f, 0xe4, 0x72,
+                0xaf, 0x34, 0x1f, 0x60, 0xb1, 0x24, 0x88, 0x8c, 0x33, 0x0d, 0xd6, 0xd3, 0x5c, 0xb3, 0xa7, 0xcc,
+                0xd3, 0x62, 0xb2, 0x67, 0x17, 0x5d, 0xe6, 0x7a, 0x99, 0x12, 0x2c, 0x06, 0xa9, 0xce, 0xbe, 0xa9,
+                0xbb, 0xa3, 0x89, 0x26, 0x45, 0x1a, 0xcf, 0xef, 0x69, 0xd0, 0x22, 0x4a, 0x8f, 0xd6, 0x07, 0xed,
+                0x24, 0xca, 0xfe, 0xbb, 0x7e, 0x31, 0x5f, 0xe0, 0x7d, 0x5e, 0x59, 0x40, 0x21, 0x5f, 0x29, 0xfb,
+                0x6f, 0x8f, 0xe5, 0x3b, 0xaa, 0xe4, 0x45, 0x51, 0xa0, 0x37, 0x0a, 0x20, 0xc0, 0x93, 0xb5, 0x46,
+                0x7f, 0xf3, 0x48, 0x20, 0x69, 0xcb, 0x46, 0x0a, 0x10, 0xa1, 0x49, 0xed, 0xc8, 0x60, 0xa4, 0xc9,
+                0xe9, 0x91, 0x15, 0x2a, 0xf0, 0xdc, 0x38, 0x2a, 0x5e, 0xe1, 0xb8, 0xa9, 0xad, 0x31, 0x96, 0x98,
+                0xc3, 0xe0, 0x74, 0x61, 0xe9, 0x15, 0xb8, 0x6c, 0x4d, 0x37, 0x9c, 0xcc, 0xb6, 0x15, 0x32, 0xb3,
+                0x0c, 0x30, 0x8d, 0x15, 0xd6, 0x6e, 0x0b, 0x68, 0x80, 0x9c, 0x0d, 0xb5, 0xcd, 0xdc, 0x86, 0xcc,
+                0x98, 0xed, 0x1d, 0xc1, 0x67, 0x31, 0x80, 0x7a, 0x17, 0x26, 0x7e, 0x57, 0x0e, 0xd4, 0x52, 0xc1,
+                0xac, 0x29, 0x60, 0x36, 0x28, 0xe9, 0x5b, 0x3e, 0x87, 0x81, 0x46, 0xe5, 0x78, 0xa9, 0xdb, 0x42,
+                0xcc, 0x2a, 0x70, 0x8a, 0x8e, 0x91, 0xe3, 0xbf, 0x48, 0x77, 0x66, 0x52, 0x46, 0x41, 0x8b, 0xc0,
+                0x83, 0x9a, 0x43, 0xfb, 0xdf, 0xeb, 0x34, 0x10, 0x0c, 0x3f, 0x42, 0x0c, 0xa6, 0xec, 0x27, 0xff,
+                0xb0, 0xb4, 0x5c, 0x17, 0x8d, 0x91, 0x2f, 0x07, 0x56, 0x78, 0xfa, 0x0a, 0xfb, 0x27, 0x83, 0x65,
+                0xb5, 0xe9, 0x8c, 0xe3, 0x2d, 0x08, 0x34, 0xde, 0xcc, 0x51, 0x45, 0xb3, 0x47, 0x4b, 0x05, 0xbb,
+                0xaf, 0xcb, 0xac, 0x62, 0x73, 0xd7, 0x0e, 0x78, 0x57, 0xc5, 0x8d, 0xbe, 0x91, 0x23, 0xe0, 0xce,
+                0xeb, 0x6b, 0x54, 0x72, 0x77, 0x45, 0x10, 0xec, 0xfb, 0x08, 0x42, 0x77, 0x56, 0xa4, 0x5e, 0x50,
+                0x6f, 0x77, 0xc5, 0xa8, 0x4f, 0x2f, 0xfd, 0x5a, 0xa5, 0x06, 0xdc, 0xdc, 0x17, 0xb3, 0x33, 0x1c,
+                0x94, 0x86, 0x2e, 0xca, 0x28, 0x50, 0x49, 0xb9, 0x17, 0x9a, 0x01, 0x2d, 0xc8, 0x70, 0x0a, 0x79,
+                0x24, 0xba, 0x7c, 0x65, 0x52, 0x85, 0x3a, 0x17, 0x91, 0x95, 0xb2, 0xb9, 0xbe, 0x90, 0xcb, 0x95,
+                0x71, 0x14, 0xc6, 0xb2, 0x50, 0xe8, 0xe9, 0x33, 0x77, 0x4f, 0xea, 0x7e, 0x27, 0x3f, 0x16, 0x08,
+                0x07, 0x3f, 0x44, 0xce, 0xbf, 0x64, 0x06, 0xf9, 0xa3, 0x6b, 0x32, 0x36, 0x5f, 0x84, 0x23, 0x13,
+                0x07, 0x55, 0x79, 0x5f, 0xb6, 0x67, 0x24, 0x04, 0x53, 0x1f, 0x44, 0xeb, 0xa9, 0xd7, 0xad, 0xe1,
+                0x1a, 0x0f, 0xb7, 0x55, 0x54, 0x03, 0xad, 0x76, 0xfd, 0xc6, 0xf6, 0x8a, 0x84, 0xb1, 0x3f, 0xd4,
+                0x1b, 0x52, 0x3e, 0xdc, 0xd9, 0x65, 0x95, 0x07, 0xd6, 0xfd, 0xc4, 0x97, 0x82, 0x63, 0x64, 0xcd,
+                0xd6, 0xc7, 0xd9, 0x25, 0xa8, 0x1f, 0x72, 0x04, 0xdc, 0x51, 0xd3, 0x9c, 0x89, 0x66, 0x63, 0xa9,
+                0xd3, 0x60, 0xaa, 0x50, 0xfa, 0x2f, 0xaf, 0x52, 0xc7, 0xa1, 0x8f, 0x81, 0x28, 0x6a, 0x8f, 0xe5,
+        ]);
+        /*
+        zome.code = Arc::new(hex!("
+            40 35 e0 39 a6 27 8a 62 9f a8 2b 2b 7e bb ed db
+            b0 90 01 f4 07 a6 e2 d5 d1 30 1f e8 77 1b f0 08
+            14 0b 09 f3 fc ec 1f 76 3e cd 94 e0 e3 bc e6 e4
+            36 d1 7e 77 d7 c4 89 8d 6f 78 9d 0b ba a4 53 c7
+            37 76 d1 f8 5e 62 29 c2 2d 3f 9a 8d b0 1f e4 72
+            af 34 1f 60 b1 24 88 8c 33 0d d6 d3 5c b3 a7 cc
+            d3 62 b2 67 17 5d e6 7a 99 12 2c 06 a9 ce be a9
+            bb a3 89 26 45 1a cf ef 69 d0 22 4a 8f d6 07 ed
+            24 ca fe bb 7e 31 5f e0 7d 5e 59 40 21 5f 29 fb
+            6f 8f e5 3b aa e4 45 51 a0 37 0a 20 c0 93 b5 46
+            7f f3 48 20 69 cb 46 0a 10 a1 49 ed c8 60 a4 c9
+            e9 91 15 2a f0 dc 38 2a 5e e1 b8 a9 ad 31 96 98
+            c3 e0 74 61 e9 15 b8 6c 4d 37 9c cc b6 15 32 b3
+            0c 30 8d 15 d6 6e 0b 68 80 9c 0d b5 cd dc 86 cc
+            98 ed 1d c1 67 31 80 7a 17 26 7e 57 0e d4 52 c1
+            ac 29 60 36 28 e9 5b 3e 87 81 46 e5 78 a9 db 42
+            cc 2a 70 8a 8e 91 e3 bf 48 77 66 52 46 41 8b c0
+            83 9a 43 fb df eb 34 10 0c 3f 42 0c a6 ec 27 ff
+            b0 b4 5c 17 8d 91 2f 07 56 78 fa 0a fb 27 83 65
+            b5 e9 8c e3 2d 08 34 de cc 51 45 b3 47 4b 05 bb
+            af cb ac 62 73 d7 0e 78 57 c5 8d be 91 23 e0 ce
+            eb 6b 54 72 77 45 10 ec fb 08 42 77 56 a4 5e 50
+            6f 77 c5 a8 4f 2f fd 5a a5 06 dc dc 17 b3 33 1c
+            94 86 2e ca 28 50 49 b9 17 9a 01 2d c8 70 0a 79
+            24 ba 7c 65 52 85 3a 17 91 95 b2 b9 be 90 cb 95
+            71 14 c6 b2 50 e8 e9 33 77 4f ea 7e 27 3f 16 08
+            07 3f 44 ce bf 64 06 f9 a3 6b 32 36 5f 84 23 13
+            07 55 79 5f b6 67 24 04 53 1f 44 eb a9 d7 ad e1
+            1a 0f b7 55 54 03 ad 76 fd c6 f6 8a 84 b1 3f d4
+            1b 52 3e dc d9 65 95 07 d6 fd c4 97 82 63 64 cd
+            d6 c7 d9 25 a8 1f 72 04 dc 51 d3 9c 89 66 63 a9
+            d3 60 aa 50 fa 2f af 52 c7 a1 8f 81 28 6a 8f e5
+            8d 95 f4 4d 27 45 07 9c f7 26 8d 41 45 28 72 5d
+            7b 90 6f 8b 81 84 c6 47 2a e5 91 c3 9a 84 81 52
+            cc c3 b7 6d 8f 94 59 d6 0d eb eb 80 08 52 fc 51
+            fb e8 77 76 f2 d6 af c6 14 01 43 72 18 f3 9d bd
+            36 ff c5 04 0f 91 25 82 2a c8 53 12 42 15 9a f7
+            46 08 d4 34 22 a4 e4 29 73 d6 6e 86 57 60 e4 ae
+            74 c9 13 ef c9 fd 25 07 1d 9d 26 44 07 94 03 73
+            ab ee df a1 1b ad 19 1c 3a f2 1a 9b 65 ca 80 6a
+            28 02 9c bd 41 d8 49 f1 79 7a 24 ab 28 03 2b 84
+            93 81 33 34 89 00 0a 16 a2 ef fa e2 3a dc b0 21
+            08 b1 01 0f 2c e4 4e e9 6e 36 09 76 11 4d e1 3c
+            6a d4 87 0b e4 cf 51 f9 31 b8 0f 9c bb 4d cc 79
+            5c de 8d 3b 04 17 9a dd 71 38 17 5b 63 70 46 58
+            50 85 d8 8d 03 98 ad 1c d0 4a 18 ea 4b 89 25 06
+            b8 e3 f7 3a 74 2b a2 7a 3a 8b 74 1c e3 eb 66 44
+            84 d8 44 8e c3 22 18 7d f7 97 bc c0 5e d6 59 00
+            7b ce c6 7c 36 d5 03 ee 92 b7 87 8a 76 46 42 59
+            fb ec 18 7a fb dc e8 55 e5 7d 69 e2 3b e3 a6 be
+            3a af 06 ec 56 25 14 bc 32 26 7b f6 9a d4 9d a0
+            5e 7a 98 23 21 3b 2e ec c1 bb 17 81 5d d1 8c e9
+            c8 44 04 8f 8a 91 37 36 d6 c2 a9 c0 b4 32 48 f3
+            c6 d1 70 df 13 a0 3b b4 ee 40 66 5d c4 c5 77 7f
+            1f 9a 53 57 f4 b3 d5 05 3d b7 ef 19 bf 13 85 e3
+            af f2 c8 ae 95 4e a4 5d 69 7f 04 82 7b f7 c0 0f
+            50 33 6b 77 0a b0 7f e9 96 ab 7c a5 10 17 d2 94
+            36 dd cb 1d f9 1b 41 1d 6f c0 a7 58 a3 c2 42 40
+            c4 83 cb c6 ef 5c 3d 71 2b c1 44 e9 85 ed 80 42
+            d5 de 20 c9 2c 82 24 b6 52 93 b7 c7 12 8f 65 34
+            43 87 08 23 0e 57 ca 19 c0 4e 1f d0 1a 7a 29 aa
+            8f 81 c0 49 70 d6 55 5b bb bd 1e 69 23 08 ba 86
+            38 2d 53 07 16 ef 8b 10 e1 13 a0 99 d7 15 26 6d
+            63 65 41 23 df bb d4 0f b4 77 1b 8b d8 ff 49 64
+            83 3b c8 38 b6 a5 a2 1b 7d 9e 59 36 de 2a ba ea
+            6c f1 a6 e9 f0 92 31 99 32 04 5a 7f ea e9 74 7f
+            17 d0 3e 2f a4 1e 85 19 3d 42 23 6d be be fc d1
+            a5 18 87 bd 5f dc 94 d9 eb 9e 2b 9d a4 4d 78 87
+            de c0 dc 9e 99 43 f6 83 8f a9 df 78 58 b3 c2 56
+            c3 15 b6 ef 1a 00 23 7b 94 c6 48 8a 1e 17 18 a9
+            10 dd 45 ce a2 e4 e0 76 f9 30 9f 41 a1 69 d3 57
+            b8 3a f4 c1 43 03 32 ba 8e a2 98 31 5d 13 de eb
+            4c d7 c9 62 31 87 8b 3b 7d 17 bd 78 bb 98 59 08
+            de 94 c7 34 9c d1 0a 8b 03 36 b3 4f 9b e5 62 6e
+            8f 0a 8a d5 38 22 d0 f0 41 cb 78 6e e2 95 2a f1
+            fb f3 95 d7 a7 87 26 49 a3 f8 6d cc 96 7f 37 f9
+            9f 38 91 6e 7f 32 24 37 8f 5e 9b e0 aa f9 fb c0
+            29 01 e8 7c ee 03 64 46 80 1e 15 4b c7 55 60 3b
+            7c 0b 13 2b 4b 06 ee eb fa 92 7c ff b1 38 5e 13
+            ca 15 86 e3 dd 15 04 a6 df 69 3a 7c 0d 04 03 04
+        "));
+        */
+
+        let expected_big_wasm = "{\"description\":\"\",\"config\":{},\"entry_types\":{\"foo\":{\"properties\":\"{}\",\"sharing\":\"public\",\"links_to\":[],\"linked_from\":[]}},\"traits\":{},\"fn_declarations\":[],\"code\":{\"code\":[\"H4sIAAAAAAAA/wEAAv/9QDXgOaYnimKfqCsrfrvt27CQAfQHpuLV0TAf6Hcb8AgUCwnz/Owfdj7NlODjvObkNtF+d9fEiY1veJ0LuqRTxzd20fheYinCLT+ajbAf5HKv\",\"NB9gsSSIjDMN1tNcs6fM02KyZxdd5nqZEiwGqc6+qbujiSZFGs/vadAiSo/WB+0kyv67fjFf4H1eWUAhXyn7b4/lO6rkRVGgNwogwJO1Rn/zSCBpy0YKEKFJ7chgpMnp\",\"kRUq8Nw4Kl7huKmtMZaYw+B0YekVuGxNN5zMthUyswwwjRXWbgtogJwNtc3chsyY7R3BZzGAehcmflcO1FLBrClgNijpWz6HgUbleKnbQswqcIqOkeO/SHdmUkZBi8CD\",\"mkP73+s0EAw/Qgym7Cf/sLRcF42RLwdWePoK+yeDZbXpjOMtCDTezFFFs0dLBbuvy6xic9cOeFfFjb6RI+DO62tUcndFEOz7CEJ3VqReUG93xahPL/1apQbc3BezMxyU\",\"hi7KKFBJuReaAS3IcAp5JLp8ZVKFOheRlbK5vpDLlXEUxrJQ6Okzd0/qfic/FggHP0TOv2QG+aNrMjZfhCMTB1V5X7ZnJARTH0Trqdet4RoPt1VUA612/cb2ioSxP9Qb\",\"Uj7c2WWVB9b9xJeCY2TN1sfZJagfcgTcUdOciWZjqdNgqlD6L69Sx6GPgShqj+WBTIVcAAIAAA==\"]},\"bridges\":[]}";
+
+        assert_eq!(
+            JsonString::from_json(expected_big_wasm),
+            JsonString::from(zome.clone()),
+        );
+        assert_eq!(
+            zome,
+            Zome::try_from(JsonString::from_json(expected_big_wasm)).unwrap(),
         );
     }
 

--- a/crates/core_types/src/lib.rs
+++ b/crates/core_types/src/lib.rs
@@ -58,6 +58,7 @@ pub mod ugly;
 pub mod validation;
 #[macro_use]
 extern crate holochain_logging;
+extern crate flate2;
 
 pub const HDK_HASH: &str = env!(
     "HDK_HASH",


### PR DESCRIPTION
## PR summary

Output .dna.json files are unwieldy and large, because WASM is output as a single base-64 encoded String.   It is difficult to view .dna.json files in pagination utilities (eg. `less`), due to  the extreme length of the WASM String.  Produces, instead, something like (with 128-symbol Strings of base-64, instead of a 6 Megabyte single String):

```
{
  ...,
  "zomes": {
    "transactions": {
      "code": {  ...
        "code": [
          "Abc..XyZ",
          "..."
          "Qrs="
        ]
      } 
    }
  }
}
```

Also, since WASM contains much redundancy, Gzip-encoding yields ~75% reduction in sizes.

Serializes to a list of Strings, instead of just a big String; small Zomes (< ~4KB) still round-trip to a single String.

Historical single String (eg. `{ "code": "AbC...XyZ==" }`) WASM will load fine, but will *not* produce an equivalent `hc hash`.  Since `hc hash` was broken until recently, this should be fine; all future `DnaWasm`s serialized will produce consistent `hc package` and `hc hash` hashes.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
