### PR TITLE
Cli sim2h

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 {{ version-heading }}
 
 ### Added
-
+- Adds support for sim2h with hc run by calling `hc run --networked sim2h --sim2h-server wss://localhost:9000`.
 - Adds support for [hApp-bundles](https://github.com/holochain/holoscape/tree/master/example-bundles) to `hc run`. This enables complex hApp setups with multiple DNAs and bridges to be easily run during development without having to write/maintain a conductor config file. [#1939](https://github.com/holochain/holochain-rust/pull/1939)
 - Adds ability to validate entries with full chain validation when author is offline [#1932](https://github.com/holochain/holochain-rust/pull/1932)
 - Adds a conductor level stats-signal that sends an overview of instance data (number of held entries etc.) over admin interfaces. [#1954](https://github.com/holochain/holochain-rust/pull/1954)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "holochain_dpki 0.0.40-alpha1",
  "holochain_json_api 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_locksmith 0.0.40-alpha1",
+ "holochain_net 0.0.40-alpha1",
  "holochain_persistence_api 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_persistence_file 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_wasm_utils 0.0.40-alpha1",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ holochain_core_types = { version = "=0.0.40-alpha1", path = "../core_types" }
 holochain_core = { version = "=0.0.40-alpha1", path = "../core" }
 holochain_common = { version = "=0.0.40-alpha1", path = "../common" }
 holochain_conductor_lib = { version = "=0.0.40-alpha1", path = "../conductor_lib" }
+holochain_net = { version = "=0.0.40-alpha1", path = "../net" }
 holochain_dpki = { version = "=0.0.40-alpha1", path = "../dpki" }
 holochain_locksmith = { version = "=0.0.40-alpha1", path = "../locksmith" }
 lib3h_sodium = "=0.0.25"

--- a/crates/cli/src/cli/run.rs
+++ b/crates/cli/src/cli/run.rs
@@ -10,9 +10,16 @@ use holochain_conductor_lib::{
     keystore::PRIMARY_KEYBUNDLE_ID,
     logger::LogRules,
 };
+use holochain_net::sim2h_worker::Sim2hConfig;
 use holochain_core_types::agent::AgentId;
 use holochain_persistence_api::cas::content::AddressableContent;
 use std::{fs, path::PathBuf};
+use crate::NetworkingType;
+
+pub enum Networking {
+    N3h,
+    Sim2h(String)
+}
 
 /// Starts a minimal configuration Conductor with the current application running
 pub fn run(
@@ -77,7 +84,7 @@ pub fn hc_run_configuration(
     dna_path: &PathBuf,
     port: u16,
     persist: bool,
-    networked: bool,
+    networked: Option<Networking>,
     interface_type: &String,
     logging: bool,
 ) -> DefaultResult<Configuration> {
@@ -96,7 +103,7 @@ pub fn hc_run_bundle_configuration(
     bundle: &HappBundle,
     port: u16,
     persist: bool,
-    networked: bool,
+    networked: Option<Networking>,
     logging: bool,
 ) -> DefaultResult<Configuration> {
     bundle
@@ -228,37 +235,53 @@ fn logger_configuration(logging: bool) -> LoggerConfiguration {
 }
 
 // NETWORKING
-fn networking_configuration(networked: bool) -> Option<NetworkConfig> {
+fn networking_configuration(networked: Option<Networking>) -> Option<NetworkConfig> {
     // create an n3h network config if the --networked flag is set
-    if !networked {
-        return None;
-    }
-
-    // note that this behaviour is documented within
-    // holochain_common::env_vars module and should be updated
-    // if this logic changes
-    let mut bootstrap_nodes = Vec::new();
-    if let Ok(node) = EnvVar::N3hBootstrapNode.value() {
-        bootstrap_nodes.push(node);
+    let networked = match networked {
+        Some(n) => n,
+        None => return None,
     };
 
-    Some(NetworkConfig::N3h(N3hConfig {
-        bootstrap_nodes,
-        n3h_log_level: EnvVar::N3hLogLevel
-            .value()
-            .ok()
-            .unwrap_or_else(default_n3h_log_level),
-        n3h_mode: EnvVar::N3hMode
-            .value()
-            .ok()
-            .unwrap_or_else(default_n3h_mode),
-        n3h_persistence_path: EnvVar::N3hWorkDir
-            .value()
-            .ok()
-            .unwrap_or_else(default_n3h_persistence_path),
-        n3h_ipc_uri: Default::default(),
-        networking_config_file: EnvVar::NetworkingConfigFile.value().ok(),
-    }))
+    match networked {
+        Networking::N3h => {
+            // note that this behaviour is documented within
+            // holochain_common::env_vars module and should be updated
+            // if this logic changes
+            let mut bootstrap_nodes = Vec::new();
+            if let Ok(node) = EnvVar::N3hBootstrapNode.value() {
+                bootstrap_nodes.push(node);
+            };
+
+            Some(NetworkConfig::N3h(N3hConfig {
+                bootstrap_nodes,
+                n3h_log_level: EnvVar::N3hLogLevel
+                    .value()
+                    .ok()
+                    .unwrap_or_else(default_n3h_log_level),
+                n3h_mode: EnvVar::N3hMode
+                    .value()
+                    .ok()
+                    .unwrap_or_else(default_n3h_mode),
+                n3h_persistence_path: EnvVar::N3hWorkDir
+                    .value()
+                    .ok()
+                    .unwrap_or_else(default_n3h_persistence_path),
+                n3h_ipc_uri: Default::default(),
+                networking_config_file: EnvVar::NetworkingConfigFile.value().ok(),
+            }))
+
+        }
+        Networking::Sim2h(sim2h_url) => Some(NetworkConfig::Sim2h(Sim2hConfig{sim2h_url})),
+    }
+}
+
+impl Networking {
+    pub fn new(networking_type: NetworkingType, sim2h_url: String) -> Self {
+        match networking_type {
+            NetworkingType::N3h => Self::N3h,
+            NetworkingType::Sim2h => Self::Sim2h(sim2h_url),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -269,9 +292,11 @@ mod tests {
     // use std::{env, process::Command, path::PathBuf};
     use self::tempfile::tempdir;
     use holochain_conductor_lib::config::*;
+    use holochain_net::sim2h_worker::Sim2hConfig;
     use holochain_core_types::dna::Dna;
     use holochain_persistence_api::cas::content::AddressableContent;
     use std::fs::{create_dir, File};
+    use super::Networking;
 
     #[test]
     // flagged as broken for:
@@ -412,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_networking_configuration() {
-        let networking = super::networking_configuration(true);
+        let networking = super::networking_configuration(Some(Networking::N3h));
         assert_eq!(
             networking,
             Some(NetworkConfig::N3h(N3hConfig {
@@ -424,8 +449,16 @@ mod tests {
                 networking_config_file: None,
             }))
         );
+        
+        let networking = super::networking_configuration(Some(Networking::Sim2h("wss://localhost:9000".into())));
+        assert_eq!(
+            networking,
+            Some(NetworkConfig::Sim2h(Sim2hConfig {
+                sim2h_url: "wss://localhost:9000".into()
+            }))
+        );
 
-        let no_networking = super::networking_configuration(false);
+        let no_networking = super::networking_configuration(None);
         assert!(no_networking.is_none());
     }
 }

--- a/crates/cli/src/cli/run.rs
+++ b/crates/cli/src/cli/run.rs
@@ -1,3 +1,4 @@
+use crate::NetworkingType;
 use cli;
 use colored::*;
 use error::DefaultResult;
@@ -10,15 +11,14 @@ use holochain_conductor_lib::{
     keystore::PRIMARY_KEYBUNDLE_ID,
     logger::LogRules,
 };
-use holochain_net::sim2h_worker::Sim2hConfig;
 use holochain_core_types::agent::AgentId;
+use holochain_net::sim2h_worker::Sim2hConfig;
 use holochain_persistence_api::cas::content::AddressableContent;
 use std::{fs, path::PathBuf};
-use crate::NetworkingType;
 
 pub enum Networking {
     N3h,
-    Sim2h(String)
+    Sim2h(String),
 }
 
 /// Starts a minimal configuration Conductor with the current application running
@@ -269,9 +269,8 @@ fn networking_configuration(networked: Option<Networking>) -> Option<NetworkConf
                 n3h_ipc_uri: Default::default(),
                 networking_config_file: EnvVar::NetworkingConfigFile.value().ok(),
             }))
-
         }
-        Networking::Sim2h(sim2h_url) => Some(NetworkConfig::Sim2h(Sim2hConfig{sim2h_url})),
+        Networking::Sim2h(sim2h_url) => Some(NetworkConfig::Sim2h(Sim2hConfig { sim2h_url })),
     }
 }
 
@@ -291,12 +290,12 @@ mod tests {
     // use assert_cmd::prelude::*;
     // use std::{env, process::Command, path::PathBuf};
     use self::tempfile::tempdir;
+    use super::Networking;
     use holochain_conductor_lib::config::*;
-    use holochain_net::sim2h_worker::Sim2hConfig;
     use holochain_core_types::dna::Dna;
+    use holochain_net::sim2h_worker::Sim2hConfig;
     use holochain_persistence_api::cas::content::AddressableContent;
     use std::fs::{create_dir, File};
-    use super::Networking;
 
     #[test]
     // flagged as broken for:
@@ -449,8 +448,9 @@ mod tests {
                 networking_config_file: None,
             }))
         );
-        
-        let networking = super::networking_configuration(Some(Networking::Sim2h("wss://localhost:9000".into())));
+
+        let networking =
+            super::networking_configuration(Some(Networking::Sim2h("wss://localhost:9000".into())));
         assert_eq!(
             networking,
             Some(NetworkConfig::Sim2h(Sim2hConfig {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -36,8 +36,7 @@ mod util;
 use crate::error::{HolochainError, HolochainResult};
 use holochain_conductor_lib::happ_bundle::HappBundle;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
-use structopt::clap::arg_enum;
-use structopt::StructOpt;
+use structopt::{clap::arg_enum, StructOpt};
 
 #[derive(StructOpt)]
 /// A command line for Holochain

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -85,10 +85,10 @@ enum Cli {
         /// Save generated data to file system
         persist: bool,
         #[structopt(long, possible_values = &NetworkingType::variants(), case_insensitive = true)]
-        /// Use real networking
+        /// Use real networking use: n3h/sim2h
         networked: Option<NetworkingType>,
         #[structopt(long, default_value = "wss://localhost:9000")]
-        /// Set the sim2h server url if you are using real networking. [default: wss://localhost:9000]
+        /// Set the sim2h server url if you are using real networking.
         sim2h_server: String,
         #[structopt(long, short, default_value = "websocket")]
         /// Specify interface type to use: websocket/http

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ extern crate holochain_common;
 extern crate holochain_conductor_lib;
 extern crate holochain_core;
 extern crate holochain_core_types;
+extern crate holochain_net;
 extern crate holochain_json_api;
 extern crate holochain_locksmith;
 extern crate holochain_persistence_api;
@@ -36,6 +37,7 @@ use crate::error::{HolochainError, HolochainResult};
 use holochain_conductor_lib::happ_bundle::HappBundle;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
+use structopt::clap::arg_enum;
 
 #[derive(StructOpt)]
 /// A command line for Holochain
@@ -82,9 +84,12 @@ enum Cli {
         #[structopt(long)]
         /// Save generated data to file system
         persist: bool,
-        #[structopt(long)]
+        #[structopt(long, possible_values = &NetworkingType::variants(), case_insensitive = true)]
         /// Use real networking
-        networked: bool,
+        networked: Option<NetworkingType>,
+        #[structopt(long, default_value = "wss://localhost:9000")]
+        /// Set the sim2h server url if you are using real networking. [default: wss://localhost:9000]
+        sim2h_server: String,
         #[structopt(long, short, default_value = "websocket")]
         /// Specify interface type to use: websocket/http
         interface: String,
@@ -142,6 +147,13 @@ enum Cli {
         property: Option<Vec<String>>,
     },
 }
+arg_enum! {
+    #[derive(Debug)]
+    pub enum NetworkingType {
+        N3h,
+        Sim2h,
+    }
+}
 
 fn main() {
     lib3h_sodium::check_init();
@@ -198,6 +210,7 @@ fn run() -> HolochainResult<()> {
             dna_path,
             persist,
             networked,
+            sim2h_server,
             interface,
             logging,
         } => {
@@ -206,6 +219,7 @@ fn run() -> HolochainResult<()> {
             let interface_type = cli::get_interface_type_string(interface);
 
             let bundle_path = project_path.join("bundle.toml");
+            let networked = networked.map(|n| cli::run::Networking::new(n, sim2h_server));
             let conductor_config = if bundle_path.exists() {
                 let mut f = File::open(bundle_path)
                     .map_err(|e| HolochainError::Default(format_err!("{}", e)))?;
@@ -222,7 +236,7 @@ fn run() -> HolochainResult<()> {
                     &dna_path,
                     port,
                     persist,
-                    networked,
+                    networked.into(),
                     &interface_type,
                     logging,
                 )

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,9 +3,9 @@ extern crate holochain_common;
 extern crate holochain_conductor_lib;
 extern crate holochain_core;
 extern crate holochain_core_types;
-extern crate holochain_net;
 extern crate holochain_json_api;
 extern crate holochain_locksmith;
+extern crate holochain_net;
 extern crate holochain_persistence_api;
 extern crate holochain_persistence_file;
 extern crate json_patch;
@@ -36,8 +36,8 @@ mod util;
 use crate::error::{HolochainError, HolochainResult};
 use holochain_conductor_lib::happ_bundle::HappBundle;
 use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
-use structopt::StructOpt;
 use structopt::clap::arg_enum;
+use structopt::StructOpt;
 
 #[derive(StructOpt)]
 /// A command line for Holochain

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -235,7 +235,7 @@ fn run() -> HolochainResult<()> {
                     &dna_path,
                     port,
                     persist,
-                    networked.into(),
+                    networked,
                     &interface_type,
                     logging,
                 )


### PR DESCRIPTION
## PR summary
This adds the option to use sim2h to `hc run`
`--networked` now takes either N3h or Sim2h (case insensitive). If it's not set then it has the same behaviour as before.
There is an additional option --sim2h-server` which takes the address of the sim2h server. It defaults to `wss://localhost:9000`.

## testing/benchmarking notes
Added a test for the Sim2h option.

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog
This might be a breaking change as `hc run --networked` now needs a parameter.
- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation
The readme doesn't currently cover flags. Maybe it should?
- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
