### PR TITLE
Empty gossip

### DIFF
--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -822,7 +822,7 @@ fn spawn_handle_message_list_data(
 
     for (entry_hash, aspects) in list_data.address_map {
         if aspects.is_empty() {
-            return;
+            continue;
         }
 
         sim2h_handle.state().spawn_agent_holds_aspects(

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -773,6 +773,11 @@ fn spawn_handle_message_publish_entry(
             });
             multi_message.push(ht::span_wrap_encode!(Level::INFO, data).into());
         }
+
+        if multi_message.is_empty() {
+            return;
+        }
+
         let multi_message = WireMessage::MultiSend(multi_message);
 
         let state = sim2h_handle.state().get_clone().await;
@@ -816,6 +821,10 @@ fn spawn_handle_message_list_data(
     // just iter/send we don't need a new task for this
 
     for (entry_hash, aspects) in list_data.address_map {
+        if aspects.is_empty() {
+            return;
+        }
+
         sim2h_handle.state().spawn_agent_holds_aspects(
             (&*space_hash).clone(),
             signer.clone(),

--- a/crates/stress/src/bin/sim2h_stress.rs
+++ b/crates/stress/src/bin/sim2h_stress.rs
@@ -544,7 +544,7 @@ impl StressJob for Job {
                 }
             }
             Err(e) if e.would_block() => (),
-            Err(e) => panic!(e),
+            Err(e) => panic!("{:?}", e),
         }
 
         if !self.got_ack {


### PR DESCRIPTION
Attempt to prevent the spread of empty gossip.

Sometimes, if we ask a random agent if they hold something, they may respond with an empty aspect list, indicating they do not. Totally fine, but when the respond we want to ignore that message in sim2h - so we don't go and tell other nodes that they hold anything, because they do not.