### PR TITLE
2019 12 26 debug cli docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,9 +339,9 @@ workflows:
    - docker-build-circle-sim2h:
       requires:
        - docker-build-latest
-   - docker-build-circle-cli-tests
-      # requires:
-      #  - docker-build-latest
+   - docker-build-circle-cli-tests:
+      requires:
+       - docker-build-latest
    - docker-build-circle-fmt:
       requires:
        - docker-build-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,9 +339,9 @@ workflows:
    - docker-build-circle-sim2h:
       requires:
        - docker-build-latest
-   - docker-build-circle-cli-tests:
-      requires:
-       - docker-build-latest
+   - docker-build-circle-cli-tests
+      # requires:
+      #  - docker-build-latest
    - docker-build-circle-fmt:
       requires:
        - docker-build-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ workflows:
         only:
          - develop
          - final-exam
-         - 2019-12-23-docker-aws-push
+         - 2019-12-26-debug-cli-docker
    - docker-build-circle-build:
       requires:
        - docker-build-latest

--- a/docker/Dockerfile.circle.cli-tests
+++ b/docker/Dockerfile.circle.cli-tests
@@ -1,7 +1,7 @@
 ARG DOCKER_BRANCH=develop
 FROM holochain/holochain-rust:latest.${DOCKER_BRANCH}
 
-RUN cargo test -p hc --target-dir "$CARGO_TARGET_DIR"/cli-test
+RUN nix-shell --run 'cargo test -p hc --target-dir "$CARGO_TARGET_DIR"/cli-test'
 
 ENV USER="$(id -u -n)"
 ENV app_name=my_first_app

--- a/docker/Dockerfile.circle.cli-tests
+++ b/docker/Dockerfile.circle.cli-tests
@@ -1,16 +1,17 @@
 ARG DOCKER_BRANCH=develop
 FROM holochain/holochain-rust:latest.${DOCKER_BRANCH}
 
+# warm unit tests for hc
 RUN nix-shell --run 'cargo test -p hc --target-dir "$CARGO_TARGET_DIR"/cli-test'
 
-ENV USER="$(id -u -n)"
+# warm the things that the cli tests will use without running all the tests
+# actually running all the tests seems to be flakey/hang inside a docker build
 ENV app_name=my_first_app
 ENV zome_name=my_zome
 RUN nix-shell --run hc-cli-install
-RUN nix-shell --run 'command -v hc'
-RUN nix-shell --run 'hc init "$TMP/$app_name"'
-WORKDIR "$TMP/$app_name"
-RUN nix-shell --run 'hc generate "zomes/$zome_name"'
-ENV CARGO_TARGET_DIR="$CARGO_TARGET_DIR/cli/hc-test"
-RUN echo "# $CARGO_TARGET_DIR"
-RUN hc test
+RUN nix-shell --run 'hc init "$TMP/$app_name" \
+ && cd "$TMP/$app_name" \
+ && hc generate "zomes/$zome_name" \
+ && export CARGO_TARGET_DIR="$CARGO_TARGET_DIR/cli/hc-test" \
+ && hc package \
+ && npm install'

--- a/docker/Dockerfile.circle.cli-tests
+++ b/docker/Dockerfile.circle.cli-tests
@@ -14,4 +14,5 @@ RUN nix-shell --run 'hc init "$TMP/$app_name" \
  && hc generate "zomes/$zome_name" \
  && export CARGO_TARGET_DIR="$CARGO_TARGET_DIR/cli/hc-test" \
  && hc package \
+ && cd test \
  && npm install'

--- a/docker/Dockerfile.circle.cli-tests
+++ b/docker/Dockerfile.circle.cli-tests
@@ -1,4 +1,16 @@
 ARG DOCKER_BRANCH=develop
 FROM holochain/holochain-rust:latest.${DOCKER_BRANCH}
 
-RUN nix-shell --run hc-cli-test
+RUN cargo test -p hc --target-dir "$CARGO_TARGET_DIR"/cli-test
+
+ENV USER="$(id -u -n)"
+ENV app_name=my_first_app
+ENV zome_name=my_zome
+RUN nix-shell --run hc-cli-install
+RUN nix-shell --run 'command -v hc'
+RUN nix-shell --run 'hc init "$TMP/$app_name"'
+WORKDIR "$TMP/$app_name"
+RUN nix-shell --run 'hc generate "zomes/$zome_name"'
+ENV CARGO_TARGET_DIR="$CARGO_TARGET_DIR/cli/hc-test"
+RUN echo "# $CARGO_TARGET_DIR"
+RUN hc test


### PR DESCRIPTION
## PR summary

seems like _something_ in `hc test` is hanging or going super slow or something, even with 45 minutes on the timeout the docker box build breaks - https://circleci.com/gh/holochain/holochain-rust/63966?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

note this slowness/hanging only happens when building a docker box that includes `hc test` and an already-built box can run the tests fine it seems

so this PR breaks the docker build process out into things that warm the relevant things in a more low-level way:

- runs the unit tests as normal
- installs the cli fresh
- npm install
- hc package (but not hc test)

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
