### PR TITLE
Sim2h URL property override

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,7 @@ workflows:
         only:
          - develop
          - final-exam
-         - wire-message-receipts
+         - sim2h-url-property-override
    - docker-build-trycp-server:
       requires:
        - docker-build-minimal
@@ -284,7 +284,7 @@ workflows:
         only:
          - develop
          - final-exam
-         - wire-message-receipts
+         - sim2h-url-property-override
    - docker-build-circle-build:
       requires:
        - docker-build-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,6 @@ workflows:
         only:
          - develop
          - final-exam
-         - sim2h-url-property-override
    - docker-build-trycp-server:
       requires:
        - docker-build-minimal
@@ -284,7 +283,6 @@ workflows:
         only:
          - develop
          - final-exam
-         - sim2h-url-property-override
    - docker-build-circle-build:
       requires:
        - docker-build-latest

--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Added command to sim2h wire protocol for getting live debug info [#2128](https://github.com/holochain/holochain-rust/pull/2128)
+- Added an environment variable (HC_IGNORE_SIM2H_URL_PROPERTY) which overrides DNA sim2h_url value for running conductors in test modes
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,7 +1379,6 @@ dependencies = [
  "pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -203,6 +203,7 @@ pub mod test {
 
         assert_eq!(result, ());
 
+        std::env::remove_var("HC_IGNORE_SIM2H_URL_PROPERTY");
         let network = network_state.network.expect("No network connection set");
         assert_eq!(network.p2p_endpoint().as_str(), "wss://localhost:9000/");
     }

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -199,11 +199,11 @@ pub mod test {
 
         root_state = root_state.reduce(ActionWrapper::new(Action::InitializeChain(dna)));
 
+        std::env::remove_var("HC_IGNORE_SIM2H_URL_PROPERTY");
         let result = reduce_init(&mut network_state, &root_state, &action_wrapper);
 
         assert_eq!(result, ());
 
-        std::env::remove_var("HC_IGNORE_SIM2H_URL_PROPERTY");
         let network = network_state.network.expect("No network connection set");
         assert_eq!(network.p2p_endpoint().as_str(), "wss://localhost:9000/");
     }

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -51,7 +51,7 @@ pub fn reduce_init(state: &mut NetworkState, root_state: &State, action_wrapper:
                 sim2h_config.sim2h_url = sim2h_url;
             } else {
                 debug!(
-                    "DNA has 'sim2h_url' override property set, but it's ignored because HC_INGORE_SIM@H_RUL_PROPERTY is set");
+                    "DNA has 'sim2h_url' override property set, but it's ignored because HC_INGORE_SIM2H_URL_PROPERTY is set");
             }
         } else {
             debug!("DNA has 'sim2h_url' override property set, but it's ignored as we are not running a sim2h network backend");

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -41,7 +41,11 @@ pub fn reduce_init(state: &mut NetworkState, root_state: &State, action_wrapper:
     if let Some(sim2h_url) = maybe_sim2h_url_override {
         // ..and we're configured to use sim2h...
         if let BackendConfig::Sim2h(sim2h_config) = &mut p2p_config.backend_config {
-            if std::env::var("HC_IGNORE_SIM2H_URL_PROPERTY").is_err() {
+            let sim2h_url_override = match std::env::var_os("HC_IGNORE_SIM2H_URL_PROPERTY") {
+                Some(val) => val == "1" || val == "true",
+                _ => false,
+            };
+            if !sim2h_url_override {
                 info!(
                     "Found property 'sim2h_url' in DNA {} - overriding conductor wide sim2h URL with: {}",
                     dna.address(),

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -41,7 +41,7 @@ pub fn reduce_init(state: &mut NetworkState, root_state: &State, action_wrapper:
     if let Some(sim2h_url) = maybe_sim2h_url_override {
         // ..and we're configured to use sim2h...
         if let BackendConfig::Sim2h(sim2h_config) = &mut p2p_config.backend_config {
-            if (std::env::var("HC_IGNORE_SIM2H_URL_PROPERTY").is_err()) {
+            if std::env::var("HC_IGNORE_SIM2H_URL_PROPERTY").is_err() {
                 info!(
                     "Found property 'sim2h_url' in DNA {} - overriding conductor wide sim2h URL with: {}",
                     dna.address(),

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -206,4 +206,37 @@ pub mod test {
         let network = network_state.network.expect("No network connection set");
         assert_eq!(network.p2p_endpoint().as_str(), "wss://localhost:9000/");
     }
+
+    #[test]
+    pub fn should_not_set_sim2h_url_if_overridden() {
+        let p2p_config = P2pConfig::new_with_sim2h_backend("wss://0.0.0.0:9999");
+        let context: Arc<Context> = test_context(p2p_config);
+        let dna_address: Address = context.agent_id.address();
+        let agent_id = context.agent_id.content().to_string();
+        let handler = NetHandler::new(Box::new(|_| Ok(())));
+        let network_settings = crate::action::NetworkSettings {
+            p2p_config: context.p2p_config.clone(),
+            dna_address,
+            agent_id,
+            handler,
+        };
+        let action_wrapper = ActionWrapper::new(Action::InitNetwork(network_settings));
+
+        let mut network_state = NetworkState::new();
+        let mut root_state = test_store(context.clone());
+
+        let props = json!({"sim2h_url": "wss://localhost:9000"});
+        let mut dna = Dna::new();
+        dna.properties = props;
+
+        root_state = root_state.reduce(ActionWrapper::new(Action::InitializeChain(dna)));
+
+        std::env::set_var("HC_IGNORE_SIM2H_URL_PROPERTY", "true");
+        let result = reduce_init(&mut network_state, &root_state, &action_wrapper);
+
+        assert_eq!(result, ());
+
+        let network = network_state.network.expect("No network connection set");
+        assert_eq!(network.p2p_endpoint().as_str(), "wss://0.0.0.0:9999/");
+    }
 }

--- a/crates/core/src/network/reducers/init.rs
+++ b/crates/core/src/network/reducers/init.rs
@@ -51,7 +51,7 @@ pub fn reduce_init(state: &mut NetworkState, root_state: &State, action_wrapper:
                 sim2h_config.sim2h_url = sim2h_url;
             } else {
                 debug!(
-                    "DNA has 'sim2h_url' override property set, but it's ignored because HC_INGORE_SIM2H_URL_PROPERTY is set");
+                    "DNA has 'sim2h_url' override property set, but it's ignored because HC_IGNORE_SIM2H_URL_PROPERTY is set");
             }
         } else {
             debug!("DNA has 'sim2h_url' override property set, but it's ignored as we are not running a sim2h network backend");

--- a/crates/trycp_server/src/main.rs
+++ b/crates/trycp_server/src/main.rs
@@ -419,6 +419,7 @@ fn main() {
         let mut conductor = Command::new("holochain")
             .args(&["-c", &config_path])
             .env("RUST_BACKTRACE", "full")
+            .env("HC_IGNORE_SIM2H_URL_PROPERTY","true")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
@@ -483,8 +484,8 @@ fn main() {
     io.add_method("replace_conductor", move |params: Params| {
         if allow_replace_conductor {
             Ok(Value::String(os_eval(&format!("curl -L -k https://github.com/holochain/{}/releases/download/{}/{} -o holochain.tar.gz && tar -xzvf holochain.tar.gz && mv holochain /holochain/.cargo/bin/holochain && rm holochain.tar.gz",
-             get_as_string("repo", &unwrap_params_map(params.clone())?)?, 
-             get_as_string("tag", &unwrap_params_map(params.clone())?)?, 
+             get_as_string("repo", &unwrap_params_map(params.clone())?)?,
+             get_as_string("tag", &unwrap_params_map(params.clone())?)?,
              get_as_string("file_name", &unwrap_params_map(params)?)?))))
         } else {
             println!("replace not allowed (-c to enable)");

--- a/crates/trycp_server/src/main.rs
+++ b/crates/trycp_server/src/main.rs
@@ -419,7 +419,7 @@ fn main() {
         let mut conductor = Command::new("holochain")
             .args(&["-c", &config_path])
             .env("RUST_BACKTRACE", "full")
-            .env("HC_IGNORE_SIM2H_URL_PROPERTY","true")
+            .env("HC_IGNORE_SIM2H_URL_PROPERTY", "true")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()


### PR DESCRIPTION
## PR summary

Adds an environment variable for overriding the sim2h_url value if set in the DNA property.  We need this for running final exam tests without changing DNA.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
