### PR TITLE
await on join

### DIFF
--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -299,12 +299,8 @@ impl Sim2hHandle {
                 data: ClientToLib3h::JoinSpace(data),
                 ..
             }) => {
-                let _ = tokio::task::spawn(spawn_handle_message_join_space(
-                    sim2h_handle,
-                    uri,
-                    signer,
-                    data,
-                ));
+                let _ =
+                    tokio::task::spawn(handle_message_join_space(sim2h_handle, uri, signer, data));
                 return;
             }
             message @ _ => message,
@@ -531,7 +527,7 @@ fn spawn_handle_message_hello(
     }
 }
 
-async fn spawn_handle_message_join_space(
+async fn handle_message_join_space(
     sim2h_handle: Sim2hHandle,
     uri: Lib3hUri,
     _signer: AgentId,
@@ -539,7 +535,7 @@ async fn spawn_handle_message_join_space(
 ) {
     sim2h_handle
         .state()
-        .spawn_new_connection(
+        .new_connection(
             data.space_address.clone(),
             data.agent_id.clone(),
             uri.clone(),

--- a/crates/sim2h/src/sim2h_im_state.rs
+++ b/crates/sim2h/src/sim2h_im_state.rs
@@ -882,16 +882,6 @@ impl StoreHandle {
         .boxed()
     }
 
-    pub async fn spawn_new_connection(
-        &self,
-        space_hash: SpaceHash,
-        agent_id: AgentId,
-        uri: Lib3hUri,
-    ) {
-        let f = self.new_connection(space_hash, agent_id, uri);
-        f.await
-    }
-
     /*
     #[must_use]
     pub fn drop_connection(&self, space_hash: SpaceHash, agent_id: AgentId) -> BoxFuture<'static, ()> {

--- a/crates/sim2h/src/sim2h_im_state.rs
+++ b/crates/sim2h/src/sim2h_im_state.rs
@@ -882,9 +882,14 @@ impl StoreHandle {
         .boxed()
     }
 
-    pub fn spawn_new_connection(&self, space_hash: SpaceHash, agent_id: AgentId, uri: Lib3hUri) {
+    pub async fn spawn_new_connection(
+        &self,
+        space_hash: SpaceHash,
+        agent_id: AgentId,
+        uri: Lib3hUri,
+    ) {
         let f = self.new_connection(space_hash, agent_id, uri);
-        tokio::task::spawn(f);
+        f.await
     }
 
     /*


### PR DESCRIPTION
## PR summary
This awaits on the new connection future instead of just spawning it because otherwise the `Lib3hToClient::HandleGetGossipingEntryList` and `Lib3hToClient::HandleGetAuthoringEntryList` messages get sent and can be responded to before the join is complete. This leads to the responses to those messages being thrown away. Then the agents id's never actually get into the DHT.
## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
