### PR TITLE
add support for setting agent_id

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 {{ version-heading }}
 
 ### Added
+- Adds support for setting the agent name and id via a parameter with hc run by calling `hc run --agent-name MyAgentName`. The `%agent_id` is generated from the name. This allows multiple hc run conductors to be used on the same machine. It will be overwritten by the `HC_AGENT` environment variable.
 - Adds support for sim2h with hc run by calling `hc run --networked sim2h --sim2h-server wss://localhost:9000`.
 - Adds support for [hApp-bundles](https://github.com/holochain/holoscape/tree/master/example-bundles) to `hc run`. This enables complex hApp setups with multiple DNAs and bridges to be easily run during development without having to write/maintain a conductor config file. [#1939](https://github.com/holochain/holochain-rust/pull/1939)
 - Adds ability to validate entries with full chain validation when author is offline [#1932](https://github.com/holochain/holochain-rust/pull/1932)

--- a/crates/cli/src/cli/run.rs
+++ b/crates/cli/src/cli/run.rs
@@ -87,9 +87,10 @@ pub fn hc_run_configuration(
     networked: Option<Networking>,
     interface_type: &String,
     logging: bool,
+    agent_name: String,
 ) -> DefaultResult<Configuration> {
     Ok(Configuration {
-        agents: vec![agent_configuration()],
+        agents: vec![agent_configuration(agent_name)],
         dnas: vec![dna_configuration(&dna_path)],
         instances: vec![instance_configuration(storage_configuration(persist)?)],
         interfaces: vec![interface_configuration(&interface_type, port)?],
@@ -105,11 +106,12 @@ pub fn hc_run_bundle_configuration(
     persist: bool,
     networked: Option<Networking>,
     logging: bool,
+    agent_name: String,
 ) -> DefaultResult<Configuration> {
     bundle
         .build_conductor_config(
             port,
-            agent_configuration(),
+            agent_configuration(agent_name),
             storage_configuration(persist)?,
             networking_configuration(networked),
             logger_configuration(logging),
@@ -118,17 +120,14 @@ pub fn hc_run_bundle_configuration(
 }
 
 // AGENT
-const AGENT_NAME_DEFAULT: &str = "testAgent";
+pub(crate) const AGENT_NAME_DEFAULT: &str = "testAgent";
 const AGENT_CONFIG_ID: &str = "hc-run-agent";
 
-fn agent_configuration() -> AgentConfiguration {
+fn agent_configuration(agent_name: String) -> AgentConfiguration {
     // note that this behaviour is documented within
     // holochain_common::env_vars module and should be updated
     // if this logic changes
-    let agent_name = EnvVar::Agent
-        .value()
-        .ok()
-        .unwrap_or_else(|| String::from(AGENT_NAME_DEFAULT));
+    let agent_name = EnvVar::Agent.value().ok().unwrap_or_else(|| agent_name);
     let mut keystore = test_keystore(&agent_name);
     let pub_key = keystore
         .get_keybundle(PRIMARY_KEYBUNDLE_ID)

--- a/crates/cli/src/cli/run.rs
+++ b/crates/cli/src/cli/run.rs
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_agent_configuration() {
-        let agent = super::agent_configuration();
+        let agent = super::agent_configuration(super::AGENT_NAME_DEFAULT.to_string());
         assert_eq!(
             agent,
             AgentConfiguration {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -92,6 +92,9 @@ enum Cli {
         #[structopt(long, short, default_value = "websocket")]
         /// Specify interface type to use: websocket/http
         interface: String,
+        #[structopt(long, short, default_value = cli::run::AGENT_NAME_DEFAULT)]
+        /// Specify agent name which will be used to generate the %agent_id.
+        agent_name: String,
     },
     #[structopt(alias = "t")]
     /// Runs tests written in the test folder
@@ -212,6 +215,7 @@ fn run() -> HolochainResult<()> {
             sim2h_server,
             interface,
             logging,
+            agent_name,
         } => {
             let dna_path = dna_path
                 .unwrap_or(util::std_package_path(&project_path).map_err(HolochainError::Default)?);
@@ -228,8 +232,15 @@ fn run() -> HolochainResult<()> {
                 let happ_bundle =
                     toml::from_str::<HappBundle>(&contents).expect("Error loading bundle.");
 
-                cli::hc_run_bundle_configuration(&happ_bundle, port, persist, networked, logging)
-                    .map_err(HolochainError::Default)?
+                cli::hc_run_bundle_configuration(
+                    &happ_bundle,
+                    port,
+                    persist,
+                    networked,
+                    logging,
+                    agent_name,
+                )
+                .map_err(HolochainError::Default)?
             } else {
                 cli::hc_run_configuration(
                     &dna_path,
@@ -238,6 +249,7 @@ fn run() -> HolochainResult<()> {
                     networked,
                     &interface_type,
                     logging,
+                    agent_name,
                 )
                 .map_err(HolochainError::Default)?
             };


### PR DESCRIPTION
## PR summary
Adds the ability to set the agent name and therefore the `%agent_id` by calling `hc run --agent-name MyAgentName`. This makes it possible to run multiple `hc run` conductors on the same machine.
Note that setting the env var `HC_AGENT` will still override this.
## testing/benchmarking notes
Modified the tests to use the default.
( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups
It would be really helpful to have this included in the next blessed release @thedavidmeister 
( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation
Documented through the `hc run --help`
- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
