### PR TITLE
make sim2h not use all the cpu

### DIFF
--- a/crates/sim2h/src/job.rs
+++ b/crates/sim2h/src/job.rs
@@ -1,10 +1,36 @@
 /// typedef for code clarity
-pub(crate) type JobContinue = bool;
+pub(crate) struct JobResult {
+    pub(crate) cont: bool,
+    pub(crate) wait_ms: u64,
+}
+
+impl Default for JobResult {
+    fn default() -> Self {
+        Self {
+            cont: true,
+            wait_ms: 0,
+        }
+    }
+}
+
+impl JobResult {
+    pub(crate) fn done() -> Self {
+        Self {
+            cont: false,
+            wait_ms: 0,
+        }
+    }
+
+    pub(crate) fn wait_ms(mut self, wait_ms: u64) -> Self {
+        self.wait_ms = wait_ms;
+        self
+    }
+}
 
 /// an item that can be executed via thread pool
 pub(crate) trait Job: 'static + Send {
     /// execute one iteration of this job - try to be as short-lived as possible
-    fn run(&mut self) -> JobContinue;
+    fn run(&mut self) -> JobResult;
 }
 
 mod pool;

--- a/crates/sim2h/src/job/tick.rs
+++ b/crates/sim2h/src/job/tick.rs
@@ -2,30 +2,17 @@ use crate::*;
 
 /// a job that prints a debug trace line once per second
 /// indicating that the thread pool is still processing jobs
-pub(crate) struct Tick {
-    next_tick: std::time::Instant,
-}
+pub(crate) struct Tick;
 
 impl Tick {
     pub(crate) fn new() -> Self {
-        Self {
-            next_tick: std::time::Instant::now()
-                .checked_add(std::time::Duration::from_secs(1))
-                .expect("failed to add 1 second"),
-        }
+        Self
     }
 }
 
 impl Job for Arc<Mutex<Tick>> {
-    fn run(&mut self) -> JobContinue {
-        let now = std::time::Instant::now();
-        let mut me = self.f_lock();
-        if now >= me.next_tick {
-            me.next_tick = now
-                .checked_add(std::time::Duration::from_secs(1))
-                .expect("failed to add 1 second");
-            trace!("sim2h job loop - 1 second tick");
-        }
-        true
+    fn run(&mut self) -> JobResult {
+        trace!("sim2h job loop - 1 second tick");
+        JobResult::default().wait_ms(1000)
     }
 }


### PR DESCRIPTION
This isn't 100% ideal

We could switch the underlying in_stream sockets to be based on mio and get the epoll/iocp benefits - which we may want to do anyway, at least to get named sockets on windows as the analog on that platform for unix domain sockets.

However, in the short-term, this lowers the idle cpu usage of sim2h_server from ~800% on my 8 core system to ~40% without sacrificing any of the fully loaded stress test performance.