### PR TITLE
Move self-holding logic from core to Sim2h to fix consistency model problems

### DIFF
--- a/crates/conductor_lib/src/conductor/base.rs
+++ b/crates/conductor_lib/src/conductor/base.rs
@@ -2076,7 +2076,8 @@ pub mod tests {
     #[test]
     fn test_conductor_signal_handler() {
         let (signal_tx, signal_rx) = signal_channel();
-        let _conductor = test_conductor_with_signals(signal_tx);
+        let mut conductor = test_conductor_with_signals(signal_tx);
+        conductor.start_signal_multiplexer();
 
         test_utils::expect_action(&signal_rx, |action| match action {
             Action::InitializeChain(_) => true,

--- a/crates/conductor_lib/src/conductor/base.rs
+++ b/crates/conductor_lib/src/conductor/base.rs
@@ -455,7 +455,9 @@ impl Conductor {
             .interfaces
             .iter()
             .map(|ic| (ic.id.clone(), self.spawn_interface_thread(ic.clone())))
-            .collect()
+            .collect();
+
+        self.start_signal_multiplexer();
     }
 
     pub fn stop_all_interfaces(&mut self) {
@@ -812,8 +814,6 @@ impl Conductor {
                     .insert(id.clone(), Arc::new(RwLock::new(instance)));
             }
         }
-
-        self.start_signal_multiplexer();
 
         for ui_interface_config in self.config.ui_interfaces.clone() {
             notify(format!("adding ui interface {}", &ui_interface_config.id));

--- a/crates/core/src/network/handler/lists.rs
+++ b/crates/core/src/network/handler/lists.rs
@@ -139,9 +139,7 @@ pub fn handle_get_gossip_list(get_list_data: GetListData, context: Arc<Context>)
         let state = context
             .state()
             .expect("No state present when trying to respond with gossip list");
-        let authoring_map = create_authoring_map(context.clone());
-        let holding_map = state.dht().get_holding_map().clone();
-        let address_map = AspectMap::merge(authoring_map, holding_map);
+        let address_map = state.dht().get_holding_map().clone();
 
         let action = Action::RespondGossipList(EntryListData {
             space_address: get_list_data.space_address,

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -9,7 +9,7 @@ use holochain_conductor_lib_api::{ConductorApi, CryptoMethod};
 use holochain_json_api::{error::JsonError, json::JsonString};
 use holochain_metrics::{DefaultMetricPublisher, MetricPublisher};
 use lib3h_protocol::{
-    data_types::{GenericResultData, Opaque, SpaceData, StoreEntryAspectData},
+    data_types::{FetchEntryData, GenericResultData, Opaque, SpaceData, StoreEntryAspectData},
     protocol::*,
     protocol_client::Lib3hClientProtocol,
     protocol_server::Lib3hServerProtocol,
@@ -28,7 +28,6 @@ use sim2h::{
 };
 use std::{convert::TryFrom, time::Instant};
 use url::Url;
-use lib3h_protocol::data_types::FetchEntryData;
 
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(1);
 
@@ -233,14 +232,21 @@ impl Sim2hWorker {
                 //let log_context = "ClientToLib3h::HandleFetchEntryResult";
                 if fetch_entry_result_data.request_id == "SIM2H_WORKER" {
                     for aspect in fetch_entry_result_data.entry.aspect_list {
-                        self.to_core.push(Lib3hServerProtocol::HandleStoreEntryAspect(
-                            StoreEntryAspectData {
-                                request_id: "".into(),
-                                space_address: fetch_entry_result_data.space_address.clone(),
-                                provider_agent_id: fetch_entry_result_data.provider_agent_id.clone(),
-                                entry_address: fetch_entry_result_data.entry.entry_address.clone(),
-                                entry_aspect: aspect,
-                            }));
+                        self.to_core
+                            .push(Lib3hServerProtocol::HandleStoreEntryAspect(
+                                StoreEntryAspectData {
+                                    request_id: "".into(),
+                                    space_address: fetch_entry_result_data.space_address.clone(),
+                                    provider_agent_id: fetch_entry_result_data
+                                        .provider_agent_id
+                                        .clone(),
+                                    entry_address: fetch_entry_result_data
+                                        .entry
+                                        .entry_address
+                                        .clone(),
+                                    entry_aspect: aspect,
+                                },
+                            ));
                     }
                     Ok(())
                 } else {
@@ -298,15 +304,14 @@ impl Sim2hWorker {
             Lib3hClientProtocol::HandleGetAuthoringEntryListResult(entry_list_data) => {
                 //let log_context = "ClientToLib3h::HandleGetAuthoringEntryListResult";
                 for (entry_hash, aspect_hashes) in &entry_list_data.address_map {
-                    self.to_core.push(Lib3hServerProtocol::HandleFetchEntry(
-                        FetchEntryData {
+                    self.to_core
+                        .push(Lib3hServerProtocol::HandleFetchEntry(FetchEntryData {
                             space_address: entry_list_data.space_address.clone(),
                             entry_address: entry_hash.clone(),
                             request_id: String::from("SIM2H_WORKER"),
                             provider_agent_id: entry_list_data.provider_agent_id.clone(),
                             aspect_address_list: Some(aspect_hashes.clone()),
-                        }
-                    ))
+                        }))
                 }
                 self.send_wire_message(WireMessage::Lib3hToClientResponse(
                     Lib3hToClientResponse::HandleGetAuthoringEntryListResult(entry_list_data),

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -30,6 +30,7 @@ use std::{convert::TryFrom, time::Instant};
 use url::Url;
 
 const RECONNECT_INTERVAL: Duration = Duration::from_secs(1);
+const SIM2H_WORKER_INTERNAL_REQUEST_ID: &str = "SIM2H_WORKER";
 
 #[derive(Deserialize, Serialize, Clone, Debug, DefaultJson, PartialEq)]
 pub struct Sim2hConfig {
@@ -230,7 +231,7 @@ impl Sim2hWorker {
             // Successful data response for a `HandleFetchEntryData` request
             Lib3hClientProtocol::HandleFetchEntryResult(fetch_entry_result_data) => {
                 //let log_context = "ClientToLib3h::HandleFetchEntryResult";
-                if fetch_entry_result_data.request_id == "SIM2H_WORKER" {
+                if fetch_entry_result_data.request_id == SIM2H_WORKER_INTERNAL_REQUEST_ID {
                     for aspect in fetch_entry_result_data.entry.aspect_list {
                         self.to_core
                             .push(Lib3hServerProtocol::HandleStoreEntryAspect(
@@ -308,7 +309,7 @@ impl Sim2hWorker {
                         .push(Lib3hServerProtocol::HandleFetchEntry(FetchEntryData {
                             space_address: entry_list_data.space_address.clone(),
                             entry_address: entry_hash.clone(),
-                            request_id: String::from("SIM2H_WORKER"),
+                            request_id: SIM2H_WORKER_INTERNAL_REQUEST_ID.to_string(),
                             provider_agent_id: entry_list_data.provider_agent_id.clone(),
                             aspect_address_list: Some(aspect_hashes.clone()),
                         }))


### PR DESCRIPTION
## PR summary

These changes replace merging the authoring list into the gossip list with code in sim2h_worker that makes the instance hold everything it's authoring.

This has two benefits:
1. Always merging the authoring into the gossip list was the only code in core that assumes a full-sync DHT. We don't want that assumption in core - if we are in a full-sync or sharded DHT should be only sim2h's concern.
2. By having core hold it's own entries explicitly we are true to the assumption in Hachiko - namely that we can tell by the core action `HoldAspect` if a node is holding something.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
