### PR TITLE
don't run .bashrc for any commands fed from .hcbuild

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -47,12 +47,17 @@ pub fn run_cmd(base_path: &PathBuf, bin: String, args: &[&str]) -> DefaultResult
     // e.g. we assume `cargo`, `wasm-gc`, `wasm-opt`, `wasm2wat`, `wat2wasm` all exist in the
     // default template (which we can't assume outside nix-shell in a portable way).
     //
+    // Note the use of --norc. This is to prevent the shell from loading up its usual startup
+    // script, which may echo things to STDOUT. The reason this matters is that some of the
+    // commands in a .hcbuild file (which are fed to this function) capture from STDOUT and do
+    // something meaningful with the value. Do we really want a MOTD in our build artifact path?
+    //
     // @TODO - does it make more sense to push "execute arbitrary bash" style features down to the
     // `nix-shell` layer where we have a better toolkit to handle environments/dependencies?
     // e.g. @see `hn-release-cut` from holonix that implements conventions/hooks to standardise
     // bash processes in an extensible way
     let status = Command::new("bash")
-        .args(&["-c", &command_string])
+        .args(&["--norc", "-c", &command_string])
         .current_dir(base_path)
         .status()?;
 


### PR DESCRIPTION
## PR summary

Resolves #2097

## testing/benchmarking notes

Profound apologies; I can't get the silly thing to compile (missing build deps for newrelic-sys and it's late). But the means for testing would be as follows:

1. Add the line `echo "hello"` somewhere in your `.bashrc` file.
2. Compile a zome with `hc package`.

On current `develop` this should fail with a message like:

```
Error: Couldn't traverse DNA in directory "/home/alice/Holochain/stub-project": artifact path /home/alice/Holochain/stub-project/zomes/stub-zome/code/***hello***
/home/alice/target/wasm32-unknown-unknown/release/stub-zome.wasm either doesn't point to a file or doesn't exist
```

With this fix it should succeed.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```