### PR TITLE
Handle unseen aspects from gossip list not just authoring list

### DIFF
--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -26,7 +26,10 @@ use cache::*;
 use connection_state::*;
 use lib3h_crypto_api::CryptoSystem;
 use lib3h_protocol::{
-    data_types::{EntryData, FetchEntryData, GetListData, Opaque, SpaceData, StoreEntryAspectData},
+    data_types::{
+        EntryData, EntryListData, FetchEntryData, GetListData, Opaque, SpaceData,
+        StoreEntryAspectData,
+    },
     protocol::*,
     types::SpaceHash,
     uri::Lib3hUri,
@@ -482,6 +485,31 @@ impl Sim2h {
         Ok(())
     }
 
+    fn handle_unseen_aspects(
+        &mut self,
+        uri: &Lib3hUri,
+        space_address: &SpaceHash,
+        agent_id: &AgentId,
+        list_data: &EntryListData,
+    ) {
+        let unseen_aspects = AspectList::from(list_data.address_map.clone())
+            .diff(self.get_or_create_space(space_address).read().all_aspects());
+        debug!("UNSEEN ASPECTS:\n{}", unseen_aspects.pretty_string());
+        for entry_address in unseen_aspects.entry_addresses() {
+            if let Some(aspect_address_list) = unseen_aspects.per_entry(entry_address) {
+                let wire_message =
+                    WireMessage::Lib3hToClient(Lib3hToClient::HandleFetchEntry(FetchEntryData {
+                        request_id: "".into(),
+                        space_address: space_address.clone(),
+                        provider_agent_id: agent_id.clone(),
+                        entry_address: entry_address.clone(),
+                        aspect_address_list: Some(aspect_address_list.clone()),
+                    }));
+                self.send(agent_id.clone(), uri.clone(), &wire_message);
+            }
+        }
+    }
+
     // given an incoming messages, prepare a proxy message and whether it's an publish or request
     fn handle_joined(
         &mut self,
@@ -558,27 +586,7 @@ impl Sim2h {
                 if (list_data.provider_agent_id != *agent_id) || (list_data.space_address != *space_address) {
                     return Err(SPACE_MISMATCH_ERR_STR.into());
                 }
-                let unseen_aspects = AspectList::from(list_data.address_map)
-                    .diff(self
-                        .get_or_create_space(&space_address)
-                        .read()
-                        .all_aspects()
-                    );
-                debug!("UNSEEN ASPECTS:\n{}", unseen_aspects.pretty_string());
-                for entry_address in unseen_aspects.entry_addresses() {
-                    if let Some(aspect_address_list) = unseen_aspects.per_entry(entry_address) {
-                        let wire_message = WireMessage::Lib3hToClient(
-                            Lib3hToClient::HandleFetchEntry(FetchEntryData {
-                                request_id: "".into(),
-                                space_address: space_address.clone(),
-                                provider_agent_id: agent_id.clone(),
-                                entry_address: entry_address.clone(),
-                                aspect_address_list: Some(aspect_address_list.clone())
-                            })
-                        );
-                        self.send(agent_id.clone(), uri.clone(), &wire_message);
-                    }
-                }
+                self.handle_unseen_aspects(uri, space_address, agent_id, &list_data);
                 Ok(())
             }
             WireMessage::Lib3hToClientResponse(Lib3hToClientResponse::HandleGetGossipingEntryListResult(list_data)) => {
@@ -586,6 +594,7 @@ impl Sim2h {
                 if (list_data.provider_agent_id != *agent_id) || (list_data.space_address != *space_address) {
                     return Err(SPACE_MISMATCH_ERR_STR.into());
                 }
+                self.handle_unseen_aspects(uri, space_address, agent_id, &list_data);
                 let (mut agents_in_space, aspects_missing_at_node) = {
                     let space = self
                         .get_or_create_space(&space_address)

--- a/stress-test/package.json
+++ b/stress-test/package.json
@@ -15,8 +15,8 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "@holochain/tryorama": "^0.3.0-rc.3",
-    "@holochain/tryorama-stress-utils": "0.0.4",
+    "@holochain/tryorama": "^0.3.0",
+    "@holochain/tryorama-stress-utils": "0.0.6",
     "ramda": "^0.26.1",
     "tape": "^4.11.0",
     "sleep": "^6.1.0"

--- a/stress-test/package.json
+++ b/stress-test/package.json
@@ -15,7 +15,7 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
-    "@holochain/tryorama": "^0.3.0",
+    "@holochain/tryorama": "^0.3.1-rc.1",
     "@holochain/tryorama-stress-utils": "0.0.6",
     "ramda": "^0.26.1",
     "tape": "^4.11.0",

--- a/stress-test/src/config.ts
+++ b/stress-test/src/config.ts
@@ -64,7 +64,7 @@ const network =
 
 const dna = Config.dna('passthrough-dna.dna.json', 'passthrough')
 
-const configCommon = {
+export const configCommon = {
   logger,
   network,
 }

--- a/stress-test/src/config.ts
+++ b/stress-test/src/config.ts
@@ -52,7 +52,7 @@ const network =
   : networkType === 'sim2h'
   ? {
     type: 'sim2h',
-    sim2h_url: 'ws://localhost:9002'
+    sim2h_url: 'wss://localhost:9002'
   }
 
   : networkType === 'memory'
@@ -61,12 +61,11 @@ const network =
   : (() => {throw new Error(`Unsupported network type: ${networkType}`)})()
   )
 
-
 const dna = Config.dna('passthrough-dna.dna.json', 'passthrough')
 
 export const configCommon = {
-  logger,
-  network,
+    logger,
+    network,
 }
 
 /** Generates a bunch of identical conductor configs with multiple identical instances */

--- a/stress-test/src/gossip.ts
+++ b/stress-test/src/gossip.ts
@@ -5,40 +5,62 @@ import { configCommon } from './config'
 const dna = Config.dna('passthrough-dna.dna.json', 'passthrough')
 const trace = R.tap(x => console.log('{T}', x))
 
-const config = Config.gen({app: dna}, configCommon)
+const path = require('path')
+const id = 'app'
+
+const instanceConfig = ({playerName, uuid, configDir}) => [
+    {
+        id: id,
+        dna: dna,
+        agent: {
+            name: `${playerName}::${id}::${uuid}`,
+            id: id,
+            keystore_file: '[UNUSED]',
+            public_address: '[SHOULD BE REWRITTEN]',
+            test_agent: true,
+        },
+        storage: {
+            type: 'lmdb',
+            path: path.join(configDir, id)
+        }
+    }
+]
+
+const config = Config.gen(instanceConfig, configCommon)
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
 module.exports = (scenario) => {
     scenario('gossip transfers entries', async (s, t) => {
         const { alice, bob, carol } = await s.players({ alice: config, bob: config, carol: config }, false)
 
+        // alice creates an entry
         await alice.spawn()
-//        await bob.spawn()
-
-        let result = await alice.call('app','main', 'commit_entry', { content: "alice entry" })
+        let result = await alice.call(id, 'main', 'commit_entry', { content: "alice entry" })
         console.log("RESULTS:", result)
         t.equal(Boolean(result.Ok), true)
         const entryHash = result.Ok
         console.log("entryHash:", entryHash)
 
-
-        await delay(2000)
-
-//        await alice.kill()
+        // bob comes on line and starts holding that entry
         await bob.spawn()
-        await delay(2000)
-        result = await bob.call('app', 'main', 'get_entry', {address: entryHash})
+        await s.consistency()
+        result = await bob.call(id, 'main', 'get_entry', {address: entryHash})
         console.log("RESULTS2:", result)
         t.equal(Boolean(result.Ok), true)
 
+        // alice and bob both go off line which means that the sim2h server should
+        // clear all it's knowledge of the space
         await alice.kill()
         await bob.kill()
         await delay(2000)
+
+        // bob comes back and carol comes on for the first time
         await bob.spawn()
         await carol.spawn()
-        await delay(10000)
+        await delay(5000)
 
-        result = await carol.call('app', 'main', 'get_entry', {address: entryHash})
+        // carol can get alices entry
+        result = await carol.call(id, 'main', 'get_entry', {address: entryHash})
         console.log("RESULTS:", result)
         t.equal(Boolean(result.Ok), true)
 

--- a/stress-test/src/gossip.ts
+++ b/stress-test/src/gossip.ts
@@ -1,0 +1,46 @@
+import { Config } from '@holochain/tryorama'
+import * as R from 'ramda'
+import { configCommon } from './config'
+
+const dna = Config.dna('passthrough-dna.dna.json', 'passthrough')
+const trace = R.tap(x => console.log('{T}', x))
+
+const config = Config.gen({app: dna}, configCommon)
+const delay = ms => new Promise(r => setTimeout(r, ms))
+
+module.exports = (scenario) => {
+    scenario('gossip transfers entries', async (s, t) => {
+        const { alice, bob, carol } = await s.players({ alice: config, bob: config, carol: config }, false)
+
+        await alice.spawn()
+//        await bob.spawn()
+
+        let result = await alice.call('app','main', 'commit_entry', { content: "alice entry" })
+        console.log("RESULTS:", result)
+        t.equal(Boolean(result.Ok), true)
+        const entryHash = result.Ok
+        console.log("entryHash:", entryHash)
+
+
+        await delay(2000)
+
+//        await alice.kill()
+        await bob.spawn()
+        await delay(2000)
+        result = await bob.call('app', 'main', 'get_entry', {address: entryHash})
+        console.log("RESULTS2:", result)
+        t.equal(Boolean(result.Ok), true)
+
+        await alice.kill()
+        await bob.kill()
+        await delay(2000)
+        await bob.spawn()
+        await carol.spawn()
+        await delay(10000)
+
+        result = await carol.call('app', 'main', 'get_entry', {address: entryHash})
+        console.log("RESULTS:", result)
+        t.equal(Boolean(result.Ok), true)
+
+    })
+}

--- a/stress-test/src/index.ts
+++ b/stress-test/src/index.ts
@@ -5,7 +5,7 @@ process.on('unhandledRejection', error => {
   console.error('got unhandledRejection:', error);
 });
 
-const middleware = 
+const middleware =
   ( networkType === 'sim1h'
   ? combine(tapeExecutor(require('tape')), localOnly)
 
@@ -30,14 +30,15 @@ const orchestrator = new Orchestrator({
 const N = parseInt(process.argv[2], 10) || 10
 const M = parseInt(process.argv[3], 10) || 1
 
-console.log(`Running stress tests with N=${N}, M=${M}`)
+console.log(`Running stress tests with N=${N}, M=${M} on ${networkType}`)
 
-require('./all-on')(orchestrator.registerScenario, N, M)
-require('./telephone-games')(orchestrator.registerScenario, N, M)
+//require('./all-on')(orchestrator.registerScenario, N, M)
+//require('./telephone-games')(orchestrator.registerScenario, N, M)
 
 // the hammer count here is the largest number we think should be acceptable
 // for ci to pass
-require('./zome-hammer')(orchestrator.registerScenario, 100)
+//require('./zome-hammer')(orchestrator.registerScenario, 100)
 
+require('./gossip')(orchestrator.registerScenario)
 
 orchestrator.run()

--- a/stress-test/src/index.ts
+++ b/stress-test/src/index.ts
@@ -32,12 +32,12 @@ const M = parseInt(process.argv[3], 10) || 1
 
 console.log(`Running stress tests with N=${N}, M=${M} on ${networkType}`)
 
-//require('./all-on')(orchestrator.registerScenario, N, M)
+require('./all-on')(orchestrator.registerScenario, N, M)
 //require('./telephone-games')(orchestrator.registerScenario, N, M)
 
 // the hammer count here is the largest number we think should be acceptable
 // for ci to pass
-//require('./zome-hammer')(orchestrator.registerScenario, 100)
+require('./zome-hammer')(orchestrator.registerScenario, 100)
 
 require('./gossip')(orchestrator.registerScenario)
 


### PR DESCRIPTION
## PR summary

There's a bug where sim2h isn't keeping track of unseen aspects in it's model of which aspects exist in the space from gossiping data only from authoring data.  This means that in this situation:  1) all the nodes that have some aspect data go off line, 2) a new node comes on-line,  3) an old node which had data but was not the author, then sim2h would not know to send the data to the new node.

This PR adds a test and refactors the handle_unseen code for use in both situations.

## testing/benchmarking notes

It also identified that tryorama was using the in-memory storage for stress tests, which would cause this case to fail because the old non-authoring node coming back on line would have lost it's holding list.

The new `gossip.ts` in the stress-tests creates a regression test.

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
