### PR TITLE
change validation queue timeout to 60sec

### DIFF
--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -346,24 +346,23 @@ impl Instance {
                                     // If we couldn't run the validation due to unresolved dependencies,
                                     // we have to re-add this entry at the end of the queue:
                                     Err(HolochainError::ValidationPending) => {
-
                                         // THIS DELAY IS BROKEN BECAUSE VALIDATION ENTAILS SENDING
                                         // A DIRECT MESSAGE WHICH TIMES OUT ON THE DEFAULT 60 SECOND
                                         // TIMEOUT, THUS THESE ARE CONFLICTING TIMEOUTS
                                         // And with a delay so we are not trying to re-validate many times per second.
                                         /*
-                                        let mut delay = maybe_delay
-                                            .map(|old_delay| {
-                                                // Exponential back-off:
-                                                // If this was delayed before we double the delay.
-                                                old_delay * 2
-                                            })
-                                            .unwrap_or(RETRY_VALIDATION_DURATION_MIN);
+                                            let mut delay = maybe_delay
+                                                .map(|old_delay| {
+                                                    // Exponential back-off:
+                                                    // If this was delayed before we double the delay.
+                                                    old_delay * 2
+                                                })
+                                                .unwrap_or(RETRY_VALIDATION_DURATION_MIN);
 
-                                        // Cap delay with max duration
-                                        if delay > RETRY_VALIDATION_DURATION_MAX {
-                                            delay = RETRY_VALIDATION_DURATION_MAX
-                                    }*/
+                                            // Cap delay with max duration
+                                            if delay > RETRY_VALIDATION_DURATION_MAX {
+                                                delay = RETRY_VALIDATION_DURATION_MAX
+                                        }*/
 
                                         let delay = RETRY_VALIDATION_TIMEOUT_MS;
 

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -39,8 +39,10 @@ use std::{
 };
 
 pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
-pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(500);
+/*pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(500);
 pub const RETRY_VALIDATION_DURATION_MAX: Duration = Duration::from_secs(60 * 60);
+ */
+pub const RETRY_VALIDATION_TIMEOUT_MS: Duration = Duration::from_millis(60000);
 
 /// Object representing a Holochain instance, i.e. a running holochain (DNA + DHT + source-chain)
 /// Holds the Event loop and processes it with the redux pattern.
@@ -327,7 +329,7 @@ impl Instance {
                             .expect("Couldn't get state in run_pending_validations")
                             .dht();
                         let maybe_holding_workflow = dht_store.next_queued_holding_workflow();
-                        if let Some((pending, maybe_delay)) = maybe_holding_workflow {
+                        if let Some((pending, _maybe_delay)) = maybe_holding_workflow {
                             log_debug!(context, "Found queued validation: {:?}", pending);
                             // NB: If for whatever reason we pop_next_holding_workflow anywhere else other than here,
                             // we can run into a race condition.
@@ -344,7 +346,12 @@ impl Instance {
                                     // If we couldn't run the validation due to unresolved dependencies,
                                     // we have to re-add this entry at the end of the queue:
                                     Err(HolochainError::ValidationPending) => {
+
+                                        // THIS DELAY IS BROKEN BECAUSE VALIDATION ENTAILS SENDING
+                                        // A DIRECT MESSAGE WHICH TIMES OUT ON THE DEFAULT 60 SECOND
+                                        // TIMEOUT, THUS THESE ARE CONFLICTING TIMEOUTS
                                         // And with a delay so we are not trying to re-validate many times per second.
+                                        /*
                                         let mut delay = maybe_delay
                                             .map(|old_delay| {
                                                 // Exponential back-off:
@@ -356,7 +363,9 @@ impl Instance {
                                         // Cap delay with max duration
                                         if delay > RETRY_VALIDATION_DURATION_MAX {
                                             delay = RETRY_VALIDATION_DURATION_MAX
-                                        }
+                                    }*/
+
+                                        let delay = RETRY_VALIDATION_TIMEOUT_MS;
 
                                         queue_holding_workflow(
                                             Arc::new(pending.same()),


### PR DESCRIPTION
## PR summary

Pending validations were being re-queued faster than the direct-message timeout.  This removes the exponential backoff and sets it to match.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
