### PR TITLE
use bash -c in hc run_cmd

### DIFF
--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1,7 +1,7 @@
 mod chain_log;
 mod generate;
 mod hash_dna;
-mod init;
+pub mod init;
 mod keygen;
 pub mod package;
 pub mod run;

--- a/crates/cli/src/cli/test.rs
+++ b/crates/cli/src/cli/test.rs
@@ -69,7 +69,7 @@ pub fn test(
         // CLI feedback
         println!("{}", "Installing node_modules".green().bold());
         util::run_cmd(
-            tests_path,
+            &tests_path,
             "npm".to_string(),
             match show_npm_output {
                 true => &["install"],
@@ -82,7 +82,7 @@ pub fn test(
     // CLI feedback
     println!("{} tests in {}", "Running".green().bold(), testfile,);
     util::run_cmd(
-        path.to_path_buf(),
+        &path.to_path_buf(),
         "node".to_string(),
         &[testfile.to_string().as_str()],
     )?;

--- a/crates/cli/src/config_files/build.rs
+++ b/crates/cli/src/config_files/build.rs
@@ -34,7 +34,7 @@ impl Build {
         for build_step in &self.steps {
             let slice_vec: Vec<_> = build_step.arguments.iter().map(|e| e.as_str()).collect();
             util::run_cmd(
-                base_path.to_path_buf(),
+                &base_path.to_path_buf(),
                 build_step.command.clone(),
                 &slice_vec[..],
             )?;

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -41,7 +41,7 @@ pub fn run_cmd(base_path: &PathBuf, bin: String, args: &[&str]) -> DefaultResult
     //  "arguments": ["$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/{{ name }}.wasm"]
     // },
     // note the implicit (in cargo) and explicit (in wasm-gc) use of $CARGO_TARGET_DIR!
-    // note also that the supported development environment is based on `nix-shell` so we at least
+    // note also that the supported development environment is based on `nix-shell` so we _already_
     // assume/expect that developers are using something bash-like for development already
     // e.g. we assume `cargo`, `wasm-gc`, `wasm-opt`, `wasm2wat`, `wat2wasm` all exist in the
     // default template (which we can't assume outside nix-shell in a portable way).

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -23,7 +23,7 @@ pub fn run_cmd(base_path: &PathBuf, bin: String, args: &[&str]) -> DefaultResult
     // i.e. the same binary should work across bash, powershell, CMD, etc.
     // to achieve this all the arg strings are built internally by the rust binary then run as-is
     // so e.g. Command::new("echo").args("$PWD") would literally print `"$PWD"` not the contents of
-    // the $PWD environment variable (e.g. this would be `%cd%` on Windows CMD)
+    // the $PWD environment variable (e.g. because Windows CMD would expect `%cd%` not `$PWD`)
     // what we want is for things to be "portable"
     // i.e. developers can configure their machines with environment variables and have `hc`
     // evaluate them to local values that fit their personal workflow/configurations

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -8,13 +8,45 @@ use std::{
     process::{Command, Stdio},
 };
 
-pub fn run_cmd(base_path: PathBuf, bin: String, args: &[&str]) -> DefaultResult<()> {
+pub fn run_cmd(base_path: &PathBuf, bin: String, args: &[&str]) -> DefaultResult<()> {
     let pretty_command = format!("{} {}", bin.green(), args.join(" ").cyan());
 
     println!("> {}", pretty_command);
 
-    let status = Command::new(bin)
-        .args(args)
+    let command_string = format!("{} {}", bin, args.join(" "));
+    println!("{:?}", command_string);
+
+    // this bypasses the native rust handling of Command by passing the whole thing to bash as:
+    // bash -c "{{ thing you wanted to do }}"
+    // it's basically `eval` which is evil :(
+    // we do this because Rust's `Command` is designed to be "portable"
+    // i.e. the same binary should work across bash, powershell, CMD, etc.
+    // to achieve this all the arg strings are built internally by the rust binary then run as-is
+    // so e.g. Command::new("echo").args("$PWD") would literally print `"$PWD"` not the contents of
+    // the $PWD environment variable (e.g. this would be `%cd%` on Windows CMD)
+    // what we want is for things to be "portable"
+    // i.e. developers can configure their machines with environment variables and have `hc`
+    // evaluate them to local values that fit their personal workflow/configurations
+    // so e.g. the following should work (i.e. `wasm-gc` finds the built .wasm file)
+    // {
+    //  "command": "cargo",
+    //  "arguments": [
+    //   "build",
+    //   "--release",
+    //   "--target=wasm32-unknown-unknown"
+    //  ]
+    // },
+    // {
+    //  "command": "wasm-gc",
+    //  "arguments": ["$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/{{ name }}.wasm"]
+    // },
+    // note the explicit (in cargo) and implicit (in wasm-gc) use of $CARGO_TARGET_DIR!
+    // note also that the supported development environment is based on `nix-shell` so we at least
+    // assume/expect that developers are using something bash-like for development already
+    // e.g. we assume `cargo`, `wasm-gc`, `wasm-opt`, `wasm2wat`, `wat2wasm` all exist in the
+    // default template (which we can't assume outside nix-shell in a portable way).
+    let status = Command::new("bash")
+        .args(&["-c", &command_string])
         .current_dir(base_path)
         .status()?;
 
@@ -96,5 +128,23 @@ pub fn check_for_cargo(use_case: &str, extra_help: Option<Vec<&str>>) -> Default
                 _ => Err(format_err!("This command requires the `cargo` command, but there was an error checking if it is available or not: {}", e)),
             }
         }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use cli::init::tests::gen_dir;
+    use util::run_cmd;
+
+    #[test]
+    fn run_cmd_test() {
+        let dir = gen_dir();
+        let dir_path_buf = &dir.path().to_path_buf();
+
+        // test this manually with:
+        // `cargo test -p hc run_cmd_test -- --nocapture`
+        // the tempdir should be echoed and not a literal '$PWD'
+        assert!(run_cmd(dir_path_buf, "echo".to_string(), &["$PWD"]).is_ok());
     }
 }

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -40,7 +40,7 @@ pub fn run_cmd(base_path: &PathBuf, bin: String, args: &[&str]) -> DefaultResult
     //  "command": "wasm-gc",
     //  "arguments": ["$CARGO_TARGET_DIR/wasm32-unknown-unknown/release/{{ name }}.wasm"]
     // },
-    // note the explicit (in cargo) and implicit (in wasm-gc) use of $CARGO_TARGET_DIR!
+    // note the implicit (in cargo) and explicit (in wasm-gc) use of $CARGO_TARGET_DIR!
     // note also that the supported development environment is based on `nix-shell` so we at least
     // assume/expect that developers are using something bash-like for development already
     // e.g. we assume `cargo`, `wasm-gc`, `wasm-opt`, `wasm2wat`, `wat2wasm` all exist in the

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -45,6 +45,11 @@ pub fn run_cmd(base_path: &PathBuf, bin: String, args: &[&str]) -> DefaultResult
     // assume/expect that developers are using something bash-like for development already
     // e.g. we assume `cargo`, `wasm-gc`, `wasm-opt`, `wasm2wat`, `wat2wasm` all exist in the
     // default template (which we can't assume outside nix-shell in a portable way).
+    //
+    // @TODO - does it make more sense to push "execute arbitrary bash" style features down to the
+    // `nix-shell` layer where we have a better toolkit to handle environments/dependencies?
+    // e.g. @see `hn-release-cut` from holonix that implements conventions/hooks to standardise
+    // bash processes in an extensible way
     let status = Command::new("bash")
         .args(&["-c", &command_string])
         .current_dir(base_path)


### PR DESCRIPTION
## PR summary

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

manual testing:

before, passing `"$PWD"` to `run_cmd`:

```
[nix-shell:~/holochain-rust]$ cargo test -p hc run_cmd_test -- --nocapture
   Compiling hc v0.0.41-alpha4 (/home/thedavidmeister/holochain-rust/crates/cli)
    Finished test [unoptimized + debuginfo] target(s) in 7.07s
     Running target/debug/deps/hc-a4319c0a8f06a72c

running 1 test
> echo $PWD
"echo $PWD"
$PWD
test util::tests::run_cmd_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out
```

before, passing `"\"$PWD\""` to `run_cmd`:

```
[nix-shell:~/holochain-rust]$ cargo test -p hc run_cmd_test -- --nocapture
   Compiling hc v0.0.41-alpha4 (/home/thedavidmeister/holochain-rust/crates/cli)
    Finished test [unoptimized + debuginfo] target(s) in 6.76s
     Running target/debug/deps/hc-a4319c0a8f06a72c

running 1 test
> echo "$PWD"
"echo \"$PWD\""
"$PWD"
test util::tests::run_cmd_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out
```

after, passing `"$PWD"` to `run_cmd`:

```
[nix-shell:~/holochain-rust]$ cargo test -p hc run_cmd_test -- --nocapture
   Compiling hc v0.0.41-alpha4 (/home/thedavidmeister/holochain-rust/crates/cli)
    Finished test [unoptimized + debuginfo] target(s) in 6.91s
     Running target/debug/deps/hc-a4319c0a8f06a72c

running 1 test
> echo $PWD
"echo $PWD"
/tmp/tmp.AVS17kzpYd/org_holochain_testaHkIaA
test util::tests::run_cmd_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out
```

after, passing `"\"$PWD\""` to `run_cmd`:

```
[nix-shell:~/holochain-rust]$ cargo test -p hc run_cmd_test -- --nocapture
   Compiling hc v0.0.41-alpha4 (/home/thedavidmeister/holochain-rust/crates/cli)
    Finished test [unoptimized + debuginfo] target(s) in 6.86s
     Running target/debug/deps/hc-a4319c0a8f06a72c

running 1 test
> echo "$PWD"
"echo \"$PWD\""
/tmp/tmp.AVS17kzpYd/org_holochain_testemzqDO
test util::tests::run_cmd_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out
```

after, passing `"'$PWD'"` (single quotes) to `run_cmd`:

```
[nix-shell:~/holochain-rust]$ cargo test -p hc run_cmd_test -- --nocapture
   Compiling hc v0.0.41-alpha4 (/home/thedavidmeister/holochain-rust/crates/cli)
    Finished test [unoptimized + debuginfo] target(s) in 6.77s
     Running target/debug/deps/hc-a4319c0a8f06a72c

running 1 test
> echo '$PWD'
"echo \'$PWD\'"
$PWD
test util::tests::run_cmd_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out
```

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
