### PR TITLE
hc-generate: Change default template to rust-proc and improve documentation

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Changed `hc generate` to use the `rust-proc` template by default [PR#0000](https://github.com/holochain/holochain-rust/pull/0000)
+
 ### Deprecated
 
 ### Removed

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,8 +61,8 @@ enum Cli {
         #[structopt(parse(from_os_str))]
         /// The path to the zome that should be generated (usually in ./zomes/)
         zome: PathBuf,
-        #[structopt(default_value = "rust")]
-        /// Either the name of a built-in template (rust, rust-proc) or the url to a git repo containing a Zome template.
+        #[structopt(default_value = "rust-proc")]
+        /// Either the name of a built-in template (rust-proc, rust) or the url to a git repo containing a Zome template.
         template: String,
     },
     #[structopt(alias = "r")]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -62,7 +62,10 @@ enum Cli {
         /// The path to the zome that should be generated (usually in ./zomes/)
         zome: PathBuf,
         #[structopt(default_value = "rust-proc")]
-        /// Either the name of a built-in template (rust-proc, rust) or the url to a `tar.gz` containing a Zome template.
+        /// The template from which to generate the zome
+        ///
+        /// This should either be the name of a built-in template (rust-proc, rust) or
+        /// the url to a `tar.gz` containing a Zome template.
         template: String,
     },
     #[structopt(alias = "r")]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -62,7 +62,7 @@ enum Cli {
         /// The path to the zome that should be generated (usually in ./zomes/)
         zome: PathBuf,
         #[structopt(default_value = "rust-proc")]
-        /// Either the name of a built-in template (rust-proc, rust) or the url to a git repo containing a Zome template.
+        /// Either the name of a built-in template (rust-proc, rust) or the url to a `tar.gz` containing a Zome template.
         template: String,
     },
     #[structopt(alias = "r")]


### PR DESCRIPTION
## PR summary

 This PR
- Changes the default template used by `hc generate` to `rust-proc` (1e19808)
  - and in so doing, fixes holochain/rust-proc-zome-template#5
- Clarifies the documentation of the template argument used by `hc generate` (3d5864f)
- Improves the formatting of the documentation for `hc generate`  (3bf5f92)
  - by moving some of it to the second line so that it only shows up in long help messages

## testing/benchmarking notes

N/A

## followups

N/A

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
