### PR TITLE
refactored correct processing of validation errors for all workflows

### DIFF
--- a/crates/core/src/nucleus/validation/app_entry.rs
+++ b/crates/core/src/nucleus/validation/app_entry.rs
@@ -38,9 +38,7 @@ pub async fn validate_app_entry(
 
     let params = EntryValidationArgs {
         validation_data: entry_to_validation_data(context.clone(), &entry, link, validation_data)
-            .map_err(|_| {
-            ValidationError::Fail("Could not get entry validation".to_string())
-        })?,
+            .map_err(|e| ValidationError::Error(e))?,
     };
     let call = CallbackFnCall::new(&zome_name, "__hdk_validate_app_entry", params);
 

--- a/crates/core/src/workflows/hold_link.rs
+++ b/crates/core/src/workflows/hold_link.rs
@@ -1,10 +1,8 @@
 use crate::{
-    context::Context, dht::actions::hold_aspect::hold_aspect,
-    network::entry_with_header::EntryWithHeader, nucleus::validation::validate_entry,
-};
-
-use crate::{
-    nucleus::validation::ValidationError,
+    context::Context,
+    dht::actions::hold_aspect::hold_aspect,
+    network::entry_with_header::EntryWithHeader,
+    nucleus::validation::{process_validation_err, validate_entry},
     workflows::{hold_entry::hold_entry_workflow, validation_package},
 };
 use holochain_core_types::{
@@ -13,6 +11,7 @@ use holochain_core_types::{
     network::entry_aspect::EntryAspect,
     validation::{EntryLifecycle, ValidationData},
 };
+use holochain_persistence_api::cas::content::AddressableContent;
 use std::sync::Arc;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
@@ -58,20 +57,16 @@ pub async fn hold_link_workflow(
         entry_with_header.entry.clone(),
         None,
         validation_data,
-        &context
-    ).await
+        &context,
+    )
+    .await
     .map_err(|err| {
-        if let ValidationError::UnresolvedDependencies(dependencies) = &err {
-            log_debug!(context, "workflow/hold_link: Link could not be validated due to unresolved dependencies and will be tried later. List of missing dependencies: {:?}", dependencies);
-            HolochainError::ValidationPending
-        } else {
-            log_warn!(context, "workflow/hold_link: Link {:?} is NOT valid! Validation error: {:?}",
-                entry_with_header.entry,
-                err,
-            );
-            HolochainError::from(err)
-        }
-
+        process_validation_err(
+            "hold_link",
+            context.clone(),
+            err,
+            entry_with_header.entry.address(),
+        )
     })?;
     log_debug!(context, "workflow/hold_link: is valid!");
 


### PR DESCRIPTION
## PR summary

Fixes a bug where timeouts when fetching entry to validate were considered a validation fail rather than simply being retried.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
