### PR TITLE
Sim2h space data remote debugging

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,14 +6,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added command to sim2h wire protocol for getting live debug info [#2128](https://github.com/holochain/holochain-rust/pull/2128)
+
 ### Changed
+
 - Changed Pagination to have different types [#2110](https://github.com/holochain/holochain-rust/pull/2110)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- Fixing wire message TK-01102
+- Fixing wire message
 
 ### Security

--- a/crates/cli/src/cli/sim2h_client.rs
+++ b/crates/cli/src/cli/sim2h_client.rs
@@ -8,10 +8,12 @@ use sim2h::{
     crypto::{Provenance, SignedWireMessage},
     WireMessage, WIRE_VERSION,
 };
-use std::sync::{Arc, Mutex};
+use std::{
+    fs::File,
+    io::prelude::*,
+    sync::{Arc, Mutex},
+};
 use url2::prelude::*;
-use std::fs::File;
-use std::io::prelude::*;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CLI)]
 pub fn sim2h_client(url_string: String, message_string: String) -> Result<(), String> {
@@ -67,14 +69,19 @@ pub fn sim2h_client(url_string: String, message_string: String) -> Result<(), St
                         | WireMessage::StatusResponse(_) => {
                             println!("Got response => {:?}", msg);
                             break;
-                        },
+                        }
                         WireMessage::DebugResponse(debug_response_map) => {
                             println!("Got DebugResponse for {} spaces.", debug_response_map.len());
                             for (space, json) in debug_response_map {
                                 let filename = format!("{}.json", space);
-                                println!("Writing Sim2h state dump for space {} to file: {}", space, filename);
-                                let mut file = File::create(filename.clone()).expect(&format!("Could not create file {}!", filename));
-                                file.write_all(json.into_bytes().as_slice()).expect("Could not write to file!");
+                                println!(
+                                    "Writing Sim2h state dump for space {} to file: {}",
+                                    space, filename
+                                );
+                                let mut file = File::create(filename.clone())
+                                    .expect(&format!("Could not create file {}!", filename));
+                                file.write_all(json.into_bytes().as_slice())
+                                    .expect("Could not write to file!");
                             }
                             break;
                         }

--- a/crates/cli/src/cli/sim2h_client.rs
+++ b/crates/cli/src/cli/sim2h_client.rs
@@ -48,7 +48,7 @@ pub fn sim2h_client(url_string: String, message_string: String) -> Result<(), St
         "debug" => WireMessage::Debug,
         _ => {
             return Err(format!(
-                "expecting 'ping' or 'status' for message, got: {}",
+                "expecting 'ping', 'status' or 'debug' for message, got: {}",
                 message_string
             ))
         }

--- a/crates/cli/src/cli/sim2h_client.rs
+++ b/crates/cli/src/cli/sim2h_client.rs
@@ -78,9 +78,12 @@ pub fn sim2h_client(url_string: String, message_string: String) -> Result<(), St
                                     "Writing Sim2h state dump for space {} to file: {}",
                                     space, filename
                                 );
-                                let mut file = File::create(filename.clone())
-                                    .expect(&format!("Could not create file {}!", filename));
-                                file.write_all(json.into_bytes().as_slice())
+
+                                File::create(filename.clone())
+                                    .unwrap_or_else(|_| {
+                                        panic!("Could not create file {}!", filename)
+                                    })
+                                    .write_all(json.into_bytes().as_slice())
                                     .expect("Could not write to file!");
                             }
                             break;

--- a/crates/cli/src/cli/sim2h_client.rs
+++ b/crates/cli/src/cli/sim2h_client.rs
@@ -41,6 +41,7 @@ pub fn sim2h_client(url_string: String, message_string: String) -> Result<(), St
         "ping" => WireMessage::Ping,
         "hello" => WireMessage::Hello(WIRE_VERSION),
         "status" => WireMessage::Status,
