### PR TITLE
hc-dpki cli for DeepKey

### DIFF
--- a/crates/cli/src/cli/dpki.rs
+++ b/crates/cli/src/cli/dpki.rs
@@ -1,0 +1,486 @@
+use crate::{
+    cli::keygen,
+    util::{self, get_secure_string_double_check, user_prompt, user_prompt_yes_no, WordCountable},
+};
+use holochain_core_types::error::HcResult;
+use holochain_dpki::{
+    key_bundle::KeyBundle,
+    keypair::KeyPair,
+    seed::{MnemonicableSeed, RootSeed, SeedTrait, SeedType, TypedSeed},
+    utils::generate_random_seed_buf,
+};
+use lib3h_sodium::secbuf::SecBuf;
+use std::{path::PathBuf, str::FromStr, string::ParseError};
+use structopt::StructOpt;
+
+const MNEMONIC_WORD_COUNT: usize = 24;
+const ENCRYPTED_MNEMONIC_WORD_COUNT: usize = 2 * MNEMONIC_WORD_COUNT;
+
+const DEFAULT_REVOCATION_KEY_DEV_INDEX: u64 = 1;
+const DEFAULT_AUTH_KEY_DEV_INDEX: u64 = 1;
+
+pub enum SignType {
+    Revoke,
+    Auth,
+}
+
+impl FromStr for SignType {
+    type Err = ParseError;
+    fn from_str(day: &str) -> Result<Self, Self::Err> {
+        match day {
+            "revoke" => Ok(SignType::Revoke),
+            "auth" => Ok(SignType::Auth),
+            _ => panic!(),
+        }
+    }
+}
+
+#[derive(StructOpt)]
+pub enum Dpki {
+    #[structopt(
+        name = "genroot",
+        about = "Generate a new random DPKI root seed. This is encrypyed with a passphrase and printed in BIP39 mnemonic form to stdout. Both the passphrase and mnemonic should be recorded and kept safe to be used later for key management."
+    )]
+    GenRoot {
+        passphrase: Option<String>,
+        quiet: bool,
+    },
+
+    #[structopt(
+        name = "keygen",
+        about = "Identical to `hc keygen` but derives agent key pair from a DPKI root seed at a given derivation index. This allows the keys to be recovered provided the root seed is known."
+    )]
+    Keygen {
+        #[structopt(long, short, help = "Specify path of file")]
+        path: Option<PathBuf>,
+
+        #[structopt(
+            long,
+            short,
+            help = "Only print machine-readable output; intended for use by programs and scripts"
+        )]
+        quiet: bool,
+
+        #[structopt(
+            long,
+            short,
+            help = "Set passphrase via argument and don't prompt for it (not reccomended)"
+        )]
+        keystore_passphrase: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "Use insecure, hard-wired passphrase for testing and Don't ask for passphrase"
+        )]
+        nullpass: bool,
+
+        #[structopt(
+            long,
+            short,
+            help = "Set root seed via argument and don't prompt for it (not reccomended). BIP39 mnemonic encoded root seed to derive device seed and agent key from"
+        )]
+        root_seed: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "Set mnemonic passphrase via argument and don't prompt for it (not reccomended)"
+        )]
+        mnemonic_passphrase: Option<String>,
+
+        #[structopt(help = "Derive device seed from root seed with this index")]
+        device_derivation_index: u64,
+    },
+
+    #[structopt(
+        name = "genrevoke",
+        about = "Generate a revocation seed given an encrypted root seed mnemonic, passphrase and derivation index."
+    )]
+    GenRevoke {
+        #[structopt(help = "Derive revocation seed from root seed with this index")]
+        derivation_index: u64,
+
+        #[structopt(
+            long,
+            short,
+            help = "unsecurely pass passphrase to decrypt root seed (not reccomended). Will prompt if encrypted seed provided."
+        )]
+        root_seed_passphrase: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "unsecurely pass passphrase to encrypt revocation seed (not reccomended)."
+        )]
+        revocation_seed_passphrase: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "Only print machine-readable output; intended for use by programs and scripts"
+        )]
+        quiet: bool,
+    },
+
+    #[structopt(
+        name = "genauth",
+        about = "Generate an auth seed given an encrypted root seed mnemonic, passphrase and derivation index."
+    )]
+    GenAuth {
+        #[structopt(help = "Derive auth seed from root seed with this index")]
+        derivation_index: u64,
+
+        #[structopt(
+            long,
+            short,
+            help = "unsecurely pass passphrase to decrypt root seed (not reccomended). Will prompt if encrypted seed provided."
+        )]
+        root_seed_passphrase: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "unsecurely pass passphrase to encrypt auth seed (not reccomended)."
+        )]
+        auth_seed_passphrase: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "Only print machine-readable output; intended for use by programs and scripts"
+        )]
+        quiet: bool,
+    },
+
+    #[structopt(
+        name = "sign",
+        about = "Produce the signed string needed to revoke a key given a revocation seed mnemonic and passphrase."
+    )]
+    Sign {
+        #[structopt(
+            help = "Public key to revoke/authorize (or any other string you want to sign with an auth/revocation key)"
+        )]
+        key: String,
+
+        #[structopt(
+            long,
+            short,
+            help = "unsecurely pass passphrase to decrypt revocation seed (not reccomended). Will prompt if encrypted seed provided."
+        )]
+        passphrase: Option<String>,
+
+        #[structopt(
+            long,
+            short,
+            help = "Only print machine-readable output; intended for use by programs and scripts"
+        )]
+        quiet: bool,
+
+        #[structopt(long, short, help = "How to interpred seed (revoke/auth)")]
+        sign_type: SignType,
+    },
+}
+
+impl Dpki {
+    pub fn execute(self) -> HcResult<String> {
+        match self {
+            Self::GenRoot { passphrase, quiet } => genroot(passphrase, quiet),
+            Self::Keygen {
+                path,
+                keystore_passphrase,
+                nullpass,
+                quiet,
+                root_seed,
+                mnemonic_passphrase,
+                device_derivation_index,
+            } => keygen(
+                path,
+                keystore_passphrase,
+                nullpass,
+                mnemonic_passphrase,
+                root_seed,
+                Some(device_derivation_index),
+                quiet,
+            )
+            .map(|_| "success".to_string()),
+            Self::GenRevoke {
+                derivation_index,
+                root_seed_passphrase,
+                revocation_seed_passphrase,
+                quiet,
+            } => genrevoke(
+                root_seed_passphrase,
+                revocation_seed_passphrase,
+                derivation_index,
+                quiet,
+            ),
+            Self::GenAuth {
+                derivation_index,
+                root_seed_passphrase,
+                auth_seed_passphrase,
+                quiet,
+            } => genauth(
+                root_seed_passphrase,
+                auth_seed_passphrase,
+                derivation_index,
+                quiet,
+            ),
+            Self::Sign {
+                passphrase,
+                key,
+                sign_type,
+                quiet,
+            } => sign(passphrase, key, sign_type, quiet),
+        }
+    }
+}
+
+fn genroot(passphrase: Option<String>, quiet: bool) -> HcResult<String> {
+    user_prompt(
+        "This will generate a new random DPKI root seed.
+You should only have to do this once and you should keep the seed safe.
+It will be printed out once as a mnemonic at the end of this process.
+The root seed can be used to generate new device, revocation and auth keys.\n",
+        quiet,
+    );
+
+    let passphrase = passphrase.or_else(|| {
+        match user_prompt_yes_no("Would you like to encrypt the root seed?", quiet) {
+            true => Some(
+                get_secure_string_double_check("Root Seed Passphrase", quiet)
+                    .expect("Could not read revocation passphrase"),
+            ),
+            false => None,
+        }
+    });
+    println!();
+    genroot_inner(passphrase)
+}
+
+pub(crate) fn genroot_inner(passphrase: Option<String>) -> HcResult<String> {
+    let seed_buf = generate_random_seed_buf();
+    let mut root_seed = RootSeed::new(seed_buf);
+    match passphrase {
+        Some(passphrase) => root_seed.encrypt(passphrase, None)?.get_mnemonic(),
+        None => root_seed.seed_mut().get_mnemonic(),
+    }
+}
+
+fn genrevoke(
+    root_seed_passphrase: Option<String>,
+    revocation_seed_passphrase: Option<String>,
+    derivation_index: u64,
+    quiet: bool,
+) -> HcResult<String> {
+    user_prompt(
+        "This will generate a new revocation seed derived from a root seed.
+This can be used to revoke access to keys you have previously authorized.\n",
+        quiet,
+    );
+
+    let root_seed_mnemonic = get_secure_string_double_check("Root Seed", quiet)?;
+    let root_seed_passphrase = match root_seed_mnemonic.word_count() {
+        MNEMONIC_WORD_COUNT => None, // ignore any passphrase passed if it is an unencrypted mnemonic
+        ENCRYPTED_MNEMONIC_WORD_COUNT => root_seed_passphrase.or_else(|| {
+            Some(
+                get_secure_string_double_check("Root Seed Passphrase", quiet)
+                    .expect("Could not read passphrase"),
+            )
+        }),
+        _ => panic!("Invalid word count for mnemonic"),
+    };
+    let revocation_seed_passphrase =
+        revocation_seed_passphrase.or_else(|| {
+            match user_prompt_yes_no("Would you like to encrypt the revocation seed?", quiet) {
+                true => Some(
+                    get_secure_string_double_check("Revocation Seed Passphrase", quiet)
+                        .expect("Could not read revocation passphrase"),
+                ),
+                false => None,
+            }
+        });
+    println!();
+    let (mnemonic, pubkey) = genauth_genrevoke_inner(
+        root_seed_mnemonic,
+        root_seed_passphrase,
+        revocation_seed_passphrase,
+        derivation_index,
+        SignType::Revoke,
+    )?;
+    Ok(format!("Public Key: {}\n\nMnemonic: {}", pubkey, mnemonic))
+}
+
+fn genauth(
+    root_seed_passphrase: Option<String>,
+    auth_seed_passphrase: Option<String>,
+    derivation_index: u64,
+    quiet: bool,
+) -> HcResult<String> {
+    user_prompt(
+        "This will generate a new authorization seed derived from a root seed.
+This can be used to authorize new keys in DPKI.\n",
+        quiet,
+    );
+
+    let root_seed_mnemonic = get_secure_string_double_check("Root Seed", quiet)?;
+    let root_seed_passphrase = match root_seed_mnemonic.word_count() {
+        MNEMONIC_WORD_COUNT => None, // ignore any passphrase passed if it is an unencrypted mnemonic
+        ENCRYPTED_MNEMONIC_WORD_COUNT => root_seed_passphrase.or_else(|| {
+            Some(
+                get_secure_string_double_check("Root Seed Passphrase", quiet)
+                    .expect("Could not read passphrase"),
+            )
+        }),
+        _ => panic!("Invalid word count for mnemonic"),
+    };
+    let auth_seed_passphrase = auth_seed_passphrase.or_else(|| {
+        match user_prompt_yes_no("Would you like to encrypt the auth seed?", quiet) {
+            true => Some(
+                get_secure_string_double_check("Auth Seed Passphrase", quiet)
+                    .expect("Could not read auth passphrase"),
+            ),
+            false => None,
+        }
+    });
+    println!();
+    let (mnemonic, pubkey) = genauth_genrevoke_inner(
+        root_seed_mnemonic,
+        root_seed_passphrase,
+        auth_seed_passphrase,
+        derivation_index,
+        SignType::Auth,
+    )?;
+    Ok(format!("Public Key: {}\n\nMnemonic: {}", pubkey, mnemonic))
+}
+
+fn genauth_genrevoke_inner(
+    root_seed_mnemonic: String,
+    root_seed_passphrase: Option<String>,
+    new_seed_passphrase: Option<String>,
+    derivation_index: u64,
+    key_type: SignType,
+) -> HcResult<(String, String)> {
+    let mut root_seed =
+        match util::get_seed(root_seed_mnemonic, root_seed_passphrase, SeedType::Root)? {
+            TypedSeed::Root(s) => s,
+            _ => unreachable!(),
+        };
+
+    match key_type {
+        SignType::Revoke => {
+            let mut revocation_seed = root_seed.generate_revocation_seed(derivation_index)?;
+            let pubkey = revocation_seed
+                .generate_revocation_key(DEFAULT_REVOCATION_KEY_DEV_INDEX)?
+                .sign_keys
+                .public();
+            match new_seed_passphrase {
+                Some(passphrase) => Ok((
+                    revocation_seed.encrypt(passphrase, None)?.get_mnemonic()?,
+                    pubkey,
+                )),
+                None => Ok((revocation_seed.seed_mut().get_mnemonic()?, pubkey)),
+            }
+        }
+        SignType::Auth => {
+            // TODO: Allow different derivation paths for the auth key
+            let mut auth_seed = root_seed
+                .generate_device_seed(derivation_index)?
+                .generate_auth_seed(1)?;
+            let pubkey = auth_seed
+                .generate_auth_key(DEFAULT_AUTH_KEY_DEV_INDEX)?
+                .sign_keys
+                .public();
+            match new_seed_passphrase {
+                Some(passphrase) => {
+                    Ok((auth_seed.encrypt(passphrase, None)?.get_mnemonic()?, pubkey))
+                }
+                None => Ok((auth_seed.seed_mut().get_mnemonic()?, pubkey)),
+            }
+        }
+    }
+}
+
+fn sign(
+    passphrase: Option<String>,
+    key_string: String,
+    sign_type: SignType,
+    quiet: bool,
+) -> HcResult<String> {
+    user_prompt("This will sign a given key/string with a auth/revocation key.
+The resulting signed message can be used to publish a DPKI auth/revocation message which will auth/revoke a key.\n", quiet);
+
+    let seed_mnemonic = get_secure_string_double_check("Seed", false)?;
+    let passphrase = match seed_mnemonic.word_count() {
+        MNEMONIC_WORD_COUNT => None, // ignore any passphrase passed if it is an unencrypted mnemonic
+        ENCRYPTED_MNEMONIC_WORD_COUNT => passphrase.or_else(|| {
+            Some(
+                get_secure_string_double_check("Seed Passphrase", quiet)
+                    .expect("Could not read passphrase"),
+            )
+        }),
+        _ => panic!("Invalid word count for mnemonic"),
+    };
+    println!();
+    sign_inner(seed_mnemonic, passphrase, key_string, sign_type)
+}
+
+fn sign_inner(
+    seed_mnemonic: String,
+    passphrase: Option<String>,
+    key_string: String,
+    sign_type: SignType,
+) -> HcResult<String> {
+    let mut keypair = match sign_type {
+        SignType::Revoke => {
+            let mut revocation_seed =
+                match util::get_seed(seed_mnemonic, passphrase, SeedType::Revocation)? {
+                    TypedSeed::Revocation(s) => s,
+                    _ => unreachable!(),
+                };
+            revocation_seed.generate_revocation_key(DEFAULT_REVOCATION_KEY_DEV_INDEX)?
+        }
+        SignType::Auth => {
+            let mut auth_seed = match util::get_seed(seed_mnemonic, passphrase, SeedType::Auth)? {
+                TypedSeed::Auth(s) => s,
+                _ => unreachable!(),
+            };
+            auth_seed.generate_auth_key(DEFAULT_AUTH_KEY_DEV_INDEX)?
+        }
+    };
+    sign_with_key_from_seed(&mut keypair, key_string)
+}
+
+fn sign_with_key_from_seed(keypair: &mut KeyBundle, key_string: String) -> HcResult<String> {
+    let mut data_buf = SecBuf::with_insecure_from_string(key_string);
+    let mut signature_buf = keypair.sign(&mut data_buf)?;
+    let buf = signature_buf.read_lock();
+    let signature_str = base64::encode(&**buf);
+    Ok(signature_str)
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use super::*;
+    use holochain_core_types::signature::{Provenance, Signature};
+    use holochain_dpki::{keypair::*, utils::Verify};
+    use holochain_persistence_api::cas::content::Address;
+
+    #[test]
+    fn can_verify_signature() {
+        let payload = "test signing payload";
+        let mut seed = generate_random_seed_buf();
+        let sign_keys = SigningKeyPair::new_from_seed(&mut seed).unwrap();
+        let enc_keys = EncryptingKeyPair::new_from_seed(&mut seed).unwrap();
+        let mut key_bundle = KeyBundle::new(sign_keys, enc_keys).unwrap();
+
+        let sig = sign_with_key_from_seed(&mut key_bundle, payload.to_string()).unwrap();
+
+        let prov = Provenance::new(
+            Address::from(key_bundle.sign_keys.public),
+            Signature::from(sig),
+        );
+        assert!(prov.verify(payload.to_string()).unwrap());
+    }
+}

--- a/crates/cli/src/cli/keygen.rs
+++ b/crates/cli/src/cli/keygen.rs
@@ -1,48 +1,106 @@
-use crate::NEW_RELIC_LICENSE_KEY;
-use error::DefaultResult;
 use holochain_common::paths::keys_directory;
-use holochain_conductor_lib::{key_loaders::mock_passphrase_manager, keystore::Keystore};
-use rpassword;
+use holochain_conductor_lib::{
+    key_loaders::mock_passphrase_manager,
+    keystore::{Keystore, PRIMARY_KEYBUNDLE_ID},
+};
+use holochain_core_types::error::HcResult;
+use holochain_locksmith::Mutex;
+use holochain_dpki::seed::{SeedType, TypedSeed};
 use std::{
     fs::create_dir_all,
     io::{self, Write},
     path::PathBuf,
+    sync::Arc,
 };
+use util::{get_secure_string_double_check, get_seed, user_prompt};
 
-#[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CLI)]
-pub fn keygen(path: Option<PathBuf>, passphrase: Option<String>, quiet: bool) -> DefaultResult<()> {
-    let passphrase = passphrase.unwrap_or_else(|| {
-        if !quiet {
-            println!(
-                "
-This will create a new agent keystore and populate it with an agent keybundle
+pub fn keygen(
+    path: Option<PathBuf>,
+    keystore_passphrase: Option<String>,
+    nullpass: bool,
+    mnemonic_passphrase: Option<String>,
+    root_seed_mnemonic: Option<String>,
+    device_derivation_index: Option<u64>,
+    quiet: bool,
+) -> HcResult<()> {
+    user_prompt(
+        "This will create a new agent keystore and populate it with an agent keybundle
 containing a public and a private key, for signing and encryption by the agent.
 This keybundle will be stored encrypted by passphrase within the keystore file.
 The passphrase is securing the keys and will be needed, together with the file,
-in order to use the key.
-Please enter a secret passphrase below. You will have to enter it again
-when unlocking the keybundle to use within a Holochain conductor."
-            );
-            print!("Passphrase: ");
-            io::stdout().flush().expect("Could not flush stdout");
-        }
-        let passphrase1 = rpassword::read_password().unwrap();
-        if !quiet {
-            print!("Re-enter passphrase: ");
-            io::stdout().flush().expect("Could not flush stdout");
-        }
-        let passphrase2 = rpassword::read_password().unwrap();
-        if passphrase1 != passphrase2 {
-            println!("Passphrases do not match. Please retry...");
-            ::std::process::exit(1);
-        }
-        passphrase1
-    });
+in order to use the key.\n",
+        quiet,
+    );
 
-    if !quiet {
-        println!("Generating keystore (this will take a few moments)...");
-    }
-    let (keystore, pub_key) = Keystore::new_standalone(mock_passphrase_manager(passphrase), None)?;
+    let keystore_passphrase = match (keystore_passphrase, nullpass) {
+        (None, true) => String::from(holochain_common::DEFAULT_PASSPHRASE),
+        (Some(s), false) => s,
+        (Some(_), true) => panic!(
+            "Invalid combination of args. Cannot pass --nullpass and also provide a passphrase"
+        ),
+        (None, false) => {
+            // prompt for the passphrase
+            user_prompt(
+                "Please enter a secret passphrase below. You will have to enter it again
+when unlocking the keybundle to use within a Holochain conductor.\n",
+                quiet,
+            );
+            io::stdout().flush().expect("Could not flush stdout");
+            get_secure_string_double_check("keystore Passphrase", quiet)
+                .expect("Could not retrieve passphrase")
+        }
+    };
+
+    let (keystore, pub_key) = if let Some(derivation_index) = device_derivation_index {
+        user_prompt("This keystore is to be generated from a DPKI root seed. You can regenerate this keystore at any time by using the same root key mnemonic and device derivation index.", quiet);
+
+        let root_seed_mnemonic = root_seed_mnemonic.unwrap_or_else(|| {
+            get_secure_string_double_check("Root Seed Mnemonic", quiet)
+                .expect("Could not retrieve mnemonic")
+        });
+
+        match root_seed_mnemonic.split(" ").count() {
+            24 => {
+                // unencrypted mnemonic
+                user_prompt(
+                    "Generating keystore (this will take a few moments)...",
+                    quiet,
+                );
+                keygen_dpki(
+                    root_seed_mnemonic,
+                    None,
+                    derivation_index,
+                    keystore_passphrase,
+                )?
+            }
+            48 => {
+                // encrypted mnemonic
+                let mnemonic_passphrase = mnemonic_passphrase.unwrap_or_else(|| {
+                    get_secure_string_double_check("Root Seed Mnemonic passphrase", quiet)
+                        .expect("Could not retrieve mnemonic passphrase")
+                });
+                user_prompt(
+                    "Generating keystore (this will take a few moments)...",
+                    quiet,
+                );
+                keygen_dpki(
+                    root_seed_mnemonic,
+                    Some(mnemonic_passphrase),
+                    derivation_index,
+                    keystore_passphrase,
+                )?
+            }
+            _ => panic!(
+                "Invalid number of words in mnemonic. Must be 24 (unencrypted) or 48 (encrypted)"
+            ),
+        }
+    } else {
+        user_prompt(
+            "Generating keystore (this will take a few moments)...",
+            quiet,
+        );
+        keygen_standalone(keystore_passphrase)?
+    };
 
     let path = if None == path {
         let p = keys_directory();
@@ -70,25 +128,90 @@ when unlocking the keybundle to use within a Holochain conductor."
     Ok(())
 }
 
+fn keygen_standalone(keystore_passphrase: String) -> HcResult<(Keystore, String)> {
+    Keystore::new_standalone(mock_passphrase_manager(keystore_passphrase), None)
+}
+
+fn keygen_dpki(
+    root_seed_mnemonic: String,
+    root_seed_passphrase: Option<String>,
+    derivation_index: u64,
+    keystore_passphrase: String,
+) -> HcResult<(Keystore, String)> {
+    let mut root_seed = match get_seed(root_seed_mnemonic, root_seed_passphrase, SeedType::Root)? {
+        TypedSeed::Root(s) => s,
+        _ => unreachable!(),
+    };
+    let mut keystore = Keystore::new(mock_passphrase_manager(keystore_passphrase), None)?;
+    let device_seed = root_seed.generate_device_seed(derivation_index)?;
+    keystore.add("device_seed", Arc::new(Mutex::new(device_seed.into())))?;
+    let (pub_key, _) = keystore.add_keybundle_from_seed("device_seed", PRIMARY_KEYBUNDLE_ID)?;
+    Ok((keystore, pub_key))
+}
+
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use holochain_conductor_lib::{
+    use cli::dpki;
+    use holochain_conductor_api::{
         key_loaders::mock_passphrase_manager,
         keystore::{Keystore, PRIMARY_KEYBUNDLE_ID},
     };
     use std::{fs::remove_file, path::PathBuf};
 
     #[test]
-    fn keygen_roundtrip() {
+    fn keygen_roundtrip_no_dpki() {
         let path = PathBuf::new().join("test.key");
         let passphrase = String::from("secret");
 
-        keygen(Some(path.clone()), Some(passphrase.clone()), true).expect("Keygen should work");
+        keygen(
+            Some(path.clone()),
+            Some(passphrase.clone()),
+            false,
+            None,
+            None,
+            None,
+            true,
+        )
+        .expect("Keygen should work");
 
         let mut keystore =
             Keystore::new_from_file(path.clone(), mock_passphrase_manager(passphrase), None)
                 .unwrap();
+
+        let keybundle = keystore.get_keybundle(PRIMARY_KEYBUNDLE_ID);
+
+        assert!(keybundle.is_ok());
+
+        let _ = remove_file(path);
+    }
+
+    #[test]
+    fn keygen_roundtrip_with_dpki() {
+        let path = PathBuf::new().join("test_dpki.key");
+        let keystore_passphrase = String::from("secret_dpki");
+        let mnemonic_passphrase = String::from("dummy passphrase");
+
+        let mnemonic = dpki::genroot_inner(Some(mnemonic_passphrase.clone()))
+            .expect("Could not generate root seed mneomonic");
+
+        keygen(
+            Some(path.clone()),
+            Some(keystore_passphrase.clone()),
+            false,
+            Some(mnemonic_passphrase),
+            Some(mnemonic),
+            Some(1),
+            true,
+        )
+        .expect("Keygen should work");
+
+        let mut keystore = Keystore::new_from_file(
+            path.clone(),
+            mock_passphrase_manager(keystore_passphrase),
+            None,
+        )
+        .unwrap();
 
         let keybundle = keystore.get_keybundle(PRIMARY_KEYBUNDLE_ID);
 

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod chain_log;
 mod generate;
 mod hash_dna;
+mod dpki;
 pub mod init;
 mod keygen;
 pub mod package;
@@ -11,6 +12,7 @@ pub mod test;
 pub use self::{
     chain_log::{chain_list, chain_log},
     generate::generate,
+    dpki::Dpki,
     hash_dna::hash_dna,
     init::init,
     keygen::keygen,

--- a/crates/dpki/src/keypair.rs
+++ b/crates/dpki/src/keypair.rs
@@ -329,4 +329,24 @@ mod tests {
         let succeeded = sign_keys.verify(&mut message, &mut signature);
         assert!(!succeeded);
     }
+
+    #[test]
+    fn keypair_should_generate_consistent_keys() {
+        let mut seed = SecBuf::with_insecure(32);
+        seed.from_array(&[
+             0u8,  1u8,  2u8,  3u8,  4u8,  5u8,  6u8,  7u8,  8u8,  9u8,
+            10u8, 11u8, 12u8, 13u8, 14u8, 15u8, 16u8, 17u8, 18u8, 19u8,
+            20u8, 21u8, 22u8, 23u8, 24u8, 25u8, 26u8, 27u8, 28u8, 29u8,
+            30u8,255u8,
+        ]).unwrap();
+        let mut keypair = SigningKeyPair::new_from_seed(&mut seed).expect("Failed to generate keypair");
+
+        assert_eq!(keypair.public(), "HcSciPgAEa7N4e6os7X7zK4JdbXnmxygkVVkHChDT3cbuh3wByfwzx9SNuo9xbz");
+
+        // ed25519 Private Keys
+        let pk = keypair.private().read_lock();
+        assert_eq!(format!("{:?}", *pk),
+                   "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 255, 56, 192, 32, 58, 205, 19, 141, 143, 109, 220, 43, 73, 24, 108, 197, 218, 230, 85, 40, 163, 136, 227, 150, 68, 25, 159, 53, 13, 203, 92, 91, 241]"
+        );
+    }
 }

--- a/crates/dpki/src/lib.rs
+++ b/crates/dpki/src/lib.rs
@@ -12,6 +12,9 @@ extern crate holochain_common;
 pub const CONTEXT_SIZE: usize = 8;
 pub const SEED_SIZE: usize = 32;
 pub const AGENT_ID_CTX: [u8; 8] = *b"HCAGNTID";
+pub const DEVICE_CTX: [u8; 8] = *b"HCDEVICE";
+pub const REVOKE_CTX: [u8; 8] = *b"HCREVOKE";
+pub const AUTH_CTX: [u8; 8] = *b"HCAUTHRZ";
 pub(crate) const SIGNATURE_SIZE: usize = 64;
 
 lazy_static! {


### PR DESCRIPTION
## PR summary
Adds some new commands to the CLI tool for managing DPKI keys.

- `hc dpki genroot` creates a new random root seed
- `hc dpki keygen` is similar to `hc keygen` but will use a dpki root seed mnemonic so that keys can be recovered
- `hc dpki genrevoke/genauth` produce revocation/auth seeds from which keys can be derived. 
- `hc dpki sign` use a revocation/auth seed to produce a key then sign a message (which can be an agent key). This is the process by which keys can be authorized and revoked

Each time a mnemonic is produced it is optionally encrypted with a passphrase

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
