### PR TITLE
Redux synced Future Wakers

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -47,11 +47,11 @@ use std::{
     time::Duration,
 };
 
-#[cfg(test)]
-use test_utils::mock_signing::mock_conductor_api;
 use crate::instance::WakerRequest;
 use futures::task::Waker;
 use snowflake::ProcessUniqueId;
+#[cfg(test)]
+use test_utils::mock_signing::mock_conductor_api;
 
 pub type ActionSender = ht::channel::SpanSender<ActionWrapper>;
 pub type ActionReceiver = ht::channel::SpanReceiver<ActionWrapper>;
@@ -357,11 +357,15 @@ impl Context {
     }
 
     pub fn register_waker(&self, future_id: ProcessUniqueId, waker: Waker) {
-        self.waker_channel.as_ref().map(|c| c.send(WakerRequest::Add(future_id, waker)));
+        self.waker_channel
+            .as_ref()
+            .map(|c| c.send(WakerRequest::Add(future_id, waker)));
     }
 
     pub fn unregister_waker(&self, future_id: ProcessUniqueId) {
-        self.waker_channel.as_ref().map(|c| c.send(WakerRequest::Remove(future_id)));
+        self.waker_channel
+            .as_ref()
+            .map(|c| c.send(WakerRequest::Remove(future_id)));
     }
 
     /// Custom future executor that enables nested futures and nested calls of `block_on`.

