### PR TITLE
Sim2h cache entry locations for performance

### DIFF
--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -438,9 +438,9 @@ impl Sim2hState {
         query_data: QueryEntryData,
         redundant_count: u64,
     ) -> Vec<Lib3hUri> {
-        let entry_loc = entry_location(&self.crypto, &query_data.entry_address);
-        let agent_pool = self
-            .get_space(&space_address)
+        let space = self.get_space(&space_address);
+        let entry_loc = space.entry_location(&query_data.entry_address);
+        let agent_pool = space
             .agents_supposed_to_hold_entry(entry_loc, redundant_count)
             .keys()
             .cloned()


### PR DESCRIPTION
## PR summary

These changes make sim2h cache the calculated `Location` of entry hashes.

## testing/benchmarking notes
![Image Pasted at 2020-1-20 17-24](https://user-images.githubusercontent.com/311749/72759695-b5f51780-3bd6-11ea-81a9-c9e986d74c1e.png)

Run-time profiling (see flame graph above) shows that sim2h spends 25% of CPU cycles (re-) calculating the rrDHT location of entry hashes.

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
