### PR TITLE
holochain_metrics: use `StatsByMetric(...)` due to differing type params

### DIFF
--- a/crates/metrics/src/stats.rs
+++ b/crates/metrics/src/stats.rs
@@ -523,7 +523,7 @@ impl<'a, D: DescriptiveStats + Clone + 'a> StatsByMetric<D> {
             data.insert(GroupingKey::new(stream_id, metric_name), stat);
         }
 
-        Ok(Self(data))
+        Ok(StatsByMetric(data))
     }
 }
 


### PR DESCRIPTION
## PR summary

new branch for mistken merge to master

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
