### PR TITLE
Make scaffold tests by using n3h as network

### DIFF
--- a/crates/cli/src/cli/js-tests-scaffold/index.js
+++ b/crates/cli/src/cli/js-tests-scaffold/index.js
@@ -16,7 +16,10 @@ const dnaPath = path.join(__dirname, "../dist/<<DNA_NAME>>.dna.json")
 const orchestrator = new Orchestrator()
 
 const dna = Config.dna(dnaPath, 'scaffold-test')
-const conductorConfig = Config.gen({myInstanceName: dna})
+const conductorConfig = Config.gen(
+  {myInstanceName: dna},
+  {network: Config.network('n3h')}
+)
 
 orchestrator.registerScenario("description of example test", async (s, t) => {
 


### PR DESCRIPTION
## PR summary

It was either this or making in-memory networking work, which requires the hack of including a tryorama middleware to combine all conductors into one single conductor. This seems simpler even though we don't want to promote n3h as a pattern.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
