### PR TITLE
get_entry panic debugging

### DIFF
--- a/crates/core/src/nucleus/actions/get_entry.rs
+++ b/crates/core/src/nucleus/actions/get_entry.rs
@@ -83,11 +83,6 @@ pub(crate) fn get_entry_crud_meta_from_dht(
         IndexFilter::LatestByAttribute,
         None,
     ))?;
-    assert!(
-        link_eavs.len() <= 1,
-        "link_eavs.len() = {}",
-        link_eavs.len()
-    );
     if link_eavs.len() == 1 {
         maybe_link_update_delete = Some(link_eavs.iter().next().unwrap().value());
     }


### PR DESCRIPTION
## PR summary

This assert created a panic in the Conductor, during recent real-world testing with the Acorn app. @thedavidmeister recommended that I open a PR with the assert removed, to open the topic for discussion. 

The issue was logged at #2069 

There is some interesting looking context around this, like:
https://github.com/holochain/holochain-rust/pull/2075/files#diff-01676d0abf6516ad0140d154d6e4ba20L51-L52
" // TODO waiting for update/remove_eav() assert!(status_eavs.len() <= 1);"
"// For now look for crud-status by life-cycle order: Deleted, Modified, Live"

and the fact that in the file tests it says: 
"/*
    /*
        #[test]
        fn test_get_entry_from_agent_chain() {
          // write this test when its easier to get a mutable agent state
        }
        }
    *
"

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
