### PR TITLE
Fix default aggregation pattern

### DIFF
--- a/crates/metrics/src/main.rs
+++ b/crates/metrics/src/main.rs
@@ -272,7 +272,7 @@ fn print_metric_stats(csv_file: PathBuf, aggregation_pattern: Option<String>) {
     let reader = BufReader::new(File::open(csv_file).unwrap());
     let mut reader = csv::Reader::from_reader(reader);
     let metrics = crate::metrics_from_reader!(reader);
-    let aggregation_pattern = aggregation_pattern.unwrap_or_else(|| "([.]*)".into());
+    let aggregation_pattern = aggregation_pattern.unwrap_or_else(|| "(.*)".into());
     let re = regex::Regex::new(aggregation_pattern.as_str()).unwrap();
     let stats_by_metric = StatsByMetric::group_by_regex(&re, metrics);
     stats_by_metric.write_csv(std::io::stdout()).unwrap();


### PR DESCRIPTION
## PR summary

This one-liner PR fixes a bug in the regex syntax for the default aggregation pattern of performance metric data.
## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
