### PR TITLE
Dedup validation queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "holochain_persistence_mem 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_wasm_utils 0.0.40-alpha1",
  "im 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-lite 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1836,6 +1837,14 @@ dependencies = [
 [[package]]
 name = "itertools"
 version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5038,6 +5047,7 @@ dependencies = [
 "checksum input_buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b822cc844905551931d6f81608ed5f50a79c1078a4e2b4d42dbc7c1eedfbf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
+"checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum json-patch 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3bde23771b4f5b9900635b0415485323b6d39afa979dcd5541218d67bb9107b4"
 "checksum jsonrpc-core 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9b392c9e8e43a12e6b21160903f473b1066e57fe18477394a93a1efd25654003"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -56,6 +56,7 @@ rand = "0.7.2"
 threadpool = "=1.7.1"
 im = { version = "=14.0.0", features = ["serde"] }
 petgraph = "=0.4.13"
+itertools = "0.8.2"
 
 [dev-dependencies]
 wabt = "=0.7.4"

--- a/crates/core/src/dht/actions/queue_holding_workflow.rs
+++ b/crates/core/src/dht/actions/queue_holding_workflow.rs
@@ -31,7 +31,7 @@ pub async fn queue_holding_workflow(
         .state()
         .expect("Can't queue holding workflow without state")
         .dht()
-        .has_queued_holding_workflow(&pending)
+        .has_exact_queued_holding_workflow(&pending)
     {
         log_trace!(context, "Queueing holding workflow: {:?}", pending);
         dispatch_queue_holding_workflow(pending.clone(), delay, context.clone());
@@ -61,7 +61,7 @@ impl Future for QueueHoldingWorkflowFuture {
         cx.waker().clone().wake();
 
         if let Some(state) = self.context.try_state() {
-            if state.dht().has_queued_holding_workflow(&self.pending) {
+            if state.dht().has_exact_queued_holding_workflow(&self.pending) {
                 Poll::Ready(())
             } else {
                 Poll::Pending

--- a/crates/core/src/dht/actions/remove_queued_holding_workflow.rs
+++ b/crates/core/src/dht/actions/remove_queued_holding_workflow.rs
@@ -29,7 +29,7 @@ impl Future for RemoveQueuedHoldingWorkflowFuture {
         cx.waker().clone().wake();
 
         if let Some(state) = self.context.try_state() {
-            if state.dht().has_queued_holding_workflow(&self.pending) {
+            if state.dht().has_exact_queued_holding_workflow(&self.pending) {
                 Poll::Pending
             } else {
                 Poll::Ready(())

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -16,7 +16,8 @@ use super::dht_inner_reducers::{
 
 use holochain_core_types::{entry::Entry, network::entry_aspect::EntryAspect};
 use holochain_persistence_api::cas::content::AddressableContent;
-
+use itertools::Itertools;
+use std::collections::VecDeque;
 // A function that might return a mutated DhtStore
 type DhtReducer = fn(&DhtStore, &ActionWrapper) -> Option<DhtStore>;
 
@@ -44,6 +45,7 @@ fn resolve_reducer(action_wrapper: &ActionWrapper) -> Option<DhtReducer> {
         Action::HoldAspect(_) => Some(reduce_hold_aspect),
         Action::QueueHoldingWorkflow(_) => Some(reduce_queue_holding_workflow),
         Action::RemoveQueuedHoldingWorkflow(_) => Some(reduce_remove_queued_holding_workflow),
+        Action::Prune => Some(reduce_prune),
         _ => None,
     }
 }
@@ -166,14 +168,41 @@ pub fn reduce_queue_holding_workflow(
         error!("Tried to add pending validation to queue which is already held!");
         None
     } else {
+        if old_store.has_same_queued_holding_worfkow(pending) {
+            warn!("Tried to add pending validation to queue which is already queued!");
+            None
+        } else {
+            let mut new_store = (*old_store).clone();
+            new_store
+                .queued_holding_workflows
+                .push_back(PendingValidationWithTimeout::new(
+                    pending.clone(),
+                    maybe_delay.map(ValidationTimeout::from),
+                ));
+            Some(new_store)
+        }
+    }
+}
+
+pub fn reduce_prune(old_store: &DhtStore, _action_wrapper: &ActionWrapper) -> Option<DhtStore> {
+    let pruned_queue = old_store
+        .queued_holding_workflows
+        .iter()
+        .unique_by(|p| {
+            (
+                p.pending.workflow.clone(),
+                p.pending.entry_with_header.header.entry_address(),
+            )
+        })
+        .cloned()
+        .collect::<VecDeque<_>>();
+
+    if pruned_queue.len() < old_store.queued_holding_workflows.len() {
         let mut new_store = (*old_store).clone();
-        new_store
-            .queued_holding_workflows
-            .push_back(PendingValidationWithTimeout::new(
-                pending.clone(),
-                maybe_delay.map(ValidationTimeout::from),
-            ));
+        new_store.queued_holding_workflows = pruned_queue;
         Some(new_store)
+    } else {
+        None
     }
 }
 
@@ -536,7 +565,7 @@ pub mod tests {
         let store = reduce_queue_holding_workflow(&store, &action).unwrap();
 
         assert_eq!(store.queued_holding_workflows().len(), 1);
-        assert!(store.has_queued_holding_workflow(&hold));
+        assert!(store.has_exact_queued_holding_workflow(&hold));
 
         let test_link = String::from("test_link");
         let test_tag = String::from("test-tag");
@@ -559,7 +588,7 @@ pub mod tests {
         let store = reduce_queue_holding_workflow(&store, &action).unwrap();
 
         assert_eq!(store.queued_holding_workflows().len(), 2);
-        assert!(store.has_queued_holding_workflow(&hold_link));
+        assert!(store.has_exact_queued_holding_workflow(&hold_link));
 
         // the link won't validate while the entry is pending so we have to remove it
         let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow(hold.clone()));
@@ -573,17 +602,17 @@ pub mod tests {
         let store = reduce_queue_holding_workflow(&store, &action).unwrap();
 
         assert_eq!(store.queued_holding_workflows().len(), 2);
-        assert!(!store.has_queued_holding_workflow(&hold));
-        assert!(store.has_queued_holding_workflow(&update));
-        assert!(store.has_queued_holding_workflow(&hold_link));
+        assert!(!store.has_exact_queued_holding_workflow(&hold));
+        assert!(store.has_exact_queued_holding_workflow(&update));
+        assert!(store.has_exact_queued_holding_workflow(&hold_link));
 
         let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow(hold_link.clone()));
         let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
 
         assert_eq!(store.queued_holding_workflows().len(), 1);
-        assert!(!store.has_queued_holding_workflow(&hold));
-        assert!(!store.has_queued_holding_workflow(&hold_link));
-        assert!(store.has_queued_holding_workflow(&update));
+        assert!(!store.has_exact_queued_holding_workflow(&hold));
+        assert!(!store.has_exact_queued_holding_workflow(&hold_link));
+        assert!(store.has_exact_queued_holding_workflow(&update));
 
         let (next_pending, _) = store.next_queued_holding_workflow().unwrap();
         assert_eq!(update, next_pending);

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -293,11 +293,23 @@ impl DhtStore {
             .next()
     }
 
-    pub(crate) fn has_queued_holding_workflow(&self, pending: &PendingValidation) -> bool {
+    pub(crate) fn has_exact_queued_holding_workflow(&self, pending: &PendingValidation) -> bool {
         self.queued_holding_workflows.iter().any(
             |PendingValidationWithTimeout {
                  pending: current, ..
              }| current == pending,
+        )
+    }
+
+    pub(crate) fn has_same_queued_holding_worfkow(&self, pending: &PendingValidation) -> bool {
+        self.queued_holding_workflows.iter().any(
+            |PendingValidationWithTimeout {
+                 pending: current, ..
+             }| {
+                current.entry_with_header.header.entry_address()
+                    == pending.entry_with_header.header.entry_address()
+                    && current.workflow == pending.workflow
+            },
         )
     }
 


### PR DESCRIPTION
## PR summary

This fixes an issue that lets the validation queue grow indefinitely, which causes even more secondary problems.

If there is an entry in the queue that has unresolved dependencies (like a link missing base or target) we can't validate it immediately and will keep it in the queue.
As a consequence, the node won't *hold* the entry and will not include it in the holding list. That will make the network (sim2h) resend a store request since this node is missing the entry aspect.

Without these changes, what happened next is that the entry will be put into the queue again because we had no check if it is queued already.

If we have entries in the queue with unresolved dependencies that don't get resolved within minutes it will lead to an accumulation of copies of the same entry in the queue indefinitely.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
