### PR TITLE
Fast passphrase hashing

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - renamed `hc-conductor-wasm-install` to `hc-conductor-wasm-bindgen-install`
 - core `shellHook` can now override holonix `shellHook`
 - several `--target-dir` flags are removed in favour of `$CARGO_TARGET_DIR`
+- the passphrase hashing config is now set to faster and less secure parameters to reduce the start-up time of conductors a lot, esp. on slow devices. (will become a setting the user can choose in the future - faster and less secure config is fine for now and throughout alpha and beta) [#1986](https://github.com/holochain/holochain-rust/pull/1986)
 
 ### Deprecated
 

--- a/crates/conductor_lib/src/conductor/base.rs
+++ b/crates/conductor_lib/src/conductor/base.rs
@@ -63,6 +63,7 @@ use holochain_net::{
     p2p_config::{BackendConfig, P2pBackendKind, P2pConfig},
     p2p_network::P2pNetwork,
 };
+use crate::keystore::test_hash_config;
 
 pub const MAX_DYNAMIC_PORT: u16 = std::u16::MAX;
 
@@ -243,7 +244,7 @@ impl Conductor {
             p2p_config: None,
             network_spawn: None,
             passphrase_manager: Arc::new(PassphraseManager::new(passphrase_service)),
-            hash_config: None,
+            hash_config: test_hash_config(),
             n3h_keepalive_network: None,
         }
     }

--- a/crates/conductor_lib/src/conductor/base.rs
+++ b/crates/conductor_lib/src/conductor/base.rs
@@ -49,6 +49,7 @@ use crate::{
     },
     config::{AgentConfiguration, PassphraseServiceConfig},
     interface::{ConductorApiBuilder, InstanceMap, Interface},
+    keystore::test_hash_config,
     port_utils::get_free_port,
     signal_wrapper::SignalWrapper,
     static_file_server::ConductorStaticFileServer,
@@ -63,7 +64,6 @@ use holochain_net::{
     p2p_config::{BackendConfig, P2pBackendKind, P2pConfig},
     p2p_network::P2pNetwork,
 };
-use crate::keystore::test_hash_config;
 
 pub const MAX_DYNAMIC_PORT: u16 = std::u16::MAX;
 


### PR DESCRIPTION
## PR summary

Use the test config for the password hash to make it much faster.

The default config for the passphrase hashing is set to super-secure: the hashing algorithm is designed to take a serious amount of resources to prevent attacks against the keys if an attacker got hold of the encrypted keys but not the passphrase.

The problem with this is: starting Holoscape takes a long time. On slow machines it will trigger the 60 seconds timeout which then shows an error and opens the logs.

**Note:**
This is a breaking-change since it will break keys/passphrases: you can't decrypt a key that was created with the old config when starting a new conductor - the new hash config will result in a different hash.

This means users have to re-create keys with the new version this change gets in.

## testing/benchmarking notes

Tried in Holoscape: makes booting and installing hApps much faster since decrypting keys is the most time consuming task in both workflows.

## followups

Ultimately we should find the right balance of security and usability. But for now, as long as we are in alpha at least, we can configure the passphrase hashing to be very simple.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
