### PR TITLE
Use regex style filter for cloudwatch log queries, handle missing statistics gracefully

### DIFF
--- a/crates/metrics/src/cloudwatch.rs
+++ b/crates/metrics/src/cloudwatch.rs
@@ -91,7 +91,7 @@ impl CloudWatchLogger {
         if let Some(log_stream_pat) = &query_args.log_stream_pat {
             query_string =
                 format!(
-                "fields @message, @logStream | filter @message like '{}' and @logStream like '{}'",
+                "fields @message, @logStream | filter @message like '{}' and @logStream like /{}/",
                 logger::METRIC_TAG, log_stream_pat);
         } else {
             query_string = format!(

--- a/crates/metrics/src/stats.rs
+++ b/crates/metrics/src/stats.rs
@@ -318,7 +318,7 @@ pub trait StatCheck {
                 let result = if let Some(actual_stat) = actual.get(grouping_key) {
                     self.check(expected_stat, actual_stat)
                 } else {
-                    panic!("No stat name") // TODO Better error handling
+                    self.check(expected_stat, &StatsRecord::default())
                 };
                 (grouping_key.clone(), result)
             },


### PR DESCRIPTION
## PR summary

Changes the `holochain_metrics` command to take regular expressions rather than a fixed string when querying the log stream parameter.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
