### PR TITLE
Sim2h dedup fix

### DIFF
--- a/crates/sim2h/src/cache.rs
+++ b/crates/sim2h/src/cache.rs
@@ -306,6 +306,32 @@ mod tests {
     use std::convert::TryFrom;
 
     #[test]
+    fn aspect_list_holds_aspects() {
+        let mut list = AspectList::from(HashMap::new());
+        assert_eq!(list.pretty_string(), "");
+        let entry_hash = EntryHash::from("entry_hash_1");
+        let aspect_hash = AspectHash::from("aspect_hash_1");
+        list.add(entry_hash.clone(), aspect_hash.clone());
+        assert_eq!(list.pretty_string(), "entry_hash_1: [aspect_hash_1]");
+        // adding again doesn't cause duplication
+        list.add(entry_hash.clone(), aspect_hash);
+        assert_eq!(list.pretty_string(), "entry_hash_1: [aspect_hash_1]");
+
+        // add more entries and aspects
+        let aspect_hash = AspectHash::from("aspect_hash_1a");
+        list.add(entry_hash, aspect_hash);
+        let entry_hash = EntryHash::from("entry_hash_2");
+        let aspect_hash = AspectHash::from("aspect_hash_2");
+        list.add(entry_hash, aspect_hash);
+        assert!(list.pretty_string() == "entry_hash_2: [aspect_hash_2]\nentry_hash_1: [aspect_hash_1, aspect_hash_1a]" ||
+                list.pretty_string() == "entry_hash_1: [aspect_hash_1, aspect_hash_1a]\nentry_hash_2: [aspect_hash_2]");
+        assert_eq!(list.aspect_hashes().len(), 3);
+    }
+
+    #[test]
+    fn aspect_list_diffs_aspects() {}
+
+    #[test]
     fn space_can_add_and_remove_agents() {
         let mut space = Space::new(Box::new(SodiumCryptoSystem::new()));
         let agent =

--- a/crates/sim2h/src/cache.rs
+++ b/crates/sim2h/src/cache.rs
@@ -208,10 +208,10 @@ impl AspectList {
     }
 
     pub fn add(&mut self, entry_address: EntryHash, aspect_address: AspectHash) {
-        self.0
-            .entry(entry_address)
-            .or_insert_with(Vec::new)
-            .push(aspect_address);
+        let list = self.0.entry(entry_address).or_insert_with(Vec::new);
+        if !list.contains(&aspect_address) {
+            list.push(aspect_address);
+        }
     }
 
     pub fn entry_addresses(&self) -> impl Iterator<Item = &EntryHash> {


### PR DESCRIPTION
## PR summary

We were inserting multiple copies of aspects into the aspect list.  This PR fixes that and adds a test. 

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

We really should be merging the AspectList with the AspectMap and doing so with benchmarking, but it's not immediately trivial because EntryData that goes over the wire is serialied as a Vec not a map so there's some from munging to do.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
