### PR TITLE
Use fair unlocking when locking the guard tracking mutex guard

### DIFF
--- a/crates/locksmith/src/tracker.rs
+++ b/crates/locksmith/src/tracker.rs
@@ -1,6 +1,6 @@
 use crate::{
     common::{
-        guards_guard, ACTIVE_GUARD_MIN_ELAPSED, ACTIVE_GUARD_NO_ACTIVITY_INTERVAL,
+        with_guards_guard, ACTIVE_GUARD_MIN_ELAPSED, ACTIVE_GUARD_NO_ACTIVITY_INTERVAL,
         GUARD_WATCHER_POLL_INTERVAL, IMMORTAL_TIMEOUT,
     },
     error::LockType,
@@ -101,10 +101,11 @@ pub fn spawn_locksmith_guard_watcher() {
             let mut inactive_for = Duration::from_millis(0);
             loop {
                 let mut reports: Vec<(i64, String)> = {
-                    guards_guard()
-                        .values_mut()
-                        .filter_map(|gt| gt.report_and_update())
-                        .collect()
+                    with_guards_guard(|g| {
+                        g.values_mut()
+                            .filter_map(|gt| gt.report_and_update())
+                            .collect()
+                    })
                 };
                 if reports.len() > 0 {
                     inactive_for = Duration::from_millis(0);


### PR DESCRIPTION
## PR summary

This may help with a case @lucksus saw where an instance couldn't acquire a lock for 20 seconds. The hypothesis is that running 80 instances in a single conductor caused the locksmith guard-tracking mutex to thrash and starve out one of the instances. Hopefully this helps.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
