### PR TITLE
prepend joinspace on reconnect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ workflows:
          - develop
          - final-exam
          - trycp-update-hc
+         - prepend-joinspace
    - docker-build-trycp-server:
       requires:
        - docker-build-minimal
@@ -285,6 +286,7 @@ workflows:
          - develop
          - final-exam
          - trycp-update-hc
+         - prepend-joinspace
    - docker-build-circle-build:
       requires:
        - docker-build-latest

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -188,7 +188,7 @@ impl Sim2hWorker {
                 }
             };
             debug!("SENDING JOIN {:#?}", msg);
-            self.send_wire_message(msg)
+            self.prepend_wire_message(msg)
                 .expect("can send JoinSpace on reconnect");
         }
     }
@@ -254,6 +254,14 @@ impl Sim2hWorker {
             // we can remove it from the outgoing buffer queue
             self.outgoing_message_buffer.remove(0);
         }
+    }
+
+    /// if we re-connected, we may need to send a join first,
+    /// before other queued messages
+    fn prepend_wire_message(&mut self, message: WireMessage) -> NetResult<()> {
+        debug!("WireMessage: queueing {:?}", message);
+        self.outgoing_message_buffer.insert(0, message);
+        Ok(())
     }
 
     /// queue a wire message for send

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -1292,10 +1292,7 @@ async fn missing_aspects_resync(sim2h_handle: Sim2hHandle, _schedule_guard: Sche
     let agents_needing_gossip = sim2h_handle.state().check_gossip().await.spaces();
 
     if agents_needing_gossip.is_empty() {
-        debug!(
-            "sim2h gossip space {:?} no agents needing gossip",
-            space_hash
-        );
+        debug!("sim2h gossip no agents needing gossip");
     }
 
     for (space_hash, agents) in agents_needing_gossip.iter() {

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -1291,12 +1291,13 @@ async fn missing_aspects_resync(sim2h_handle: Sim2hHandle, _schedule_guard: Sche
 
     let agents_needing_gossip = sim2h_handle.state().check_gossip().await.spaces();
 
-    for (space_hash, agents) in agents_needing_gossip.iter() {
-        trace!("sim2h gossip agent count: {}", agents.len());
+    if agents_needing_gossip.is_empty() {
+        debug!("sim2h gossip space {:?} no agents needing gossip", space_hash);
+    }
 
-        if agents.is_empty() {
-            debug!("sim2h gossip space {:?} no agents needing gossip", space_hash);
-        }
+    for (space_hash, agents) in agents_needing_gossip.iter() {
+        trace!("sim2h gossip agent count: {} in space {:?}", agents.len(), space_hash);
+
 
         for agent_id in agents {
             // explicitly yield here as we don't want to hog the scheduler
@@ -1309,8 +1310,6 @@ async fn missing_aspects_resync(sim2h_handle: Sim2hHandle, _schedule_guard: Sche
                 None => continue,
                 Some(r) => r,
             };
-
-            debug!("sim2h gossip agent {:?} looking for aspects in {} entries", agent_id, r.len());
 
             for (entry_hash, aspects) in r.iter() {
                 if aspects.is_empty() {

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -1292,12 +1292,18 @@ async fn missing_aspects_resync(sim2h_handle: Sim2hHandle, _schedule_guard: Sche
     let agents_needing_gossip = sim2h_handle.state().check_gossip().await.spaces();
 
     if agents_needing_gossip.is_empty() {
-        debug!("sim2h gossip space {:?} no agents needing gossip", space_hash);
+        debug!(
+            "sim2h gossip space {:?} no agents needing gossip",
+            space_hash
+        );
     }
 
     for (space_hash, agents) in agents_needing_gossip.iter() {
-        trace!("sim2h gossip agent count: {} in space {:?}", agents.len(), space_hash);
-
+        trace!(
+            "sim2h gossip agent count: {} in space {:?}",
+            agents.len(),
+            space_hash
+        );
 
         for agent_id in agents {
             // explicitly yield here as we don't want to hog the scheduler

--- a/crates/sim2h/src/wire_message.rs
+++ b/crates/sim2h/src/wire_message.rs
@@ -16,6 +16,7 @@ pub enum WireError {
 pub struct StatusData {
     pub spaces: usize,
     pub connections: usize,
+    pub joined_connections: usize,
     pub redundant_count: u64,
     pub version: u32,
 }


### PR DESCRIPTION
When sim2h_worker does a reconnect - it needs to prepend the joinspace message to the outgoing messages queue.