+        "debug" => WireMessage::Debug,
         _ => {
             return Err(format!(
                 "expecting 'ping' or 'status' for message, got: {}",
@@ -61,7 +62,8 @@ pub fn sim2h_client(url_string: String, message_string: String) -> Result<(), St
                     match msg {
                         WireMessage::Pong
                         | WireMessage::HelloResponse(_)
-                        | WireMessage::StatusResponse(_) => {
+                        | WireMessage::StatusResponse(_)
+                        | WireMessage::DebugResponse(_) => {
                             println!("Got response => {:?}", msg);
                             break;
                         }

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -547,6 +547,8 @@ impl Sim2hWorker {
                 WireError::Other(e) => error!("Got error from Sim2h server: {:?}", e),
             },
             WireMessage::Status => error!("Got a Status from the Sim2h server, weird! Ignoring"),
+            WireMessage::Debug => error!("Got a Debug from the Sim2h server, weird! Ignoring"),
+            WireMessage::DebugResponse(_) => error!("Got a DebugResponse from the Sim2h server, weird! Ignoring"),
             WireMessage::Hello(_) => error!("Got a Hello from the Sim2h server, weird! Ignoring"),
             WireMessage::HelloResponse(response) => {
                 if WIRE_VERSION != response.version {

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -208,8 +208,8 @@ pub enum DhtAlgorithm {
 #[allow(dead_code)]
 mod mono_ref;
 use mono_ref::*;
-use twox_hash::XxHash64;
 use std::collections::BTreeMap;
+use twox_hash::XxHash64;
 
 #[allow(dead_code)]
 mod sim2h_im_state;

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -52,10 +52,10 @@ use in_stream::*;
 use log::*;
 use rand::{seq::SliceRandom, thread_rng};
 use std::{
-    fs::File,
-    io::prelude::*,
     convert::TryFrom,
+    fs::File,
     hash::{Hash, Hasher},
+    io::prelude::*,
 };
 
 use holochain_locksmith::Mutex;
@@ -499,15 +499,11 @@ fn spawn_handle_message_debug(sim2h_handle: Sim2hHandle, uri: Lib3hUri, signer: 
         let mut response_map: BTreeMap<SpaceHash, String> = BTreeMap::new();
         for (hash, space) in state.spaces.iter() {
             let json = serde_json::to_string(&space).expect("Space must be serializable");
-            response_map.insert(
-                (**hash).clone(),
-                json.clone(),
-            );
+            response_map.insert((**hash).clone(), json.clone());
             let filename = format!("{}.json", **hash);
             if let Ok(mut file) = File::create(filename.clone()) {
-                file.write_all(json.into_bytes().as_slice()).unwrap_or_else(|_| {
-                    error!("Could not write to file {}!", filename)
-                })
+                file.write_all(json.into_bytes().as_slice())
+                    .unwrap_or_else(|_| error!("Could not write to file {}!", filename))
             } else {
                 error!("Could not create file {}!", filename)
             }

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -496,7 +496,10 @@ fn spawn_handle_message_debug(sim2h_handle: Sim2hHandle, uri: Lib3hUri, signer: 
         let state = sim2h_handle.state().get_clone().await;
         let mut response_map: BTreeMap<SpaceHash, String> = BTreeMap::new();
         for (hash, space) in state.spaces.iter() {
-            response_map.insert((**hash).clone(), format!("{:?}", space));
+            response_map.insert(
+                (**hash).clone(),
+                serde_json::to_string(&space).expect("Space must be serializable"),
+            );
         }
         sim2h_handle.send(
             signer.clone(),

--- a/crates/sim2h/src/mono_ref.rs
+++ b/crates/sim2h/src/mono_ref.rs
@@ -3,7 +3,7 @@ use crate::*;
 /// We could just use `Arc`s directly, but the newtype lets us override Debug
 /// in sim2h MonoRef lets us have multiple views into the same hashes
 /// without exploding our memory footprint.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub struct MonoRef<T>(std::sync::Arc<T>);
 
 impl std::fmt::Debug for MonoRef<AgentId> {

--- a/crates/sim2h/src/sim2h_im_state.rs
+++ b/crates/sim2h/src/sim2h_im_state.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use lib3h::rrdht_util::Location;
 use rand::Rng;
+use serde::{Serialize, Serializer};
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -127,6 +128,15 @@ impl std::fmt::Debug for UpcomingInstant {
     }
 }
 
+impl Serialize for UpcomingInstant {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{:?}", self))
+    }
+}
+
 impl UpcomingInstant {
     pub fn new_ms_from_now(ms: u64) -> Self {
         Self(
@@ -149,9 +159,10 @@ enum StoreProto {
 }
 
 /// represents an active connection
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ConnectionState {
     agent_id: MonoAgentId,
+    #[serde(serialize_with = "serialize_location")]
     agent_loc: Location,
     uri: MonoUri,
     next_gossip_check: UpcomingInstant,
@@ -167,15 +178,25 @@ pub type MonoUri = MonoRef<Lib3hUri>;
 pub type Holding = im::HashMap<MonoAspectHash, im::HashSet<MonoAgentId>>;
 
 /// so we cache entry locations as well
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct EntryInfo {
     pub entry_hash: MonoEntryHash,
+    #[serde(serialize_with = "serialize_location")]
     pub entry_loc: Location,
     pub aspects: Holding,
 }
 
+pub fn serialize_location<S>(loc: &Location, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_u32(loc.clone().into())
+}
+
 /// sim2h state storage
+#[derive(Serialize)]
 pub struct Space {
+    #[serde(skip)]
     pub crypto: Box<dyn CryptoSystem>,
     pub redundancy: u64,
     pub aspect_to_entry_hash: im::HashMap<MonoAspectHash, (MonoAspectHash, MonoEntryHash)>,

--- a/crates/sim2h/src/sim2h_im_state.rs
+++ b/crates/sim2h/src/sim2h_im_state.rs
@@ -186,6 +186,7 @@ pub struct EntryInfo {
     pub aspects: Holding,
 }
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn serialize_location<S>(loc: &Location, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,

--- a/crates/sim2h/src/wire_message.rs
+++ b/crates/sim2h/src/wire_message.rs
@@ -1,9 +1,7 @@
 //! encapsulates lib3h ghostmessage for sim2h including security challenge
 use crate::{error::Sim2hError, NEW_RELIC_LICENSE_KEY};
-use lib3h_protocol::{data_types::Opaque, protocol::*};
-use std::convert::TryFrom;
-use lib3h_protocol::types::SpaceHash;
-use std::collections::BTreeMap;
+use lib3h_protocol::{data_types::Opaque, protocol::*, types::SpaceHash};
+use std::{collections::BTreeMap, convert::TryFrom};
 
 pub type WireMessageVersion = u32;
 pub const WIRE_VERSION: WireMessageVersion = 3;

--- a/crates/sim2h/src/wire_message.rs
+++ b/crates/sim2h/src/wire_message.rs
@@ -2,6 +2,8 @@
 use crate::{error::Sim2hError, NEW_RELIC_LICENSE_KEY};
 use lib3h_protocol::{data_types::Opaque, protocol::*};
 use std::convert::TryFrom;
+use lib3h_protocol::types::SpaceHash;
+use std::collections::BTreeMap;
 
 pub type WireMessageVersion = u32;
 pub const WIRE_VERSION: WireMessageVersion = 3;
@@ -44,6 +46,8 @@ pub enum WireMessage {
     Status,
     StatusResponse(StatusData),
     Ack(u64),
+    Debug,
+    DebugResponse(BTreeMap<SpaceHash, String>),
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(SIM2H)]
@@ -56,6 +60,8 @@ impl WireMessage {
             WireMessage::StatusResponse(_) => "StatusResponse",
             WireMessage::Hello(_) => "Hello",
             WireMessage::HelloResponse(_) => "HelloResponse",
+            WireMessage::Debug => "Debug",
+            WireMessage::DebugResponse(_) => "DebugResponse",
             WireMessage::ClientToLib3h(span_wrap) => match span_wrap.data {
                 ClientToLib3h::Bootstrap(_) => "[C>L]Bootstrap",
                 ClientToLib3h::FetchEntry(_) => "[C>L]FetchEntry",


### PR DESCRIPTION
## PR summary
Adds a `WireMessge::Debug` and `WireMessage::DebugResponse(BTreeMap<SpaceHash, String>)` to retrieve all space data as JSON serialized string.

`hc` can request this debug state dump and write it to file(s) (each space data into a separate one):
```
[nix-shell:~/hc]$ hc sim2h-client --message debug --url ws://localhost:9000
url: ws://localhost:9000
message: debug
connecting to: ws://127.0.0.1:9000/
Generated agent id: HcSCiDdSTjGaajts3zqY9WqC4zfJhnuhs8m4R6rC35RwObu8Uc6seVaYWe9eija
Await successfull
Sending wire message to sim2h: Debug
Ack(3079098903191232539)
Got DebugResponse for 1 spaces.
Writing Sim2h state dump for space QmXghcjdFQ7vEvihuBVQdiQBATGnRo6qX5wNxrq6HdNH9i to file: QmXghcjdFQ7vEvihuBVQdiQBATGnRo6qX5wNxrq6HdNH9i.json
```

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

**Make this optional (per command line parameter / configuration) such that public sim2h servers don't offer potential sensitive information to everybody**

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
