### PR TITLE
holochain_metrics: use `StatsByMetric(...)` due to differing type params

### DIFF
--- a/crates/metrics/src/stats.rs
+++ b/crates/metrics/src/stats.rs
@@ -523,7 +523,7 @@ impl<'a, D: DescriptiveStats + Clone + 'a> StatsByMetric<D> {
             data.insert(GroupingKey::new(stream_id, metric_name), stat);
         }
 
-        Ok(Self(data))
+        Ok(StatsByMetric(data))
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug in `stats.rs` (the `holochain_metrics` crate) discovered in https://crater-reports.s3.amazonaws.com/pr-69340/try%239ff4d07208097950831ed4ea9d76feb1eafc8baa/reg/holochain_metrics-0.0.42-alpha5/log.txt. The problem here is that the type parameter `D` used in the `Self` type is not the same as the one returned by the function. This was accepted due to a bug in the compiler and is being fixed by https://github.com/rust-lang/rust/pull/69340.