### PR TITLE
Fix update aspects

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -16,5 +16,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Older rust-tracing traces.
 
 ### Fixed
+- Bug where EntryAspects were being associated with the wrong Entries
 
 ### Security

--- a/crates/core/src/dht/aspect_map.rs
+++ b/crates/core/src/dht/aspect_map.rs
@@ -28,7 +28,10 @@ impl AspectMap {
     }
 
     pub fn contains(&self, aspect: &EntryAspect) -> bool {
-        let entry_address: EntryHash = aspect.entry_address().into();
+        let entry_address: EntryHash = aspect
+            .entry_address()
+            .expect("Could not get entry address from aspect")
+            .into();
         let entry_aspect_address = aspect.address();
         self.0
             .get(&entry_address)
@@ -37,7 +40,10 @@ impl AspectMap {
     }
 
     pub fn add(&mut self, aspect: &EntryAspect) {
-        let entry_address = aspect.entry_address().into();
+        let entry_address = aspect
+            .entry_address()
+            .expect("Could not get entry address from aspect")
+            .into();
         let entry_aspect_address = aspect.address().into();
 
         self.0

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -237,8 +237,7 @@ pub fn reduce_remove_queued_holding_workflow(
 #[cfg(test)]
 pub mod tests {
 
-    use holochain_persistence_api::cas::content::Address;
-use crate::{
+    use crate::{
         action::{Action, ActionWrapper},
         content_store::{AddContent, GetContent},
         dht::{
@@ -256,13 +255,13 @@ use crate::{
     use bitflags::_core::time::Duration;
     use holochain_core_types::{
         agent::{test_agent_id, test_agent_id_with_name},
-        chain_header::{test_chain_header_with_sig, test_chain_header},
+        chain_header::{test_chain_header, test_chain_header_with_sig},
         eav::Attribute,
         entry::{test_entry, test_sys_entry, Entry},
         link::{link_data::LinkData, Link, LinkActionKind},
         network::entry_aspect::EntryAspect,
     };
-    use holochain_persistence_api::cas::content::AddressableContent;
+    use holochain_persistence_api::cas::content::{Address, AddressableContent};
     use std::{sync::Arc, time::SystemTime};
     // TODO do this for all crate tests somehow
     #[allow(dead_code)]
@@ -549,7 +548,11 @@ use crate::{
         assert_eq!(&entry, &result_entry,);
     }
 
-    fn create_pending_validation(entry: Entry, workflow: ValidatingWorkflow, link_update_delete: Option<Address>) -> PendingValidation {
+    fn create_pending_validation(
+        entry: Entry,
+        workflow: ValidatingWorkflow,
+        link_update_delete: Option<Address>,
+    ) -> PendingValidation {
         let entry_with_header = EntryWithHeader {
             entry: entry.clone(),
             header: test_chain_header_with_sig("sig", link_update_delete),
@@ -565,7 +568,8 @@ use crate::{
         assert_eq!(store.queued_holding_workflows().len(), 0);
 
         let test_entry = test_entry();
-        let hold = create_pending_validation(test_entry.clone(), ValidatingWorkflow::HoldEntry, None);
+        let hold =
+            create_pending_validation(test_entry.clone(), ValidatingWorkflow::HoldEntry, None);
         let hold_header = hold.entry_with_header.header.clone();
         let action = ActionWrapper::new(Action::QueueHoldingWorkflow((
             hold.clone(),
@@ -606,7 +610,11 @@ use crate::{
         let (next_pending, _) = store.next_queued_holding_workflow().unwrap();
         assert_eq!(hold_link, next_pending);
 
-        let update = create_pending_validation(test_entry.clone(), ValidatingWorkflow::UpdateEntry, Some(hold_header.address()));
+        let update = create_pending_validation(
+            test_entry.clone(),
+            ValidatingWorkflow::UpdateEntry,
+            Some(hold_header.address()),
+        );
         let action = ActionWrapper::new(Action::QueueHoldingWorkflow((update.clone(), None)));
         let store = reduce_queue_holding_workflow(&store, &action).unwrap();
 

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -433,8 +433,8 @@ pub mod tests {
             Arc::new(RwLock::new(ExampleEntityAttributeValueStorage::new())),
         );
         let entry = test_entry();
-        let header1 = test_chain_header_with_sig("sig1");
-        let header2 = test_chain_header_with_sig("sig2");
+        let header1 = test_chain_header_with_sig("sig1", None);
+        let header2 = test_chain_header_with_sig("sig2", None);
         store.add_header_for_entry(&entry, &header1).unwrap();
         store.add_header_for_entry(&entry, &header2).unwrap();
         let headers = store.get_headers(entry.address()).unwrap();
@@ -445,7 +445,7 @@ pub mod tests {
         entry: Entry,
         dependencies: Vec<Address>,
     ) -> PendingValidationWithTimeout {
-        let header = test_chain_header_with_sig("sig1");
+        let header = test_chain_header_with_sig("sig1", None);
         let mut pending_struct = PendingValidationStruct::new(
             EntryWithHeader { entry, header },
             ValidatingWorkflow::HoldEntry,

--- a/crates/core/src/network/handler/lists.rs
+++ b/crates/core/src/network/handler/lists.rs
@@ -62,7 +62,8 @@ fn create_authoring_map(context: Arc<Context>) -> AspectMap {
 
         // And then we deduce the according base entry and meta aspect from that entry
         // and its header:
-        let maybe_meta_aspect = entry_to_meta_aspect(entry, header);
+        let maybe_meta_aspect =
+            entry_to_meta_aspect(entry, header).expect("Couldn't derive meta aspect from entry");
 
         if let Some((base_address, meta_aspect)) = maybe_meta_aspect {
             address_map

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -407,7 +407,7 @@ fn entry_to_meta_aspect(entry: Entry, header: ChainHeader) -> Option<(Address, E
         Entry::Deletion(_) => Some(EntryAspect::Deletion(header)),
         _ => None,
     }
-    .map(|aspect| (aspect.entry_address().clone(), aspect))
+    .map(|aspect| (aspect.entry_address(), aspect))
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -397,26 +397,20 @@ fn get_content_aspect(
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 fn entry_to_meta_aspect(entry: Entry, header: ChainHeader) -> Option<(Address, EntryAspect)> {
     match entry {
-        Entry::App(app_type, app_value) => header.link_update_delete().map(|updated_entry| {
-            (
-                updated_entry,
-                EntryAspect::Update(Entry::App(app_type, app_value), header),
-            )
+        Entry::App(app_type, app_value) => header.link_update_delete().map(|_| {
+            EntryAspect::Update(Entry::App(app_type, app_value), header)
         }),
-        Entry::LinkAdd(link_data) => Some((
-            link_data.link.base().clone(),
+        Entry::LinkAdd(link_data) => Some(
             EntryAspect::LinkAdd(link_data, header),
-        )),
-        Entry::LinkRemove((link_data, addresses)) => Some((
-            link_data.link.base().clone(),
+        ),
+        Entry::LinkRemove((link_data, addresses)) => Some(
             EntryAspect::LinkRemove((link_data, addresses), header),
-        )),
-        Entry::Deletion(_) => Some((
-            header.link_update_delete().expect(""),
+        ),
+        Entry::Deletion(_) => Some(
             EntryAspect::Deletion(header),
-        )),
+        ),
         _ => None,
-    }
+    }.map(|aspect| (aspect.entry_address().clone(), aspect))
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]

--- a/crates/core/src/network/handler/mod.rs
+++ b/crates/core/src/network/handler/mod.rs
@@ -397,20 +397,17 @@ fn get_content_aspect(
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 fn entry_to_meta_aspect(entry: Entry, header: ChainHeader) -> Option<(Address, EntryAspect)> {
     match entry {
-        Entry::App(app_type, app_value) => header.link_update_delete().map(|_| {
-            EntryAspect::Update(Entry::App(app_type, app_value), header)
-        }),
-        Entry::LinkAdd(link_data) => Some(
-            EntryAspect::LinkAdd(link_data, header),
-        ),
-        Entry::LinkRemove((link_data, addresses)) => Some(
-            EntryAspect::LinkRemove((link_data, addresses), header),
-        ),
-        Entry::Deletion(_) => Some(
-            EntryAspect::Deletion(header),
-        ),
+        Entry::App(app_type, app_value) => header
+            .link_update_delete()
+            .map(|_| EntryAspect::Update(Entry::App(app_type, app_value), header)),
+        Entry::LinkAdd(link_data) => Some(EntryAspect::LinkAdd(link_data, header)),
+        Entry::LinkRemove((link_data, addresses)) => {
+            Some(EntryAspect::LinkRemove((link_data, addresses), header))
+        }
+        Entry::Deletion(_) => Some(EntryAspect::Deletion(header)),
         _ => None,
-    }.map(|aspect| (aspect.entry_address().clone(), aspect))
+    }
+    .map(|aspect| (aspect.entry_address().clone(), aspect))
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]

--- a/crates/core_types/src/chain_header.rs
+++ b/crates/core_types/src/chain_header.rs
@@ -128,7 +128,10 @@ pub fn test_chain_header() -> ChainHeader {
 }
 
 /// returns a dummy header for use in tests
-pub fn test_chain_header_with_sig(sig: &'static str, link_update_delete: Option<Address>) -> ChainHeader {
+pub fn test_chain_header_with_sig(
+    sig: &'static str,
+    link_update_delete: Option<Address>,
+) -> ChainHeader {
     ChainHeader::new(
         &test_entry_type(),
         &test_entry().address(),

--- a/crates/core_types/src/chain_header.rs
+++ b/crates/core_types/src/chain_header.rs
@@ -124,18 +124,18 @@ impl AddressableContent for ChainHeader {
 
 /// returns a dummy header for use in tests
 pub fn test_chain_header() -> ChainHeader {
-    test_chain_header_with_sig("sig")
+    test_chain_header_with_sig("sig", None)
 }
 
 /// returns a dummy header for use in tests
-pub fn test_chain_header_with_sig(sig: &'static str) -> ChainHeader {
+pub fn test_chain_header_with_sig(sig: &'static str, link_update_delete: Option<Address>) -> ChainHeader {
     ChainHeader::new(
         &test_entry_type(),
         &test_entry().address(),
         &test_provenances(sig),
         &None,
         &None,
-        &None,
+        &link_update_delete,
         &test_iso_8601(),
     )
 }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -113,7 +113,9 @@ impl EntryAspect {
                     ))
                 })?
             }
-            EntryAspect::Header(header) => header.entry_address().clone(),
+            // EntryAspect::Header is currently unused,
+            // but this is what it will be when we do use it
+            EntryAspect::Header(header) => header.address().clone(),
         })
     }
 }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -95,11 +95,18 @@ impl EntryAspect {
     }
     /// NB: this is the inverse function of entry_to_meta_aspect,
     /// so it is very important that they agree!
-    pub fn entry_address(&self) -> &Address {
+    pub fn entry_address(&self) -> Address {
         match self {
-            EntryAspect::LinkAdd(link_data, _) => link_data.link.base(),
-            EntryAspect::LinkRemove((link_data, _), _) => link_data.link.base(),
-            _ => self.header().entry_address()
+            EntryAspect::Content(_, header) => match header.link_update_delete() {
+                Some(ref updated_entry) => updated_entry.clone(),
+                None => header.entry_address().clone(),
+            },
+            EntryAspect::LinkAdd(link_data, _) => link_data.link.base().clone(),
+            EntryAspect::LinkRemove((link_data, _), _) => link_data.link.base().clone(),
+            EntryAspect::Update(_, header) | EntryAspect::Deletion(header) => header
+                .link_update_delete()
+                .expect("no link_update_delete on Deletion entry header"),
+            EntryAspect::Header(header) => header.entry_address().clone(),
         }
     }
 }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -108,7 +108,7 @@ impl EntryAspect {
             EntryAspect::Update(_, header) | EntryAspect::Deletion(header) => {
                 header.link_update_delete().ok_or_else(|| {
                     HolochainError::ErrorGeneric(format!(
-                        "no link_update_delete on Deletion entry header. Header: {:?}",
+                        "no link_update_delete on Update/Deletion entry header. Header: {:?}",
                         header
                     ))
                 })?

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -115,7 +115,7 @@ impl EntryAspect {
             }
             // EntryAspect::Header is currently unused,
             // but this is what it will be when we do use it
-            EntryAspect::Header(header) => header.address().clone(),
+            EntryAspect::Header(header) => header.address(),
         })
     }
 }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -103,9 +103,12 @@ impl EntryAspect {
             },
             EntryAspect::LinkAdd(link_data, _) => link_data.link.base().clone(),
             EntryAspect::LinkRemove((link_data, _), _) => link_data.link.base().clone(),
-            EntryAspect::Update(_, header) | EntryAspect::Deletion(header) => header
-                .link_update_delete()
-                .expect("no link_update_delete on Deletion entry header"),
+            EntryAspect::Update(_, header) | EntryAspect::Deletion(header) => {
+                header.link_update_delete().expect(&format!(
+                    "no link_update_delete on Deletion entry header. Header: {:?}",
+                    header
+                ))
+            }
             EntryAspect::Header(header) => header.entry_address().clone(),
         }
     }


### PR DESCRIPTION
## PR summary

Extending the work done in `localize-handle-query-workflows`, updates the logic for `EntryAspect::entry_address()` to accurately match the `entry_to_meta_aspect`, which it is basically the inverse function of.

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
