### PR TITLE
fix macos tls in-stream dev certificate generation

### DIFF
--- a/crates/in_stream/src/tls/certificate.rs
+++ b/crates/in_stream/src/tls/certificate.rs
@@ -70,12 +70,12 @@ impl TlsCertificate {
         let (key, cert) = generate_dev();
 
         let pkcs12 = openssl::pkcs12::Pkcs12::builder()
-            .build("", "in_stream_tls", &*key, &cert)
+            .build("dev-passphrase", "in_stream_tls", &*key, &cert)
             .unwrap();
 
         Self {
             pkcs12_data: pkcs12.to_der().unwrap(),
-            passphrase: "".to_string(),
+            passphrase: "dev-passphrase".to_string(),
         }
     }
 


### PR DESCRIPTION
macos apparently doesn't like empty string passphrases for tls certificates : )