### PR TITLE
GetLinks fix plus localize handle query workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,6 @@ workflows:
         only:
          - develop
          - final-exam
-         - ioerror-on-disconnect
    - docker-build-trycp-server:
       requires:
        - docker-build-minimal
@@ -285,7 +284,6 @@ workflows:
         only:
          - develop
          - final-exam
-         - ioerror-on-disconnect
    - docker-build-circle-build:
       requires:
        - docker-build-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ workflows:
         only:
          - develop
          - final-exam
+         - ioerror-on-disconnect
    - docker-build-trycp-server:
       requires:
        - docker-build-minimal
@@ -284,6 +285,7 @@ workflows:
         only:
          - develop
          - final-exam
+         - ioerror-on-disconnect
    - docker-build-circle-build:
       requires:
        - docker-build-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,4 +46,3 @@ exclude = [
 #holochain_tracing_macros = { path = "../holochain-tracing/crates/tracing_macros" }
 #holochain_tracing = { git = "https://github.com/holochain/holochain-tracing", branch ="tokio" }
 #holochain_tracing_macros = { git = "https://github.com/holochain/holochain-tracing", branch ="tokio" }
-

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -2,7 +2,7 @@ const { one, two } = require('../config')
 const sleep = require('sleep')
 
 module.exports = scenario => {
-  scenario.only('delete_post', async (s, t) => {
+  scenario('delete_post', async (s, t) => {
     const { alice, bob } = await s.players({ alice: one, bob: one }, true)
 
     // creates a simple link with alice as author with initial chain header

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -2,7 +2,7 @@ const { one, two } = require('../config')
 const sleep = require('sleep')
 
 module.exports = scenario => {
-  scenario('delete_post', async (s, t) => {
+  scenario.only('delete_post', async (s, t) => {
     const { alice, bob } = await s.players({ alice: one, bob: one }, true)
 
     // creates a simple link with alice as author with initial chain header
@@ -104,7 +104,7 @@ module.exports = scenario => {
         pagesize: 3,
         pagenumber:0
       })
-    
+
       const alice_posts_live = await alice.call('app', 'simple', 'get_my_links_with_pagination',
       {
         base: alice.info('app').agentAddress,
@@ -123,7 +123,7 @@ module.exports = scenario => {
         pagesize: 3,
         pagenumber:1
       })
-    
+
       const alice_posts_live_2 = await alice.call('app', 'simple', 'get_my_links_with_pagination',
       {
         base: alice.info('app').agentAddress,

--- a/crates/conductor_lib/test-bridge-caller/Cargo.toml
+++ b/crates/conductor_lib/test-bridge-caller/Cargo.toml
@@ -19,4 +19,3 @@ hdk = { path = "../../hdk" }
 serde_derive = "=1.0.104"
 holochain_json_derive = "=0.0.23"
 holochain_persistence_api = "=0.0.18"
-

--- a/crates/core/src/network/actions/query.rs
+++ b/crates/core/src/network/actions/query.rs
@@ -89,7 +89,6 @@ impl Future for QueryFuture {
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
         if let Some(err) = self.context.action_channel_error("GetEntryFuture") {
-            debug!("in query future action_channel_error");
             return Poll::Ready(Err(err));
         }
 

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -391,6 +391,9 @@ fn get_content_aspect(
 /// base address to which it is meta, if the entry is the source entry of a meta aspect,
 /// i.e. a CRUD or link entry.
 /// If the entry is not that it returns None.
+///
+/// NB: this is the inverse function of EntryAspect::entry_address(), so it is very important
+/// that they agree!
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 fn entry_to_meta_aspect(entry: Entry, header: ChainHeader) -> Option<(Address, EntryAspect)> {
     match entry {

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -26,11 +26,11 @@ use crate::{
             store::*,
         },
     },
-    workflows::get_entry_result::get_entry_with_meta_workflow,
+    workflows::get_entry_result::get_entry_with_meta_workflow_local,
 };
 use boolinator::Boolinator;
 use holochain_core_types::{
-    chain_header::ChainHeader, eav::Attribute, entry::Entry, error::HolochainError, time::Timeout,
+    chain_header::ChainHeader, eav::Attribute, entry::Entry, error::HolochainError,
 };
 use holochain_json_api::json::JsonString;
 use holochain_net::connection::net_connection::NetHandler;
@@ -470,12 +470,7 @@ fn get_meta_aspects_from_dht_eav(
             _ => false,
         })
         .map(|eavi| {
-            let value_entry = context
-                .block_on(get_entry_with_meta_workflow(
-                    &context,
-                    &eavi.value(),
-                    &Timeout::default(),
-                ))?
+            let value_entry = get_entry_with_meta_workflow_local(&context, &eavi.value())?
                 .ok_or_else(|| {
                     HolochainError::from("Entry linked in EAV not found! This should never happen.")
                 })?;

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -499,7 +499,7 @@ fn get_meta_aspects_from_dht_eav(
                             // but currently incorrect in this implementation and needs to be fixed
                             // in hdk v3.
                             Ok(EntryAspect::LinkRemove(
-                                (link_data.clone(), vec![eavi.value()]),
+                                (link_data, vec![eavi.value()]),
                                 header,
                             ))
                         }

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -481,7 +481,10 @@ fn get_meta_aspects_from_dht_eav(
                     Entry::LinkAdd(link_data) | Entry::LinkRemove((link_data, _)) => {
                         Ok(EntryAspect::LinkAdd(link_data, header))
                     }
-                    _ => Err(HolochainError::from("Invalid Entry Value for Link Add")),
+                    _ => Err(HolochainError::from(format!(
+                        "Invalid Entry Value for LinkTag: {:?}",
+                        value_entry
+                    ))),
                 },
                 Attribute::RemovedLink(_link_type, _link_tag) => {
                     match value_entry.entry_with_meta.entry {
@@ -498,14 +501,20 @@ fn get_meta_aspects_from_dht_eav(
                                 header,
                             ))
                         }
-                        _ => Err(HolochainError::from("Invalid Entry Value for Remove Link")),
+                        _ => Err(HolochainError::from(format!(
+                            "Invalid Entry Value for RemovedLink: {:?}",
+                            value_entry
+                        ))),
                     }
                 }
                 Attribute::CrudLink => Ok(EntryAspect::Update(
                     value_entry.entry_with_meta.entry,
                     header,
                 )),
-                _ => Err(HolochainError::from("Invalid Attribute in eavi")),
+                _ => Err(HolochainError::from(format!(
+                    "Invalid Attribute in eavi: {:?}",
+                    eavi.attribute()
+                ))),
             }
         })
         .partition(Result::is_ok);

--- a/crates/core/src/network/handler/query.rs
+++ b/crates/core/src/network/handler/query.rs
@@ -7,7 +7,7 @@ use crate::{
         GetLinksNetworkQuery, GetLinksNetworkResult, NetworkQuery, NetworkQueryResult,
     },
     nucleus,
-    workflows::get_entry_result::get_entry_result_workflow,
+    workflows::get_entry_result::get_entry_result_workflow_inner,
 };
 use holochain_core_types::{
     crud_status::CrudStatus,
@@ -75,9 +75,10 @@ fn get_links(
             };
 
             context
-                .block_on(get_entry_result_workflow(
+                .block_on(get_entry_result_workflow_inner(
                     &context.clone(),
                     &link_add_entry_args,
+                    true // local only please!
                 ))
                 .map(|get_entry_result| match get_entry_result.result {
                     GetEntryResultType::Single(entry_with_meta_and_headers) => {

--- a/crates/core/src/network/handler/query.rs
+++ b/crates/core/src/network/handler/query.rs
@@ -78,7 +78,7 @@ fn get_links(
                 .block_on(get_entry_result_workflow_inner(
                     &context.clone(),
                     &link_add_entry_args,
-                    true // local only please!
+                    true, // local only please!
                 ))
                 .map(|get_entry_result| match get_entry_result.result {
                     GetEntryResultType::Single(entry_with_meta_and_headers) => {

--- a/crates/core/src/network/handler/query.rs
+++ b/crates/core/src/network/handler/query.rs
@@ -26,7 +26,7 @@ use std::{convert::TryInto, sync::Arc};
 
 pub type LinkTag = String;
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
-pub fn get_links(
+fn get_links(
     context: &Arc<Context>,
     base: Address,
     link_type: Option<String>,

--- a/crates/core/src/network/handler/query.rs
+++ b/crates/core/src/network/handler/query.rs
@@ -7,7 +7,7 @@ use crate::{
         GetLinksNetworkQuery, GetLinksNetworkResult, NetworkQuery, NetworkQueryResult,
     },
     nucleus,
-    workflows::get_entry_result::get_entry_result_workflow_inner,
+    workflows::get_entry_result::get_entry_result_workflow_local,
 };
 use holochain_core_types::{
     crud_status::CrudStatus,
@@ -74,12 +74,7 @@ fn get_links(
                 },
             };
 
-            context
-                .block_on(get_entry_result_workflow_inner(
-                    &context.clone(),
-                    &link_add_entry_args,
-                    true, // local only please!
-                ))
+            get_entry_result_workflow_local(&context.clone(), &link_add_entry_args)
                 .map(|get_entry_result| match get_entry_result.result {
                     GetEntryResultType::Single(entry_with_meta_and_headers) => {
                         let maybe_entry_headers = if query_configuration.headers {

--- a/crates/core/src/network/reducers/send_direct_message.rs
+++ b/crates/core/src/network/reducers/send_direct_message.rs
@@ -152,11 +152,10 @@ mod tests {
 
         assert_eq!(
             maybe_reply,
-            Some(Err(HolochainError::Timeout(format!(
-                "timeout src: {}:{}",
-                file!(),
-                line!()
-            ))))
+            Some(Err(HolochainError::Timeout(
+                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:81"
+                    .to_string()
+            )))
         );
     }
 }

--- a/crates/core/src/scheduled_jobs/timeouts.rs
+++ b/crates/core/src/scheduled_jobs/timeouts.rs
@@ -95,7 +95,7 @@ mod tests {
         assert_eq!(
             maybe_reply,
             Some(Err(HolochainError::Timeout(
-                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:158"
+                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:81"
                     .to_string()
             )))
         );

--- a/crates/core/src/scheduled_jobs/timeouts.rs
+++ b/crates/core/src/scheduled_jobs/timeouts.rs
@@ -95,7 +95,7 @@ mod tests {
         assert_eq!(
             maybe_reply,
             Some(Err(HolochainError::Timeout(
-                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:81"
+                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:158"
                     .to_string()
             )))
         );

--- a/crates/core/src/scheduled_jobs/timeouts.rs
+++ b/crates/core/src/scheduled_jobs/timeouts.rs
@@ -95,7 +95,7 @@ mod tests {
         assert_eq!(
             maybe_reply,
             Some(Err(HolochainError::Timeout(
-                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:78"
+                "timeout src: crates/core/src/network/reducers/send_direct_message.rs:81"
                     .to_string()
             )))
         );

--- a/crates/core/src/workflows/get_entry_result.rs
+++ b/crates/core/src/workflows/get_entry_result.rs
@@ -14,6 +14,27 @@ use holochain_wasm_utils::api_serialization::get_entry::{
 };
 use std::sync::Arc;
 
+/// GenEntry locally
+pub fn get_entry_with_meta_workflow_local<'a>(
+    context: &'a Arc<Context>,
+    address: &'a Address,
+) -> Result<Option<EntryWithMetaAndHeader>, HolochainError> {
+    let maybe_entry_with_meta =
+        nucleus::actions::get_entry::get_entry_with_meta(context, address.clone())?;
+    let entry = maybe_entry_with_meta
+        .ok_or_else(|| HolochainError::ErrorGeneric("Could not get entry".to_string()))?;
+    context
+        .state()
+        .ok_or_else(|| HolochainError::ErrorGeneric("Could not get state".to_string()))?
+        .get_headers(address.clone())
+        .map(|headers| {
+            Some(EntryWithMetaAndHeader {
+                entry_with_meta: entry.clone(),
+                headers,
+            })
+        })
+}
+
 /// Get Entry workflow
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn get_entry_with_meta_workflow<'a>(

--- a/crates/core/src/workflows/get_link_result.rs
+++ b/crates/core/src/workflows/get_link_result.rs
@@ -27,7 +27,7 @@ pub async fn get_link_result_workflow<'a>(
     };
     let method = QueryMethod::Link(link_args.clone(), GetLinksNetworkQuery::Links(config));
     let response = query(context.clone(), method, link_args.options.timeout.clone()).await?;
-    
+
     let links_result = match response {
         NetworkQueryResult::Links(query, _, _) => Ok(query),
         _ => Err(HolochainError::ErrorGeneric(

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -99,7 +99,7 @@ impl EntryAspect {
         match self {
             EntryAspect::LinkAdd(link_data, _) => link_data.link.base(),
             EntryAspect::LinkRemove((link_data, _), _) => link_data.link.base(),
-            _ => self.header().entry_address()
+            _ => self.header().entry_address(),
         }
     }
 }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -93,8 +93,14 @@ impl EntryAspect {
             EntryAspect::Deletion(header) => header,
         }
     }
+    /// NB: this is the inverse function of entry_to_meta_aspect,
+    /// so it is very important that they agree!
     pub fn entry_address(&self) -> &Address {
-        self.header().entry_address()
+        match self {
+            EntryAspect::LinkAdd(link_data, _) => link_data.link.base(),
+            EntryAspect::LinkRemove((link_data, _), _) => link_data.link.base(),
+            _ => self.header().entry_address()
+        }
     }
 }
 

--- a/crates/net/src/connection/net_connection_thread.rs
+++ b/crates/net/src/connection/net_connection_thread.rs
@@ -83,7 +83,7 @@ impl NetConnectionThread {
                 // Loop as long owner wants to
                 let mut sleep_duration_us = TICK_SLEEP_MIN_US;
                 while can_keep_running_child.load(Ordering::Relaxed) {
-                     // Check if we received something from parent (NetConnectionThread::send())
+                    // Check if we received something from parent (NetConnectionThread::send())
                     let mut did_something = false;
                     recv_channel
                         .try_recv() // TODO: can we use recv_timeout instead to reduce the poll interval?


### PR DESCRIPTION
## PR summary

- [x] fix how entry aspects are created from entries for linksadd and linkRemove (was using the linkadd as the base not the actual base)
- [x] handle query workflows also used to use the network fallthrough version of `get_entry_with_meta_workflow` this converts this to use the local only version.

## testing/benchmarking notes

This fix is tested against [this branch of passthrough dna](https://github.com/holochain/passthrough-dna/pull/23)

## followups

- [ ] find out why holofuel stress test still times out and pegs cpus of nodes

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
