### PR TITLE
Some crates were missing from the workspace, confusing cargoToNix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/conductor_api",
   "crates/holochain_wasm",
   "crates/core",
+  "crates/core_types",
   "crates/dpki",
   "crates/hdk_v2",
   "crates/hdk",
@@ -19,7 +20,8 @@ members = [
   "crates/trycp_server",
   "crates/sim1h",
   "crates/sim2h",
-  "crates/sim2h_server"
+  "crates/sim2h_server",
+  "crates/wasm_utils"
 ]
 exclude = [
   "test_utils",


### PR DESCRIPTION
## PR summary

The cargoToNix functionality in holo-nixpkgs requires some consistency between a workspace Cargo.toml and its constituent crates, in addition to what is required by `cargo build`, in order to reliably and deterministically locate all the dependent crates and build a Nix derivation.

This was causing problems for the Holo hpos-config crate.  This adds some of the missing crates to the root Cargo.toml.  This probably shouldn't effect a normal `cargo build`, just fixes cargoToNix generated derivations.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
