### PR TITLE
hc: Update to 2018 edition

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,6 +6,7 @@ homepage = "https://github.com/holochain/holochain-rust"
 documentation = "https://github.com/holochain/holochain-rust"
 version = "0.0.41-alpha4"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+edition = "2018"
 
 [dependencies]
 holochain_core_types = { version = "=0.0.41-alpha4", path = "../core_types" }

--- a/crates/cli/src/cli/chain_log.rs
+++ b/crates/cli/src/cli/chain_log.rs
@@ -1,5 +1,6 @@
 use crate::error::DefaultResult;
 use colored::*;
+use failure::format_err;
 use holochain_core::{
     agent::{
         chain_store::ChainStore,

--- a/crates/cli/src/cli/generate.rs
+++ b/crates/cli/src/cli/generate.rs
@@ -1,4 +1,5 @@
 use crate::error::DefaultResult;
+use failure::format_err;
 use flate2::read::GzDecoder;
 use glob::glob;
 use std::{

--- a/crates/cli/src/cli/hash_dna.rs
+++ b/crates/cli/src/cli/hash_dna.rs
@@ -1,4 +1,4 @@
-use error::DefaultResult;
+use crate::error::DefaultResult;
 use failure::err_msg;
 use holochain_conductor_lib::conductor::Conductor;
 use holochain_persistence_api::cas::content::{Address, AddressableContent};

--- a/crates/cli/src/cli/init.rs
+++ b/crates/cli/src/cli/init.rs
@@ -138,9 +138,9 @@ pub fn init(path: &PathBuf) -> DefaultResult<()> {
 
 #[cfg(test)]
 pub mod tests {
-    use super::*;
-    extern crate tempfile;
     use self::tempfile::{Builder, TempDir};
+    use super::*;
+    use tempfile;
 
     const HOLOCHAIN_TEST_PREFIX: &str = "org_holochain_test";
 

--- a/crates/cli/src/cli/init.rs
+++ b/crates/cli/src/cli/init.rs
@@ -8,6 +8,7 @@ use crate::{
     util::DIST_DIR_NAME,
 };
 use colored::*;
+use failure::bail;
 use serde_json;
 use std::{
     collections::HashMap,

--- a/crates/cli/src/cli/keygen.rs
+++ b/crates/cli/src/cli/keygen.rs
@@ -1,4 +1,4 @@
-use error::DefaultResult;
+use crate::error::DefaultResult;
 use holochain_common::paths::keys_directory;
 use holochain_conductor_lib::{key_loaders::mock_passphrase_manager, keystore::Keystore};
 use rpassword;

--- a/crates/cli/src/cli/package.rs
+++ b/crates/cli/src/cli/package.rs
@@ -1,13 +1,14 @@
 use crate::{config_files::Build, error::DefaultResult, util};
 use base64;
 use colored::*;
+use failure::format_err;
 use holochain_core::nucleus::ribosome::{run_dna, WasmCallData};
 use holochain_core_types::dna::Dna;
 use holochain_json_api::json::JsonString;
 use holochain_persistence_api::cas::content::AddressableContent;
 use ignore::WalkBuilder;
 use json_patch::merge;
-use serde_json::{self, Map, Value};
+use serde_json::{self, json, Map, Value};
 use std::{
     convert::TryFrom,
     fs::{self, File},

--- a/crates/cli/src/cli/run.rs
+++ b/crates/cli/src/cli/run.rs
@@ -1,5 +1,6 @@
 use crate::{cli, error::DefaultResult, NetworkingType};
 use colored::*;
+use failure::format_err;
 use holochain_common::env_vars::EnvVar;
 use holochain_conductor_lib::{
     conductor::{mount_conductor_from_config, Conductor, CONDUCTOR},
@@ -12,6 +13,7 @@ use holochain_conductor_lib::{
 use holochain_core_types::agent::AgentId;
 use holochain_net::sim2h_worker::Sim2hConfig;
 use holochain_persistence_api::cas::content::AddressableContent;
+use serde_json::json;
 use std::{fs, path::PathBuf};
 
 pub enum Networking {

--- a/crates/cli/src/cli/run.rs
+++ b/crates/cli/src/cli/run.rs
@@ -1,7 +1,5 @@
-use crate::NetworkingType;
-use cli;
+use crate::{cli, error::DefaultResult, NetworkingType};
 use colored::*;
-use error::DefaultResult;
 use holochain_common::env_vars::EnvVar;
 use holochain_conductor_lib::{
     conductor::{mount_conductor_from_config, Conductor, CONDUCTOR},
@@ -284,7 +282,7 @@ impl Networking {
 
 #[cfg(test)]
 mod tests {
-    extern crate tempfile;
+    use tempfile;
     // use crate::cli::init::{init, tests::gen_dir};
     // use assert_cmd::prelude::*;
     // use std::{env, process::Command, path::PathBuf};

--- a/crates/cli/src/cli/test.rs
+++ b/crates/cli/src/cli/test.rs
@@ -1,6 +1,7 @@
 use crate::{cli::package, error::DefaultResult, util};
 use colored::*;
-use failure::Error;
+use failure::{ensure, Error};
+use serde_json::json;
 use std::{
     io::ErrorKind,
     path::PathBuf,

--- a/crates/cli/src/config_files/app.rs
+++ b/crates/cli/src/config_files/app.rs
@@ -1,5 +1,6 @@
 use crate::config_files::Dht;
 use semver::Version;
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/crates/cli/src/config_files/build.rs
+++ b/crates/cli/src/config_files/build.rs
@@ -1,5 +1,7 @@
 use crate::{error::DefaultResult, util};
 use base64;
+use failure::bail;
+use serde_derive::{Deserialize, Serialize};
 use serde_json;
 use std::{
     fs::File,

--- a/crates/cli/src/config_files/dht.rs
+++ b/crates/cli/src/config_files/dht.rs
@@ -1,2 +1,4 @@
+use serde_derive::{Deserialize, Serialize};
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Dht {}

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,4 +1,4 @@
-use failure::Error;
+use failure::{format_err, Error, Fail};
 
 #[derive(Debug, Fail)]
 pub enum HolochainError {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,38 +1,15 @@
 #![warn(unused_extern_crates)]
-extern crate holochain_common;
-extern crate holochain_conductor_lib;
-extern crate holochain_core;
-extern crate holochain_core_types;
-extern crate holochain_json_api;
-extern crate holochain_locksmith;
-extern crate holochain_net;
-extern crate holochain_persistence_api;
-extern crate holochain_persistence_file;
-extern crate json_patch;
-extern crate lib3h_crypto_api;
-extern crate lib3h_protocol;
-extern crate lib3h_sodium;
-extern crate sim2h;
-extern crate structopt;
+use holochain_common;
+
+use lib3h_sodium;
+
 #[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;
-extern crate base64;
-extern crate colored;
-extern crate semver;
+
 #[macro_use]
 extern crate serde_json;
-extern crate dns_lookup;
-extern crate flate2;
-extern crate glob;
-extern crate ignore;
-extern crate in_stream;
-extern crate rpassword;
-extern crate tar;
-extern crate tempfile;
-extern crate tera;
-extern crate url2;
 
 mod cli;
 mod config_files;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,13 +3,9 @@ use holochain_common;
 
 use lib3h_sodium;
 
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate serde_derive;
+use failure::format_err;
 
-#[macro_use]
-extern crate serde_json;
+use serde_json::json;
 
 mod cli;
 mod config_files;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,20 +1,16 @@
-use holochain_common;
-
-use lib3h_sodium;
-
+use crate::error::{HolochainError, HolochainResult};
 use failure::format_err;
-
+use holochain_common;
+use holochain_conductor_lib::happ_bundle::HappBundle;
+use lib3h_sodium;
 use serde_json::json;
+use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
+use structopt::{clap::arg_enum, StructOpt};
 
 mod cli;
 mod config_files;
 mod error;
 mod util;
-
-use crate::error::{HolochainError, HolochainResult};
-use holochain_conductor_lib::happ_bundle::HappBundle;
-use std::{fs::File, io::Read, path::PathBuf, str::FromStr};
-use structopt::{clap::arg_enum, StructOpt};
 
 #[derive(StructOpt)]
 /// A command line for Holochain

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,3 @@
-#![warn(unused_extern_crates)]
 use holochain_common;
 
 use lib3h_sodium;

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,5 +1,6 @@
 use crate::error::DefaultResult;
 use colored::*;
+use failure::{ensure, format_err};
 pub use holochain_common::paths::DNA_EXTENSION;
 use std::{
     fs,


### PR DESCRIPTION
## PR summary

This PR
- Updates `hc`'s `Cargo.toml` to use the 2018 edition of Rust (74f04b2)
- Fixes the broken `use` declarations caused by the changes to namespacing in the 2018 edition (74f04b2)
- Removes most `extern crate`s because the 2018 edition makes them unneeded (74f04b2)
- Deletes the remaining `#[macro_use] extern crate`s and adds `use` declarations for their macros where needed (1693930)
- Removes the lint annotation `#[warn(unused_extern_crates)]` because there are no longer any `extern crate` declarations (50c68b0)
  - Why do we have this on any of our crates? Warning on unused `extern crate`s should be the default...
- Does some small re-arranging of `use` declarations for clarity (fc1b594)

## testing/benchmarking notes

N/A

## followups

I'm currently working on one of these for `holochain_core_types` as well.

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