--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -49,6 +49,9 @@ use std::{
 
 #[cfg(test)]
 use test_utils::mock_signing::mock_conductor_api;
+use crate::instance::WakerRequest;
+use futures::task::Waker;
+use snowflake::ProcessUniqueId;
 
 pub type ActionSender = ht::channel::SpanSender<ActionWrapper>;
 pub type ActionReceiver = ht::channel::SpanReceiver<ActionWrapper>;
@@ -94,6 +97,7 @@ pub struct Context {
     state: Option<Arc<RwLock<StateWrapper>>>,
     pub action_channel: Option<ActionSender>,
     pub observer_channel: Option<Sender<Observer>>,
+    pub waker_channel: Option<Sender<WakerRequest>>,
     pub chain_storage: Arc<RwLock<dyn ContentAddressableStorage>>,
     pub dht_storage: Arc<RwLock<dyn ContentAddressableStorage>>,
     pub eav_storage: Arc<RwLock<dyn EntityAttributeValueStorage<Attribute>>>,
@@ -159,6 +163,7 @@ impl Context {
             action_channel: None,
             signal_tx,
             observer_channel: None,
+            waker_channel: None,
             chain_storage,
             dht_storage,
             eav_storage: eav,
@@ -199,6 +204,7 @@ impl Context {
             action_channel,
             signal_tx,
             observer_channel,
+            waker_channel: None,
             chain_storage: cas.clone(),
             dht_storage: cas,
             eav_storage: eav,
@@ -348,6 +354,14 @@ impl Context {
             .send(Observer { ticker: tick_tx })
             .expect("Observer channel not initialized");
         tick_rx
+    }
+
+    pub fn register_waker(&self, future_id: ProcessUniqueId, waker: Waker) {
+        self.waker_channel.as_ref().map(|c| c.send(WakerRequest::Add(future_id, waker)));
+    }
+
+    pub fn unregister_waker(&self, future_id: ProcessUniqueId) {
+        self.waker_channel.as_ref().map(|c| c.send(WakerRequest::Remove(future_id)));
     }
 
     /// Custom future executor that enables nested futures and nested calls of `block_on`.

--- a/crates/core/src/dht/actions/queue_holding_workflow.rs
+++ b/crates/core/src/dht/actions/queue_holding_workflow.rs
@@ -66,11 +66,11 @@ impl Future for QueueHoldingWorkflowFuture {
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
         self.context
-            .register_waker(self.id.clone().into(), cx.waker().clone());
+            .register_waker(self.id.clone(), cx.waker().clone());
 
         if let Some(state) = self.context.try_state() {
             if state.dht().has_exact_queued_holding_workflow(&self.pending) {
-                self.context.unregister_waker(self.id.clone().into());
+                self.context.unregister_waker(self.id.clone());
                 Poll::Ready(())
             } else {
                 Poll::Pending

--- a/crates/core/src/dht/actions/queue_holding_workflow.rs
+++ b/crates/core/src/dht/actions/queue_holding_workflow.rs
@@ -5,6 +5,7 @@ use crate::{
     instance::dispatch_action,
 };
 use futures::{future::Future, task::Poll};
+use snowflake::ProcessUniqueId;
 use std::{
     pin::Pin,
     sync::Arc,
@@ -37,7 +38,13 @@ pub async fn queue_holding_workflow(
     {
         log_trace!(context, "Queueing holding workflow: {:?}", pending);
         dispatch_queue_holding_workflow(pending.clone(), delay, context.clone());
-        QueueHoldingWorkflowFuture { context, pending }.await
+        let id = ProcessUniqueId::new();
+        QueueHoldingWorkflowFuture {
+            context,
+            pending,
+            id,
+        }
+        .await
     } else {
         log_trace!(
             context,
@@ -50,6 +57,7 @@ pub async fn queue_holding_workflow(
 pub struct QueueHoldingWorkflowFuture {
     context: Arc<Context>,
     pending: PendingValidation,
+    id: ProcessUniqueId,
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
@@ -57,14 +65,12 @@ impl Future for QueueHoldingWorkflowFuture {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
-        //
-        // TODO: connect the waker to state updates for performance reasons
-        // See: https://github.com/holochain/holochain-rust/issues/314
-        //
-        cx.waker().clone().wake();
+        self.context
+            .register_waker(self.id.clone().into(), cx.waker().clone());
 
         if let Some(state) = self.context.try_state() {
             if state.dht().has_exact_queued_holding_workflow(&self.pending) {
+                self.context.unregister_waker(self.id.clone().into());
                 Poll::Ready(())
             } else {
                 Poll::Pending

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use clokwerk::{ScheduleHandle, Scheduler, TimeUnits};
 use crossbeam_channel::{unbounded, Receiver, Sender};
+use futures::task::Waker;
 use holochain_core_types::{
     dna::Dna,
     error::{HcResult, HolochainError},
@@ -30,6 +31,7 @@ use holochain_persistence_api::cas::content::Address;
 use holochain_tracing::{self as ht, channel::lax_send_wrapped};
 use snowflake::ProcessUniqueId;
 use std::{
+    collections::HashMap,
     sync::{
         atomic::Ordering::{self, Relaxed},
         Arc,
@@ -37,8 +39,6 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use futures::task::Waker;
-use std::collections::HashMap;
 
 pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
 
@@ -168,7 +168,9 @@ impl Instance {
     }
 
     /// Returns recievers for actions and observers that get added to this instance
-    fn initialize_channels(&mut self) -> (ActionReceiver, Receiver<Observer>, Receiver<WakerRequest>) {
+    fn initialize_channels(
+        &mut self,
+    ) -> (ActionReceiver, Receiver<Observer>, Receiver<WakerRequest>) {
         let (tx_action, rx_action) = unbounded::<ht::SpanWrap<ActionWrapper>>();
         let (tx_observer, rx_observer) = unbounded::<Observer>();
         let (tx_waker, rx_waker) = unbounded::<WakerRequest>();

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -222,7 +222,7 @@ impl Instance {
                         // Add new observers
                         state_observers.extend(rx_observer.try_iter());
                         // Process waker requests
-                        for waker_request in rx_waker.iter() {
+                        for waker_request in rx_waker.try_iter() {
                             match waker_request {
                                 WakerRequest::Add(id, waker) => wakers.insert(id, waker),
                                 WakerRequest::Remove(id) => wakers.remove(&id),

--- a/crates/core/src/network/actions/initialize_network.rs
+++ b/crates/core/src/network/actions/initialize_network.rs
@@ -8,6 +8,7 @@ use futures::{task::Poll, Future};
 use holochain_core_types::error::HcResult;
 #[cfg(test)]
 use holochain_persistence_api::cas::content::Address;
+use snowflake::ProcessUniqueId;
 use std::{pin::Pin, sync::Arc};
 
 /// Creates a network proxy object and stores DNA and agent hash in the network state.
@@ -26,8 +27,10 @@ pub async fn initialize_network(context: &Arc<Context>) -> HcResult<()> {
     dispatch_action(context.action_channel(), action_wrapper.clone());
 
     log_debug!(context, "waiting for network");
+    let id = ProcessUniqueId::new();
     InitNetworkFuture {
         context: context.clone(),
+        id,
     }
     .await?;
 
@@ -58,6 +61,7 @@ pub async fn initialize_network_with_spoofed_dna(
 
 pub struct InitNetworkFuture {
     context: Arc<Context>,
+    id: ProcessUniqueId,
 }
 
 impl Future for InitNetworkFuture {
@@ -69,15 +73,15 @@ impl Future for InitNetworkFuture {
         }
         //
 
-        // TODO: connect the waker to state updates for performance reasons
-        // See: https://github.com/holochain/holochain-rust/issues/314
-        //
-        cx.waker().clone().wake();
+        self.context
+            .register_waker(self.id.clone(), cx.waker().clone());
+
         if let Some(state) = self.context.try_state() {
             if state.network().network.is_some()
                 && state.network().dna_address.is_some()
                 && state.network().agent_id.is_some()
             {
+                self.context.unregister_waker(self.id.clone());
                 Poll::Ready(Ok(()))
             } else {
                 Poll::Pending

--- a/crates/core/src/network/actions/initialize_network.rs
+++ b/crates/core/src/network/actions/initialize_network.rs
@@ -53,8 +53,10 @@ pub async fn initialize_network_with_spoofed_dna(
     let action_wrapper = ActionWrapper::new(Action::InitNetwork(network_settings));
     dispatch_action(context.action_channel(), action_wrapper.clone());
 
+    let id = ProcessUniqueId::new();
     InitNetworkFuture {
         context: context.clone(),
+        id,
     }
     .await
 }
@@ -71,7 +73,6 @@ impl Future for InitNetworkFuture {
         if let Some(err) = self.context.action_channel_error("InitializeNetworkFuture") {
             return Poll::Ready(Err(err));
         }
-        //
 
         self.context
             .register_waker(self.id.clone(), cx.waker().clone());

--- a/crates/core/src/network/actions/publish_header_entry.rs
+++ b/crates/core/src/network/actions/publish_header_entry.rs
@@ -7,6 +7,7 @@ use crate::{
 use futures::{future::Future, task::Poll};
 use holochain_core_types::error::HcResult;
 use holochain_persistence_api::cas::content::Address;
+use snowflake::ProcessUniqueId;
 use std::{pin::Pin, sync::Arc};
 
 /// Publish Header Entry Action Creator
@@ -15,9 +16,11 @@ use std::{pin::Pin, sync::Arc};
 pub async fn publish_header_entry(address: Address, context: &Arc<Context>) -> HcResult<Address> {
     let action_wrapper = ActionWrapper::new(Action::PublishHeaderEntry(address));
     dispatch_action(context.action_channel(), action_wrapper.clone());
+    let id = ProcessUniqueId::new();
     PublishHeaderEntryFuture {
         context: context.clone(),
         action: action_wrapper,
+        id,
     }
     .await
 }
@@ -27,6 +30,7 @@ pub async fn publish_header_entry(address: Address, context: &Arc<Context>) -> H
 pub struct PublishHeaderEntryFuture {
     context: Arc<Context>,
     action: ActionWrapper,
+    id: ProcessUniqueId,
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
@@ -41,11 +45,8 @@ impl Future for PublishHeaderEntryFuture {
             return Poll::Ready(Err(err));
         }
 
-        //
-        // TODO: connect the waker to state updates for performance reasons
-        // See: https://github.com/holochain/holochain-rust/issues/314
-        //
-        cx.waker().clone().wake();
+        self.context
+            .register_waker(self.id.clone(), cx.waker().clone());
 
         if let Some(state) = self.context.try_state() {
             let state = state.network();
@@ -61,6 +62,7 @@ impl Future for PublishHeaderEntryFuture {
                                 self.action.id().to_string(),
                             )),
                         );
+                        self.context.unregister_waker(self.id.clone());
                         Poll::Ready(result.clone())
                     }
                     _ => unreachable!(),

--- a/crates/core/src/network/actions/shutdown.rs
+++ b/crates/core/src/network/actions/shutdown.rs
@@ -38,10 +38,6 @@ impl Future for ShutdownFuture {
     type Output = HcResult<()>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
-        //
-        // TODO: connect the waker to state updates for performance reasons
-        // See: https://github.com/holochain/holochain-rust/issues/314
-        //
         cx.waker().clone().wake();
         self.state
             .try_read()


### PR DESCRIPTION
## PR summary

Closes #314 (finally).

This fixes a performance issue where the future executor eats up all available CPU cycles because we naively called `waker.wake()` in our futures' poll functions.

These changes align future waking with the redux loop, i.e. state mutations. The redux thread stores a map of wakers (of all active futures) and calls `wake()` on each after an action got reduced.

Futures register their waker by sending it over a channel they got in via the context.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
