### PR TITLE
Revert "holochain_metrics: use `StatsByMetric(...)` due to differing type params"

### DIFF
--- a/crates/metrics/src/stats.rs
+++ b/crates/metrics/src/stats.rs
@@ -523,7 +523,7 @@ impl<'a, D: DescriptiveStats + Clone + 'a> StatsByMetric<D> {
             data.insert(GroupingKey::new(stream_id, metric_name), stat);
         }
 
-        Ok(StatsByMetric(data))
+        Ok(Self(data))
     }
 }
 


### PR DESCRIPTION
Reverts holochain/holochain-rust#2126