### PR TITLE
Cache and retry failed wire messages in Sim2hWorker

### DIFF
--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -382,8 +382,9 @@ impl NetWorker for Sim2hWorker {
                 if self.time_of_last_connection_attempt.elapsed() > RECONNECT_INTERVAL {
                     self.time_of_last_connection_attempt = Instant::now();
                     warn!("No connection to sim2h server. Trying to reconnect...");
-                    self.stream_manager
-                        .connect(&self.server_url.clone().into())?;
+                    if let Err(e) = self.stream_manager.connect(&self.server_url.clone().into()) {
+                        error!("TransportError trying to connect to sim2h server: {:?}", e);
+                    }
                 }
             }
             ConnectionStatus::Initializing => debug!("connecting..."),

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -402,6 +402,8 @@ impl NetWorker for Sim2hWorker {
         let client_messages = self.inbox.drain(..).collect::<Vec<_>>();
         for data in client_messages {
             debug!("CORE >> Sim2h: {:?}", data);
+            // outgoing messages triggered by `self.hand_client_message` that fail because of
+            // connection status, will automatically be re-sent via `self.outgoing_failed_messages`
             if let Err(error) = self.handle_client_message(data) {
                 error!("Error handling client message in Sim2hWorker: {:?}", error);
             }


### PR DESCRIPTION
## PR summary

What happened before:
If we are offline (i.e. don't have connection to the sim2h server) the sim2h worker would not process its inbox and thus would not generate any new messages to be sent.

But:
if the sending of a wire message failed we would have lost that message.
And if a connection would break up, we most likely would realise that by trying to send and getting an error. So there was a high-chance that connection issues would actually lead to message/data loss which could lead to all sorts of problems.

Now:
If we get a `TransportError` during send, we are caching the message and once we have a connection again, we are processing all cached messages.

We are now also processing the inbox even if offline.
* This makes sense because we currently still process queries locally anyway and also create a store message for every publish locally. Before we wouldn't do this when offline which would have resulted in not seeing local data until we reconnect again
* If the processing of those inbox messages leads to messages to be sent to sim2h, that is not a problem any more since those message will get chached.

## testing/benchmarking notes

There is no test for this in this PR. The only way to proper test this is to simulate connection drops, for which we have another ticket. Maybe that should be done within this PR?

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
