### PR TITLE
Intra-conductor link propagation

### DIFF
--- a/app_spec/test/config.js
+++ b/app_spec/test/config.js
@@ -75,6 +75,12 @@ module.exports = {
     },
     commonConfig
   ),
+  twoSame: Config.gen({
+      app1: dna,
+      app2: dna,
+    },
+    commonConfig
+  ),
   two: Config.gen({
       app1: dna,
       app2: dna2

--- a/app_spec/test/config.js
+++ b/app_spec/test/config.js
@@ -69,6 +69,7 @@ const logger = {
 const commonConfig = { logger, network }
 
 module.exports = {
+  dna,
   one: Config.gen({
       app: dna
     },

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -1,14 +1,10 @@
-const { one, two, dna } = require('../config')
+const { one, twoSame } = require('../config')
 const { Config } = require('@holochain/tryorama')
 
 module.exports = scenario => {
 
   scenario.only('links propagate within a single conductor', async (s, t) => {
-    const config = Config.gen({
-      app1: dna,
-      app2: dna,
-    })
-    const { alice } = await s.players({alice: config}, true)
+    const { alice } = await s.players({alice: twoSame}, true)
 
     await alice.call('app1', 'simple', 'create_link',
       { base: alice.info('app1').agentAddress, target: 'Posty' }


### PR DESCRIPTION
## PR summary

Adds a test that demonstrates whether or not links can propagate between instances of the same DNA on a single conductor. The viability of writing in-memory tests, and scaled up final-exam tests, relies on this result.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
