### PR TITLE
Unique EntryAspect hash

### DIFF
--- a/crates/core_types/src/chain_header.rs
+++ b/crates/core_types/src/chain_header.rs
@@ -27,7 +27,7 @@ use std::convert::TryInto;
 // @TODO - serialize properties as defined in ChainHeadersEntrySchema from golang alpha 1
 // @see https://github.com/holochain/holochain-proto/blob/4d1b8c8a926e79dfe8deaa7d759f930b66a5314f/entry_headers.go#L7
 // @see https://github.com/holochain/holochain-rust/issues/75
-#[derive(Clone, Debug, Serialize, Deserialize, DefaultJson, Eq)]
+#[derive(Clone, Debug, Serialize, Deserialize, DefaultJson, Eq, Hash)]
 pub struct ChainHeader {
     /// the type of this entry
     /// system types may have associated "subconscious" behavior

--- a/crates/core_types/src/chain_header.rs
+++ b/crates/core_types/src/chain_header.rs
@@ -27,7 +27,7 @@ use std::convert::TryInto;
 // @TODO - serialize properties as defined in ChainHeadersEntrySchema from golang alpha 1
 // @see https://github.com/holochain/holochain-proto/blob/4d1b8c8a926e79dfe8deaa7d759f930b66a5314f/entry_headers.go#L7
 // @see https://github.com/holochain/holochain-rust/issues/75
-#[derive(Clone, Debug, Serialize, Deserialize, DefaultJson, Eq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, DefaultJson, PartialEq, Eq, Hash)]
 pub struct ChainHeader {
     /// the type of this entry
     /// system types may have associated "subconscious" behavior
@@ -45,12 +45,6 @@ pub struct ChainHeader {
     link_update_delete: Option<Address>,
     /// ISO8601 time stamp
     timestamp: Iso8601,
-}
-
-impl PartialEq for ChainHeader {
-    fn eq(&self, other: &ChainHeader) -> bool {
-        self.address() == other.address()
-    }
 }
 
 impl ChainHeader {

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -157,5 +157,6 @@ impl fmt::Debug for EntryAspect {
 impl Hash for EntryAspect {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.header().hash(state);
+        self.type_hint().hash(state);
     }
 }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -156,7 +156,6 @@ impl fmt::Debug for EntryAspect {
 // the entry addresses which is part of all. QED.
 impl Hash for EntryAspect {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let address: String = self.header().entry_address().to_owned().into();
-        state.write(address.as_bytes());
+        self.header().hash(state);
     }
 }


### PR DESCRIPTION
## PR summary

The custom `Hash` impl for `EntryAspect` was basing the hash only on the entry address found in the aspects entry header. This is not correct though as an entry could be created multiple times (either by the same author at different points in time - or by different authors) which would result in the same entry and entry hash but different headers (different provenance and/or timestamp).

In order to differentiate these different entry aspects they need to hash differently.

These changes include the whole header as well as the aspect type in the input for the hash calculation.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
