### PR TITLE
don't get links from network if we are the authority

### DIFF
--- a/app_spec/test/files/entry.js
+++ b/app_spec/test/files/entry.js
@@ -1,4 +1,5 @@
 const { one, two } = require('../config')
+const sleep = require('sleep')
 
 module.exports = scenario => {
   scenario('delete_entry_post', async (s, t) => {
@@ -219,6 +220,8 @@ module.exports = scenario => {
     t.equal(address, address3)
 
     await s.consistency()
+
+    sleep.sleep(5)  // why do we need this now?
 
     const sources1 = await alice.call('app', 'blog', 'get_sources', { address }).then(x => x.Ok.sort())
     const sources2 = await bob.call('app', 'blog', 'get_sources', { address }).then(x => x.Ok.sort())

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -73,7 +73,7 @@ module.exports = scenario => {
     t.ok(result_bob_delete.Err)
     t.notOk(result_bob_delete.Ok)
     const error = JSON.parse(result_bob_delete.Err.Internal)
-    t.deepEqual(error.kind, { ErrorGeneric: 'Target for link not found' })
+    t.match(error.kind.ErrorGeneric, /Target for link not found: Link { base: HashString(".*"), target: HashString(".*"), link_type: "authored_posts", tag: "" }/)
     t.ok(error.file)
     t.ok(error.line)
   })

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -180,6 +180,8 @@ module.exports = scenario => {
       { base: alice.info('app').agentAddress, target: 'Holo world 2' }
     )
 
+    await s.consistency()
+
     // get posts for alice from alice
     const alice_posts_live = await alice.call('app', 'simple', 'get_my_links',
       {
@@ -208,6 +210,8 @@ module.exports = scenario => {
         base: alice.info('app').agentAddress,
         target: 'Holo world'
       })
+
+    await s.consistency()
 
     // get all posts with a deleted status from bob
     const bob_posts_deleted = await bob.call('app', 'simple', 'get_my_links',

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -73,7 +73,7 @@ module.exports = scenario => {
     t.ok(result_bob_delete.Err)
     t.notOk(result_bob_delete.Ok)
     const error = JSON.parse(result_bob_delete.Err.Internal)
-    t.match(error.kind.ErrorGeneric, /Target for link not found: Link { base: HashString(".*"), target: HashString(".*"), link_type: "authored_posts", tag: "" }/)
+    t.match(error.kind.ErrorGeneric, /Target for link not found: Link { base: HashString\(".*"\), target: HashString\(".*"\), link_type: "authored_posts", tag: "" }/)
     t.ok(error.file)
     t.ok(error.line)
   })

--- a/app_spec/test/files/offline-validation.js
+++ b/app_spec/test/files/offline-validation.js
@@ -1,6 +1,6 @@
 const { one } = require('../config')
 
-const delay = ms => new Promise(resolve => setTimeout(resolve, ms)) 
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
 module.exports = scenario => {
 
@@ -43,7 +43,7 @@ module.exports = scenario => {
       })
 
       scenario('Can perform validation of an entry while the author is offline', async (s, t) => {
-        
+
         const { alice, bob, carol } = await s.players({alice: one, bob: one, carol: one})
         // alice and bob start online
         await alice.spawn()
@@ -68,7 +68,7 @@ module.exports = scenario => {
         const bob_result = await bob.call('app', "blog", "get_post", { post_address: create_result.Ok })
         t.ok(bob_result.Ok)
         t.equal(JSON.parse(bob_result.Ok.App[1]).content, initialContent)
-        
+
         // alice then goes offline
         t.comment('waiting for alice to go offline')
         await alice.kill()

--- a/app_spec/test/files/offline-validation.js
+++ b/app_spec/test/files/offline-validation.js
@@ -10,7 +10,6 @@ module.exports = scenario => {
         await bob.spawn()
 
         await s.consistency()
-
         // alice publishes a memo. This is private but should still publish a header
         const create_result = await alice.call('app', "blog", "create_memo", { content: "private memo" })
         t.comment(JSON.stringify(create_result))
@@ -27,14 +26,13 @@ module.exports = scenario => {
         let chain_headers = []
 
         await s.consistency()
-
         for (let i=0; i< chain_header_hashes.length; i++) {
             // can use get_post because it just returns a raw entry given a hash
             let header_hash = chain_header_hashes[i]
-            t.comment(header_hash)
 
             // check bob can retrieve alices header entries
-            let header_bob = await bob.call('app', "blog", "get_post", { post_address: header_hash })
+            let header_bob = await alice.call('app', "blog", "get_post", { post_address: header_hash })
+            t.comment(header_hash)
             t.ok(header_bob.Ok)
 
             chain_headers.push(header_bob.Ok)

--- a/crates/conductor_lib/src/holochain.rs
+++ b/crates/conductor_lib/src/holochain.rs
@@ -76,7 +76,7 @@
 //! hc.start().expect("couldn't start the holochain instance");
 //!
 //! // call a function in the zome code
-//! hc.call("test_zome", CapabilityRequest::new(Address::from("some_token"), Address::from("caller"), Signature::fake()), "some_fn", "{}");
+//! hc.call_zome_function("test_zome", CapabilityRequest::new(Address::from("some_token"), Address::from("caller"), Signature::fake()), "some_fn", "{}");
 //!
 //! // get the state
 //! {

--- a/crates/core/src/action.rs
+++ b/crates/core/src/action.rs
@@ -1,6 +1,6 @@
 use crate::{
     agent::state::AgentState,
-    dht::pending_validations::PendingValidation,
+    dht::{dht_store::HoldAspectAttemptId, pending_validations::PendingValidation},
     network::{
         direct_message::DirectMessage,
         entry_aspect::EntryAspect,
@@ -23,7 +23,6 @@ use holochain_core_types::{
 use holochain_net::{connection::net_connection::NetHandler, p2p_config::P2pConfig};
 use holochain_persistence_api::cas::content::Address;
 use lib3h_protocol::data_types::{EntryListData, FetchEntryData, QueryEntryData};
-use snowflake::ProcessUniqueId;
 use std::{
     hash::{Hash, Hasher},
     time::{Duration, SystemTime},
@@ -121,7 +120,7 @@ pub enum Action {
 
     /// Adds an entry aspect to the local DHT shard.
     /// Does not validate, assumes referenced entry is valid.
-    HoldAspect((EntryAspect, ProcessUniqueId)),
+    HoldAspect((EntryAspect, HoldAspectAttemptId)),
 
     //action for updating crudstatus
     CrudStatus((EntryWithHeader, CrudStatus)),

--- a/crates/core/src/action.rs
+++ b/crates/core/src/action.rs
@@ -23,6 +23,7 @@ use holochain_core_types::{
 use holochain_net::{connection::net_connection::NetHandler, p2p_config::P2pConfig};
 use holochain_persistence_api::cas::content::Address;
 use lib3h_protocol::data_types::{EntryListData, FetchEntryData, QueryEntryData};
+use snowflake::ProcessUniqueId;
 use std::{
     hash::{Hash, Hasher},
     time::{Duration, SystemTime},
@@ -120,7 +121,7 @@ pub enum Action {
 
     /// Adds an entry aspect to the local DHT shard.
     /// Does not validate, assumes referenced entry is valid.
-    HoldAspect(EntryAspect),
+    HoldAspect((EntryAspect, ProcessUniqueId)),
 
     //action for updating crudstatus
     CrudStatus((EntryWithHeader, CrudStatus)),

--- a/crates/core/src/consistency.rs
+++ b/crates/core/src/consistency.rs
@@ -160,7 +160,7 @@ impl ConsistencyModel {
                     None
                 })
             }
-            Action::HoldAspect(aspect) => match aspect {
+            Action::HoldAspect((aspect,_)) => match aspect {
                 EntryAspect::Content(entry, _) => Some(ConsistencySignal::new_terminal(Hold(entry.address()))),
                 EntryAspect::Update(_, header) => {
                     header.link_update_delete().map(|old| {

--- a/crates/core/src/dht/actions/hold_aspect.rs
+++ b/crates/core/src/dht/actions/hold_aspect.rs
@@ -5,6 +5,8 @@ use crate::{
 };
 use futures::{future::Future, task::Poll};
 use holochain_core_types::{error::HolochainError, network::entry_aspect::EntryAspect};
+use holochain_persistence_api::cas::content::AddressableContent;
+use lib3h_protocol::data_types::EntryListData;
 use snowflake::ProcessUniqueId;
 use std::{pin::Pin, sync::Arc};
 
@@ -13,13 +15,34 @@ pub async fn hold_aspect(aspect: EntryAspect, context: Arc<Context>) -> Result<(
     let action_wrapper = ActionWrapper::new(Action::HoldAspect((aspect.clone(), id)));
     dispatch_action(context.action_channel(), action_wrapper.clone());
     let r = HoldAspectFuture {
-        context,
+        context: context.clone(),
         //        aspect,
         id,
     }
     .await;
     if r.is_err() {
         panic!(r);
+    } else {
+        // send a gossip list with this aspect in it back to sim2h so it know we are holding it
+        let c = context.clone();
+        let closure = async move || {
+            let state = context
+                .state()
+                .expect("No state present when trying to respond with gossip list");
+
+            // TODO: send the whole holding map for now fix to the specific aspect later
+            let address_map = state.dht().get_holding_map().clone();
+
+            let action = Action::RespondGossipList(EntryListData {
+                space_address: state.network().dna_address.clone().unwrap().into(),
+                provider_agent_id: context.agent_id.address().into(), //get_list_data.provider_agent_id,
+                request_id: "".to_string(),
+                address_map: address_map.into(),
+            });
+            dispatch_action(context.action_channel(), ActionWrapper::new(action));
+        };
+        let future = closure();
+        c.spawn_task(future);
     }
     r
 }

--- a/crates/core/src/dht/actions/hold_aspect.rs
+++ b/crates/core/src/dht/actions/hold_aspect.rs
@@ -21,7 +21,7 @@ pub async fn hold_aspect(aspect: EntryAspect, context: Arc<Context>) -> Result<(
     }
     .await;
     if r.is_err() {
-        panic!(r);
+        error!("HoldAspect action completed with error: {:?}", r);
     } else {
         // send a gossip list with this aspect in it back to sim2h so it know we are holding it
         let c = context.clone();

--- a/crates/core/src/dht/actions/hold_aspect.rs
+++ b/crates/core/src/dht/actions/hold_aspect.rs
@@ -1,6 +1,7 @@
 use crate::{
     action::{Action, ActionWrapper},
     context::Context,
+    dht::aspect_map::AspectMap,
     instance::dispatch_action,
 };
 use futures::{future::Future, task::Poll};
@@ -30,8 +31,8 @@ pub async fn hold_aspect(aspect: EntryAspect, context: Arc<Context>) -> Result<(
                 .state()
                 .expect("No state present when trying to respond with gossip list");
 
-            // TODO: send the whole holding map for now fix to the specific aspect later
-            let address_map = state.dht().get_holding_map().clone();
+            let mut address_map = AspectMap::new();
+            address_map.add(&aspect);
 
             let action = Action::RespondGossipList(EntryListData {
                 space_address: state.network().dna_address.clone().unwrap().into(),

--- a/crates/core/src/dht/aspect_map.rs
+++ b/crates/core/src/dht/aspect_map.rs
@@ -27,6 +27,10 @@ impl AspectMap {
         &self.0
     }
 
+    pub fn contains_entry(&self, entry_address: &EntryHash) -> bool {
+        self.0.contains_key(entry_address)
+    }
+
     pub fn contains(&self, aspect: &EntryAspect) -> bool {
         let entry_address: EntryHash = aspect
             .entry_address()

--- a/crates/core/src/dht/dht_inner_reducers.rs
+++ b/crates/core/src/dht/dht_inner_reducers.rs
@@ -72,8 +72,9 @@ pub(crate) fn reduce_add_remove_link_inner(
         Ok(link.link().base().clone())
     } else {
         Err(HolochainError::ErrorGeneric(format!(
-            "Base for link not found: {:?}", link)
-        ))
+            "Base for link not found: {:?}",
+            link
+        )))
     }
 }
 

--- a/crates/core/src/dht/dht_inner_reducers.rs
+++ b/crates/core/src/dht/dht_inner_reducers.rs
@@ -71,9 +71,9 @@ pub(crate) fn reduce_add_remove_link_inner(
         store.add_eavi(&eav)?;
         Ok(link.link().base().clone())
     } else {
-        Err(HolochainError::ErrorGeneric(String::from(
-            "Base for link not found",
-        )))
+        Err(HolochainError::ErrorGeneric(format!(
+            "Base for link not found: {:?}", link)
+        ))
     }
 }
 

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -281,7 +281,9 @@ pub mod tests {
         network::entry_aspect::EntryAspect,
     };
     use holochain_persistence_api::cas::content::{Address, AddressableContent};
+    use snowflake::ProcessUniqueId;
     use std::{sync::Arc, time::SystemTime};
+
     // TODO do this for all crate tests somehow
     #[allow(dead_code)]
     fn enable_logging_for_test() {
@@ -306,7 +308,7 @@ pub mod tests {
         let new_dht_store = reduce_hold_aspect(
             &store.dht(),
             &ActionWrapper::new(Action::HoldAspect((
-                (EntryAspect::Content(sys_entry.clone(), test_chain_header())),
+                EntryAspect::Content(sys_entry.clone(), test_chain_header()),
                 ProcessUniqueId::new(),
             ))),
         )
@@ -347,10 +349,10 @@ pub mod tests {
             test_chain_header(),
             test_agent_id(),
         );
-        let action = ActionWrapper::new(Action::HoldAspect(
-            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+        let action = ActionWrapper::new(Action::HoldAspect((
+            EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
             ProcessUniqueId::new(),
-        ));
+        )));
         let link_entry = Entry::LinkAdd(link_data.clone());
 
         let new_dht_store = (*reduce(store.dht(), &action)).clone();
@@ -395,8 +397,8 @@ pub mod tests {
 
         //add link to dht
         let entry_link_add = Entry::LinkAdd(link_data.clone());
-        let action_link_add = ActionWrapper::new(Action::HoldAspect((
-            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+        let action_link_add = ActionWrapper::new(Action::HoldAspect(
+            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
             ProcessUniqueId::new(),
         )));
 
@@ -411,13 +413,13 @@ pub mod tests {
 
         //remove added link from dht
         let action_link_remove = ActionWrapper::new(Action::HoldAspect((
-            (EntryAspect::LinkRemove(
+            EntryAspect::LinkRemove(
                 (
                     link_remove_data.clone(),
                     vec![entry_link_add.clone().address()],
                 ),
                 test_chain_header(),
-            )),
+            ),
             ProcessUniqueId::new(),
         )));
         let new_dht_store = reduce(new_dht_store, &action_link_remove);
@@ -446,7 +448,7 @@ pub mod tests {
 
         //add new link with same chain header
         let action_link_add = ActionWrapper::new(Action::HoldAspect((
-            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+            EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
             ProcessUniqueId::new(),
         )));
         let new_dht_store = reduce(store.dht(), &action_link_add);
@@ -527,12 +529,10 @@ pub mod tests {
             test_chain_header(),
             test_agent_id(),
         );
-        let action = ActionWrapper::new(Action::HoldAspect(
-            ((
-                EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
-                ProcessUniqueId::new(),
-            )),
-        ));
+        let action = ActionWrapper::new(Action::HoldAspect((
+            EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
+            ProcessUniqueId::new(),
+        )));
 
         let new_dht_store = reduce(store.dht(), &action);
 

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -75,14 +75,13 @@ pub(crate) fn reduce_hold_aspect(
 ) -> Option<DhtStore> {
     let aspect = unwrap_to!(action_wrapper.action() => Action::HoldAspect);
     let mut new_store = (*old_store).clone();
-    new_store.mark_aspect_as_held(&aspect);
 
     // TODO: we think we don't need this but not 100%
     // new_store.actions_mut().insert(
     //     action_wrapper.clone(),
     //     Ok("TODO: nico, do we need this?".into()),
     // );
-    match aspect {
+    let mut r = match aspect {
         EntryAspect::Content(entry, header) => {
             match reduce_store_entry_inner(&mut new_store, entry) {
                 Ok(()) => {
@@ -146,7 +145,11 @@ pub(crate) fn reduce_hold_aspect(
             error!("Got EntryAspect::Header which is not implemented.");
             None
         }
+    };
+    if let Some(ref mut store) = r {
+        store.mark_aspect_as_held(&aspect);
     }
+    r
 }
 
 #[allow(dead_code)]

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -397,8 +397,8 @@ pub mod tests {
 
         //add link to dht
         let entry_link_add = Entry::LinkAdd(link_data.clone());
-        let action_link_add = ActionWrapper::new(Action::HoldAspect((
-            EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
+        let action_link_add = ActionWrapper::new(Action::HoldAspect(
+            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
             ProcessUniqueId::new(),
         )));
 

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -93,7 +93,7 @@ pub(crate) fn reduce_hold_aspect(
                 }
                 Err(e) => {
                     let err = format!("EntryAspect::Content hold error: {}", e);
-                    hold_result = Err(HolochainError::ErrorGeneric(err.clone()));
+                    hold_result = Err(HolochainError::ErrorGeneric(err));
                     None
                 }
             }

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -306,7 +306,7 @@ pub mod tests {
             &store.dht(),
             &ActionWrapper::new(Action::HoldAspect((
                 EntryAspect::Content(sys_entry.clone(), test_chain_header()),
-                ProcessUniqueId::new(),
+                (ProcessUniqueId::new(), ProcessUniqueId::new()),
             ))),
         )
         .expect("there should be a new store for committing a sys entry");
@@ -348,7 +348,7 @@ pub mod tests {
         );
         let action = ActionWrapper::new(Action::HoldAspect((
             EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
         let link_entry = Entry::LinkAdd(link_data.clone());
 
@@ -396,7 +396,7 @@ pub mod tests {
         let entry_link_add = Entry::LinkAdd(link_data.clone());
         let action_link_add = ActionWrapper::new(Action::HoldAspect((
             EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
 
         let new_dht_store = reduce(store.dht(), &action_link_add);
@@ -417,7 +417,7 @@ pub mod tests {
                 ),
                 test_chain_header(),
             ),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
         let new_dht_store = reduce(new_dht_store, &action_link_remove);
 
@@ -446,7 +446,7 @@ pub mod tests {
         //add new link with same chain header
         let action_link_add = ActionWrapper::new(Action::HoldAspect((
             EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
         let new_dht_store = reduce(store.dht(), &action_link_add);
 
@@ -482,7 +482,7 @@ pub mod tests {
         let entry_link_add = Entry::LinkAdd(link_data.clone());
         let action_link_add = ActionWrapper::new(Action::HoldAspect((
             EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
         let new_dht_store_2 = reduce(store.dht(), &action_link_add);
 
@@ -528,7 +528,7 @@ pub mod tests {
         );
         let action = ActionWrapper::new(Action::HoldAspect((
             EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
 
         let new_dht_store = reduce(store.dht(), &action);
@@ -553,7 +553,7 @@ pub mod tests {
         let entry = test_entry();
         let action_wrapper = ActionWrapper::new(Action::HoldAspect((
             EntryAspect::Content(entry.clone(), test_chain_header()),
-            ProcessUniqueId::new(),
+            (ProcessUniqueId::new(), ProcessUniqueId::new()),
         )));
 
         store.reduce(action_wrapper);

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -110,7 +110,7 @@ pub(crate) fn reduce_hold_aspect(
                 Ok(_) => Some(new_store),
                 Err(e) => {
                     let err = format!("EntryAspect::Content hold error: {}", e);
-                    hold_result = Err(HolochainError::ErrorGeneric(err.clone()));
+                    hold_result = Err(HolochainError::ErrorGeneric(err));
                     error!("{}", e);
                     None
                 }

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -397,8 +397,8 @@ pub mod tests {
 
         //add link to dht
         let entry_link_add = Entry::LinkAdd(link_data.clone());
-        let action_link_add = ActionWrapper::new(Action::HoldAspect(
-            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
+        let action_link_add = ActionWrapper::new(Action::HoldAspect((
+            EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
             ProcessUniqueId::new(),
         )));
 

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -305,10 +305,10 @@ pub mod tests {
 
         let new_dht_store = reduce_hold_aspect(
             &store.dht(),
-            &ActionWrapper::new(
-                Action::HoldAspect(EntryAspect::Content(sys_entry.clone(), test_chain_header())),
+            &ActionWrapper::new(Action::HoldAspect((
+                (EntryAspect::Content(sys_entry.clone(), test_chain_header())),
                 ProcessUniqueId::new(),
-            ),
+            ))),
         )
         .expect("there should be a new store for committing a sys entry");
 
@@ -347,10 +347,10 @@ pub mod tests {
             test_chain_header(),
             test_agent_id(),
         );
-        let action = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+        let action = ActionWrapper::new(Action::HoldAspect(
+            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
             ProcessUniqueId::new(),
-        );
+        ));
         let link_entry = Entry::LinkAdd(link_data.clone());
 
         let new_dht_store = (*reduce(store.dht(), &action)).clone();
@@ -395,10 +395,10 @@ pub mod tests {
 
         //add link to dht
         let entry_link_add = Entry::LinkAdd(link_data.clone());
-        let action_link_add = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+        let action_link_add = ActionWrapper::new(Action::HoldAspect((
+            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
             ProcessUniqueId::new(),
-        );
+        )));
 
         let new_dht_store = reduce(store.dht(), &action_link_add);
 
@@ -410,8 +410,8 @@ pub mod tests {
         );
 
         //remove added link from dht
-        let action_link_remove = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::LinkRemove(
+        let action_link_remove = ActionWrapper::new(Action::HoldAspect((
+            (EntryAspect::LinkRemove(
                 (
                     link_remove_data.clone(),
                     vec![entry_link_add.clone().address()],
@@ -419,7 +419,7 @@ pub mod tests {
                 test_chain_header(),
             )),
             ProcessUniqueId::new(),
-        );
+        )));
         let new_dht_store = reduce(new_dht_store, &action_link_remove);
 
         //fetch from dht and when tombstone is found return tombstone
@@ -445,10 +445,10 @@ pub mod tests {
         );
 
         //add new link with same chain header
-        let action_link_add = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+        let action_link_add = ActionWrapper::new(Action::HoldAspect((
+            (EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
             ProcessUniqueId::new(),
-        );
+        )));
         let new_dht_store = reduce(store.dht(), &action_link_add);
 
         //fetch from dht after link with same chain header is added
@@ -481,10 +481,10 @@ pub mod tests {
             test_agent_id_with_name("new_agent"),
         );
         let entry_link_add = Entry::LinkAdd(link_data.clone());
-        let action_link_add = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
+        let action_link_add = ActionWrapper::new(Action::HoldAspect((
+            EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
             ProcessUniqueId::new(),
-        );
+        )));
         let new_dht_store_2 = reduce(store.dht(), &action_link_add);
 
         //after new link has been added return from fetch and make sure tombstone and new link is added
@@ -527,10 +527,12 @@ pub mod tests {
             test_chain_header(),
             test_agent_id(),
         );
-        let action = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::LinkAdd(link_data.clone(), test_chain_header())),
-            ProcessUniqueId::new(),
-        );
+        let action = ActionWrapper::new(Action::HoldAspect(
+            ((
+                EntryAspect::LinkAdd(link_data.clone(), test_chain_header()),
+                ProcessUniqueId::new(),
+            )),
+        ));
 
         let new_dht_store = reduce(store.dht(), &action);
 
@@ -552,10 +554,10 @@ pub mod tests {
         let store = test_store(context.clone());
 
         let entry = test_entry();
-        let action_wrapper = ActionWrapper::new(
-            Action::HoldAspect(EntryAspect::Content(entry.clone(), test_chain_header())),
+        let action_wrapper = ActionWrapper::new(Action::HoldAspect((
+            EntryAspect::Content(entry.clone(), test_chain_header()),
             ProcessUniqueId::new(),
-        );
+        )));
 
         store.reduce(action_wrapper);
 

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -73,7 +73,7 @@ pub struct PendingValidationStruct {
     pub entry_with_header: EntryWithHeader,
     pub dependencies: Vec<Address>,
     pub workflow: ValidatingWorkflow,
-    uuid: ProcessUniqueId,
+    pub uuid: ProcessUniqueId,
 }
 
 impl PendingValidationStruct {

--- a/crates/core/src/entry/mod.rs
+++ b/crates/core/src/entry/mod.rs
@@ -35,7 +35,7 @@ impl CanPublish for EntryType {
 
         // app entry type must be publishable
         if !entry_type_def.sharing.clone().can_publish() {
-            log_debug!(context, "dht/entry {} is not publishable", entry_type_name);
+            log_trace!(context, "dht/entry {} is not publishable", entry_type_name);
             return false;
         }
         true

--- a/crates/core/src/network/actions/query.rs
+++ b/crates/core/src/network/actions/query.rs
@@ -28,6 +28,14 @@ pub enum QueryMethod {
     Link(GetLinksArgs, GetLinksNetworkQuery),
 }
 
+pub fn crud_status_from_link_args(link_args: &GetLinksArgs) -> Option<CrudStatus> {
+    match link_args.options.status_request {
+        LinksStatusRequestKind::All => None,
+        LinksStatusRequestKind::Deleted => Some(CrudStatus::Deleted),
+        LinksStatusRequestKind::Live => Some(CrudStatus::Live),
+    }
+}
+
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn query(
     context: Arc<Context>,
@@ -49,11 +57,7 @@ pub async fn query(
                 tag: link_args.tag.clone(),
                 id: nanoid::simple(),
             };
-            let crud_status = match link_args.options.status_request {
-                LinksStatusRequestKind::All => None,
-                LinksStatusRequestKind::Deleted => Some(CrudStatus::Deleted),
-                LinksStatusRequestKind::Live => Some(CrudStatus::Live),
-            };
+            let crud_status = crud_status_from_link_args(&link_args);
             (
                 QueryKey::Links(key),
                 QueryPayload::Links((crud_status, query)),

--- a/crates/core/src/network/handler/query.rs
+++ b/crates/core/src/network/handler/query.rs
@@ -26,7 +26,7 @@ use std::{convert::TryInto, sync::Arc};
 
 pub type LinkTag = String;
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
-fn get_links(
+pub fn get_links(
     context: &Arc<Context>,
     base: Address,
     link_type: Option<String>,

--- a/crates/core/src/network/handler/send.rs
+++ b/crates/core/src/network/handler/send.rs
@@ -110,7 +110,7 @@ pub fn handle_send_message_result(message_data: DirectMessageData, context: Arc<
     match response {
         DirectMessage::Custom(custom_direct_message) => {
             if initial_message.is_none() {
-                log_error!(context, "net: Received a custom direct message response but could not find message ID in history. Not able to process.");
+                log_error!(context, "net: Received a custom direct message response but could not find message ID {} in history. Not able to process.", message_data.request_id);
                 return;
             }
 
@@ -129,7 +129,7 @@ pub fn handle_send_message_result(message_data: DirectMessageData, context: Arc<
         ),
         DirectMessage::ValidationPackage(maybe_validation_package) => {
             if initial_message.is_none() {
-                log_error!(context, "net: Received a validation package but could not find message ID in history. Not able to process.");
+                log_error!(context, "net: Received a validation package but could not find message ID {} in history. Not able to process.", message_data.request_id);
                 return;
             }
 

--- a/crates/core/src/network/reducers/publish.rs
+++ b/crates/core/src/network/reducers/publish.rs
@@ -138,15 +138,11 @@ fn publish_link_meta(
     )
 }
 
-#[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
-fn reduce_publish_inner(
+fn publish_entry_with_header(
     network_state: &mut NetworkState,
-    root_state: &State,
-    address: &Address,
+    entry_with_header: EntryWithHeader,
 ) -> Result<(), HolochainError> {
     network_state.initialized()?;
-
-    let entry_with_header = fetch_entry_with_header(&address, root_state)?;
 
     match entry_with_header.entry.entry_type() {
         EntryType::AgentId => publish_entry(network_state, &entry_with_header),
@@ -181,6 +177,16 @@ fn reduce_publish_inner(
             entry_with_header.entry.entry_type()
         ))),
     }
+}
+
+#[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
+fn reduce_publish_inner(
+    network_state: &mut NetworkState,
+    root_state: &State,
+    address: &Address,
+) -> Result<(), HolochainError> {
+    let entry_with_header = fetch_entry_with_header(&address, root_state)?;
+    publish_entry_with_header(network_state, entry_with_header)
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]

--- a/crates/core/src/network/reducers/query.rs
+++ b/crates/core/src/network/reducers/query.rs
@@ -80,7 +80,8 @@ pub fn reduce_query_timeout(
         network_state.get_query_results.insert(
             key.clone(),
             Some(Err(HolochainError::Timeout(format!(
-                "timeout src: {}:{}",
+                "key: {:?}, timeout src: {}:{}",
+                key,
                 file!(),
                 line!()
             )))),

--- a/crates/core/src/nucleus/state.rs
+++ b/crates/core/src/nucleus/state.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use holochain_core_types::{dna::Dna, error::HolochainError};
 
-use crate::state::StateWrapper;
+use crate::{state::StateWrapper, wasm_engine::api::ZomeApiFunction};
 use holochain_json_api::{
     error::{JsonError, JsonResult},
     json::JsonString,
@@ -16,7 +16,6 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{collections::VecDeque, convert::TryFrom, fmt};
-use crate::wasm_engine::api::ZomeApiFunction;
 
 #[autotrace]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, DefaultJson)]
@@ -231,9 +230,10 @@ impl ZomeFnCallState {
             match call.function {
                 // init globals call is never started so expect this to fail
                 ZomeApiFunction::InitGlobals => Ok(()),
-                _ =>    Err(HolochainError::new(
-                    &format!("Attempted to end HDK call, but none was started! {:?} {:?}",call, result)
-                ))
+                _ => Err(HolochainError::new(&format!(
+                    "Attempted to end HDK call, but none was started! {:?} {:?}",
+                    call, result
+                ))),
             }
         }
     }

--- a/crates/core/src/nucleus/state.rs
+++ b/crates/core/src/nucleus/state.rs
@@ -221,7 +221,7 @@ impl ZomeFnCallState {
                 ))
             } else if current_result.is_some() {
                 Err(HolochainError::new(
-                    "Ending and HDK which was already ended.",
+                    "Ending an HDK call which was already ended.",
                 ))
             } else {
                 self.hdk_fn_invocations.push((call, Some(result)));

--- a/crates/core/src/nucleus/state.rs
+++ b/crates/core/src/nucleus/state.rs
@@ -16,6 +16,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use std::{collections::VecDeque, convert::TryFrom, fmt};
+use crate::wasm_engine::api::ZomeApiFunction;
 
 #[autotrace]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, DefaultJson)]
@@ -227,9 +228,13 @@ impl ZomeFnCallState {
                 Ok(())
             }
         } else {
-            Err(HolochainError::new(
-                "Attempted to end HDK call, but none was started!",
-            ))
+            match call.function {
+                // init globals call is never started so expect this to fail
+                ZomeApiFunction::InitGlobals => Ok(()),
+                _ =>    Err(HolochainError::new(
+                    &format!("Attempted to end HDK call, but none was started! {:?} {:?}",call, result)
+                ))
+            }
         }
     }
 }

--- a/crates/core/src/wasm_engine/api/commit.rs
+++ b/crates/core/src/wasm_engine/api/commit.rs
@@ -17,6 +17,7 @@ use wasmi::{RuntimeArgs, RuntimeValue};
 pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
     let context = runtime.context()?;
 
+    log_debug!(context, "commit_app_entry_1");
     // deserialize args
     let args_str = runtime.load_json_string_from_args(&args);
     let commit_entry_arg = match CommitEntryArgs::try_from(args_str.clone()) {
@@ -33,6 +34,8 @@ pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> Zom
             return ribosome_error_code!(ArgumentDeserializationFailed);
         }
     };
+    log_debug!(context, "commit_app_entry_2");
+
     let span = context
         .tracer
         .span("hdk invoke_commit_app_entry")
@@ -42,7 +45,9 @@ pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> Zom
         ))
         .start()
         .into();
+    log_debug!(context, "commit_app_entry_3");
     let _spanguard = ht::push_span(span);
+    log_debug!(context, "commit_app_entry_4");
 
     // Wait for future to be resolved
     let task_result: Result<CommitEntryResult, HolochainError> = context.block_on(author_entry(
@@ -51,8 +56,12 @@ pub fn invoke_commit_app_entry(runtime: &mut Runtime, args: &RuntimeArgs) -> Zom
         &context,
         &commit_entry_arg.options().provenance(),
     ));
+    log_debug!(context, "commit_app_entry_5");
 
-    runtime.store_result(task_result)
+    let x = runtime.store_result(task_result);
+
+    log_debug!(context, "commit_app_entry_6");
+    x
 }
 
 #[cfg(test)]

--- a/crates/core/src/wasm_engine/api/get_links.rs
+++ b/crates/core/src/wasm_engine/api/get_links.rs
@@ -68,6 +68,7 @@ pub mod tests {
     use holochain_persistence_api::cas::content::Address;
     use holochain_wasm_utils::api_serialization::get_links::GetLinksArgs;
     use serde_json;
+    use snowflake::ProcessUniqueId;
 
     /// dummy link_entries args from standard test entry
     pub fn test_get_links_args_bytes(
@@ -124,8 +125,10 @@ pub mod tests {
                     &initialized_context
                 ))
                 .is_ok());
+            let fake_id = ProcessUniqueId::new();
             assert!(initialized_context
                 .block_on(hold_aspect(
+                    &fake_id,
                     EntryAspect::LinkAdd(
                         LinkData::add_from_link(link, test_chain_header(), test_agent_id()),
                         test_chain_header(),

--- a/crates/core/src/wasm_engine/api/macros.rs
+++ b/crates/core/src/wasm_engine/api/macros.rs
@@ -87,7 +87,7 @@ macro_rules! link_zome_api {
                                 trace_return_hdk_function(zome_api_call.clone(), hdk_fn_call, hdk_fn_result, &context);
                                 result
                             } else {
-                                error!("Can't record zome call hdk invocations for non zome call {:?}", ZomeApiFunction::$enum_variant);
+                                // we don't record hdk function calls for callbacks or direct function calls
                                 $function_name(runtime, args)
                             }
                         } else {

--- a/crates/core/src/wasm_engine/api/macros.rs
+++ b/crates/core/src/wasm_engine/api/macros.rs
@@ -87,7 +87,7 @@ macro_rules! link_zome_api {
                                 trace_return_hdk_function(zome_api_call.clone(), hdk_fn_call, hdk_fn_result, &context);
                                 result
                             } else {
-                                error!("Can't record zome call hdk invocations for non zome call");
+                                error!("Can't record zome call hdk invocations for non zome call {:?}", ZomeApiFunction::$enum_variant);
                                 $function_name(runtime, args)
                             }
                         } else {

--- a/crates/core/src/wasm_engine/callback/links_utils.rs
+++ b/crates/core/src/wasm_engine/callback/links_utils.rs
@@ -24,8 +24,9 @@ pub fn get_link_entries(
         context.block_on(get_entry_result_workflow(&context, entry_args))?;
     if !base_entry_get_result.found() {
         return Err(HolochainError::ErrorGeneric(format!(
-            "Base for link not found: {:?}", link)
-        ));
+            "Base for link not found: {:?}",
+            link
+        )));
     }
     let base_entry = base_entry_get_result.latest().unwrap();
     let entry_args = &GetEntryArgs {
@@ -36,8 +37,9 @@ pub fn get_link_entries(
         context.block_on(get_entry_result_workflow(&context, entry_args))?;
     if !target_entry_get_result.found() {
         return Err(HolochainError::ErrorGeneric(format!(
-            "Target for link not found: {:?}", link)
-        ));
+            "Target for link not found: {:?}",
+            link
+        )));
     }
 
     Ok((base_entry, target_entry_get_result.latest().unwrap()))

--- a/crates/core/src/wasm_engine/callback/links_utils.rs
+++ b/crates/core/src/wasm_engine/callback/links_utils.rs
@@ -23,9 +23,9 @@ pub fn get_link_entries(
     let base_entry_get_result =
         context.block_on(get_entry_result_workflow(&context, entry_args))?;
     if !base_entry_get_result.found() {
-        return Err(HolochainError::ErrorGeneric(String::from(
-            "Base for link not found",
-        )));
+        return Err(HolochainError::ErrorGeneric(format!(
+            "Base for link not found: {:?}", link)
+        ));
     }
     let base_entry = base_entry_get_result.latest().unwrap();
     let entry_args = &GetEntryArgs {
@@ -35,9 +35,9 @@ pub fn get_link_entries(
     let target_entry_get_result =
         context.block_on(get_entry_result_workflow(&context, entry_args))?;
     if !target_entry_get_result.found() {
-        return Err(HolochainError::ErrorGeneric(String::from(
-            "Target for link not found",
-        )));
+        return Err(HolochainError::ErrorGeneric(format!(
+            "Target for link not found: {:?}", link)
+        ));
     }
 
     Ok((base_entry, target_entry_get_result.latest().unwrap()))

--- a/crates/core/src/workflows/get_link_result.rs
+++ b/crates/core/src/workflows/get_link_result.rs
@@ -1,7 +1,8 @@
 use crate::{
     context::Context,
     network::{
-        actions::query::{query, QueryMethod},
+        actions::query::{crud_status_from_link_args, query, QueryMethod},
+        handler::query::get_links,
         query::{
             GetLinksNetworkQuery, GetLinksNetworkResult, GetLinksQueryConfiguration,
             NetworkQueryResult,
@@ -10,10 +11,19 @@ use crate::{
 };
 
 use holochain_core_types::error::HolochainError;
+use holochain_persistence_api::cas::content::{Address, AddressableContent};
 use holochain_wasm_utils::api_serialization::get_links::{
     GetLinksArgs, GetLinksResult, LinksResult,
 };
 use std::sync::Arc;
+
+// check to see if we are an authority on the DHT for this base, if so no need
+// to go out to request this from anybody else.  We know for sure that we are an authority
+// for anything that is linked on our own agent hash.
+pub fn am_i_dht_authority_for_base<'a>(context: &'a Arc<Context>, base: &Address) -> bool {
+    let me: Address = context.agent_id.address();
+    *base == me
+}
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn get_link_result_workflow<'a>(
@@ -25,32 +35,48 @@ pub async fn get_link_result_workflow<'a>(
         pagination: link_args.options.pagination.clone(),
         sort_order: link_args.options.sort_order.clone(),
     };
-    let method = QueryMethod::Link(link_args.clone(), GetLinksNetworkQuery::Links(config));
-    let response = query(context.clone(), method, link_args.options.timeout.clone()).await?;
-
-    let links_result = match response {
-        NetworkQueryResult::Links(query, _, _) => Ok(query),
-        _ => Err(HolochainError::ErrorGeneric(
-            "Wrong type for response type Entry".to_string(),
-        )),
-    }?;
-
-    match links_result {
-        GetLinksNetworkResult::Links(links) => {
-            let get_links_result = links
-                .into_iter()
-                .map(|get_entry_crud| LinksResult {
-                    address: get_entry_crud.target.clone(),
-                    headers: get_entry_crud.headers.unwrap_or_default(),
-                    status: get_entry_crud.crud_status,
-                    tag: get_entry_crud.tag.clone(),
-                })
-                .collect::<Vec<LinksResult>>();
-
-            Ok(GetLinksResult::new(get_links_result))
+    let method = QueryMethod::Link(
+        link_args.clone(),
+        GetLinksNetworkQuery::Links(config.clone()),
+    );
+    let links = if am_i_dht_authority_for_base(context, &link_args.entry_address) {
+        // get the results from the local DHT
+        let links = get_links(
+            context,
+            link_args.entry_address.clone(),
+            link_args.link_type.clone(),
+            link_args.tag.clone(),
+            crud_status_from_link_args(&link_args),
+            config,
+        )?;
+        links
+    } else {
+        let response = query(context.clone(), method, link_args.options.timeout.clone()).await?;
+        let links_result = match response {
+            NetworkQueryResult::Links(query, _, _) => Ok(query),
+            _ => Err(HolochainError::ErrorGeneric(
+                "Wrong type for response type Entry".to_string(),
+            )),
+        }?;
+        match links_result {
+            GetLinksNetworkResult::Links(links) => links,
+            _ => {
+                return Err(HolochainError::ErrorGeneric(
+                    "Could not get links".to_string(),
+                ))
+            }
         }
-        _ => Err(HolochainError::ErrorGeneric(
-            "Could not get links".to_string(),
-        )),
-    }
+    };
+
+    let get_links_result = links
+        .into_iter()
+        .map(|get_entry_crud| LinksResult {
+            address: get_entry_crud.target.clone(),
+            headers: get_entry_crud.headers.unwrap_or_default(),
+            status: get_entry_crud.crud_status,
+            tag: get_entry_crud.tag.clone(),
+        })
+        .collect::<Vec<LinksResult>>();
+
+    Ok(GetLinksResult::new(get_links_result))
 }

--- a/crates/core/src/workflows/get_link_result.rs
+++ b/crates/core/src/workflows/get_link_result.rs
@@ -15,6 +15,7 @@ use holochain_persistence_api::cas::content::{Address, AddressableContent};
 use holochain_wasm_utils::api_serialization::get_links::{
     GetLinksArgs, GetLinksResult, LinksResult,
 };
+use lib3h_protocol::types::EntryHash;
 use std::sync::Arc;
 
 // check to see if we are an authority on the DHT for this base, if so no need
@@ -22,7 +23,16 @@ use std::sync::Arc;
 // for anything that is linked on our own agent hash.
 pub fn am_i_dht_authority_for_base<'a>(context: &'a Arc<Context>, base: &Address) -> bool {
     let me: Address = context.agent_id.address();
-    *base == me
+    if *base == me {
+        return true;
+    }
+    let state = context
+        .state()
+        .expect("No state present when trying to respond with gossip list");
+    state
+        .dht()
+        .get_holding_map()
+        .contains_entry(&EntryHash::from(base))
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]

--- a/crates/core/src/workflows/hold_entry.rs
+++ b/crates/core/src/workflows/hold_entry.rs
@@ -9,13 +9,13 @@ use holochain_core_types::{
     network::entry_aspect::EntryAspect,
     validation::{EntryLifecycle, ValidationData},
 };
-
 use holochain_persistence_api::cas::content::AddressableContent;
-
+use snowflake::ProcessUniqueId;
 use std::sync::Arc;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn hold_entry_workflow(
+    pending_id: &ProcessUniqueId,
     entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
@@ -70,7 +70,7 @@ pub async fn hold_entry_workflow(
         entry_with_header.entry.clone(),
         entry_with_header.header.clone(),
     );
-    hold_aspect(aspect, context.clone()).await?;
+    hold_aspect(pending_id, aspect, context.clone()).await?;
 
     log_debug!(
         context,

--- a/crates/core/src/workflows/hold_entry_remove.rs
+++ b/crates/core/src/workflows/hold_entry_remove.rs
@@ -10,10 +10,12 @@ use holochain_core_types::{
     validation::{EntryLifecycle, ValidationData},
 };
 use holochain_persistence_api::cas::content::AddressableContent;
+use snowflake::ProcessUniqueId;
 use std::sync::Arc;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn hold_remove_workflow(
+    pending_id: &ProcessUniqueId,
     entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
@@ -54,6 +56,6 @@ pub async fn hold_remove_workflow(
 
     // 4. If valid store the entry aspect in the local DHT shard
     let aspect = EntryAspect::Deletion(entry_with_header.header.clone());
-    hold_aspect(aspect, context.clone()).await?;
+    hold_aspect(pending_id, aspect, context.clone()).await?;
     Ok(())
 }

--- a/crates/core/src/workflows/hold_entry_update.rs
+++ b/crates/core/src/workflows/hold_entry_update.rs
@@ -11,10 +11,12 @@ use holochain_core_types::{
     validation::{EntryLifecycle, ValidationData},
 };
 use holochain_persistence_api::cas::content::AddressableContent;
+use snowflake::ProcessUniqueId;
 use std::sync::Arc;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn hold_update_workflow(
+    pending_id: &ProcessUniqueId,
     entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
@@ -60,7 +62,7 @@ pub async fn hold_update_workflow(
         entry_with_header.entry.clone(),
         entry_with_header.header.clone(),
     );
-    hold_aspect(aspect, context.clone()).await?;
+    hold_aspect(pending_id, aspect, context.clone()).await?;
 
     Ok(())
 }

--- a/crates/core/src/workflows/hold_link.rs
+++ b/crates/core/src/workflows/hold_link.rs
@@ -12,10 +12,12 @@ use holochain_core_types::{
     validation::{EntryLifecycle, ValidationData},
 };
 use holochain_persistence_api::cas::content::AddressableContent;
+use snowflake::ProcessUniqueId;
 use std::sync::Arc;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn hold_link_workflow(
+    pending_id: &ProcessUniqueId,
     entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
@@ -72,12 +74,12 @@ pub async fn hold_link_workflow(
 
     // 3. If valid store the entry aspect in the local DHT shard
     let aspect = EntryAspect::LinkAdd(link_add.clone(), entry_with_header.header.clone());
-    hold_aspect(aspect, context.clone()).await?;
+    hold_aspect(pending_id, aspect, context.clone()).await?;
 
     log_debug!(context, "workflow/hold_link: added! {:?}", link);
 
     //4. store link_add entry so we have all we need to respond to get links queries without any other network look-up
-    hold_entry_workflow(&entry_with_header, context.clone()).await?;
+    hold_entry_workflow(pending_id, &entry_with_header, context.clone()).await?;
     log_debug!(
         context,
         "workflow/hold_entry: added! {:?}",

--- a/crates/core/src/workflows/mod.rs
+++ b/crates/core/src/workflows/mod.rs
@@ -256,19 +256,19 @@ pub async fn run_holding_workflow(
 ) -> Result<(), HolochainError> {
     match pending.workflow {
         ValidatingWorkflow::HoldLink => {
-            hold_link_workflow(&pending.entry_with_header, context.clone()).await
+            hold_link_workflow(&pending.uuid, &pending.entry_with_header, context.clone()).await
         }
         ValidatingWorkflow::HoldEntry => {
-            hold_entry_workflow(&pending.entry_with_header, context.clone()).await
+            hold_entry_workflow(&pending.uuid, &pending.entry_with_header, context.clone()).await
         }
         ValidatingWorkflow::RemoveLink => {
-            remove_link_workflow(&pending.entry_with_header, context.clone()).await
+            remove_link_workflow(&pending.uuid, &pending.entry_with_header, context.clone()).await
         }
         ValidatingWorkflow::UpdateEntry => {
-            hold_update_workflow(&pending.entry_with_header, context.clone()).await
+            hold_update_workflow(&pending.uuid, &pending.entry_with_header, context.clone()).await
         }
         ValidatingWorkflow::RemoveEntry => {
-            hold_remove_workflow(&pending.entry_with_header, context.clone()).await
+            hold_remove_workflow(&pending.uuid, &pending.entry_with_header, context.clone()).await
         }
     }
 }

--- a/crates/core/src/workflows/remove_link.rs
+++ b/crates/core/src/workflows/remove_link.rs
@@ -12,10 +12,12 @@ use holochain_core_types::{
     validation::{EntryLifecycle, ValidationData},
 };
 use holochain_persistence_api::cas::content::AddressableContent;
+use snowflake::ProcessUniqueId;
 use std::sync::Arc;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn remove_link_workflow(
+    pending_id: &ProcessUniqueId,
     entry_with_header: &EntryWithHeader,
     context: Arc<Context>,
 ) -> Result<(), HolochainError> {
@@ -77,11 +79,11 @@ pub async fn remove_link_workflow(
         (link_data.clone(), links_to_remove.clone()),
         entry_with_header.header.clone(),
     );
-    hold_aspect(aspect, context.clone()).await?;
+    hold_aspect(pending_id, aspect, context.clone()).await?;
     log_debug!(context, "workflow/remove_link: added! {:?}", link);
 
     //4. store link_remove entry so we have all we need to respond to get links queries without any other network look-up```
-    hold_entry_workflow(&entry_with_header, context.clone()).await?;
+    hold_entry_workflow(pending_id, &entry_with_header, context.clone()).await?;
     log_debug!(
         context,
         "workflow/hold_entry: added! {:?}",

--- a/crates/net/src/in_memory/memory_server.rs
+++ b/crates/net/src/in_memory/memory_server.rs
@@ -738,10 +738,19 @@ impl InMemoryServer {
 
     /// Received response from our request for the 'holding_list'
     fn priv_serve_HandleGetGossipingEntryListResult(&mut self, msg: &EntryListData) {
-        let chain_id = self
-            .priv_check_request(&msg.request_id)
-            .expect("Not our request")
-            .to_string();
+        let chain_id = {
+            // we are using GossipEntryListResult without a request to confirm
+            // hold aspect requests.
+            if msg.request_id == "" {
+                let agent = msg.provider_agent_id.clone();
+                let space = msg.space_address.clone();
+                into_chain_id(&space.into(), &agent.into())
+            } else {
+                self.priv_check_request(&msg.request_id)
+                    .expect("Not our request")
+                    .to_string()
+            }
+        };
         self.log.d(&format!(
             "---- HandleGetHoldingEntryListResult: chain_id = '{}'",
             chain_id,

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -581,7 +581,8 @@ impl Sim2hWorker {
     /// Tells us if Sim2hWorker should render the local core instance to be self-suficient,
     /// i.e. storing everything locally and answering to queries locally.
     fn is_autonomous_node(&mut self) -> bool {
-        self.is_full_sync_DHT || !self.connection_ready()
+        return true;
+        //        self.is_full_sync_DHT || !self.connection_ready()
     }
 
     #[allow(dead_code)]

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -581,8 +581,8 @@ impl Sim2hWorker {
     /// Tells us if Sim2hWorker should render the local core instance to be self-suficient,
     /// i.e. storing everything locally and answering to queries locally.
     fn is_autonomous_node(&mut self) -> bool {
-        return true;
-        //        self.is_full_sync_DHT || !self.connection_ready()
+        //return true;
+        self.is_full_sync_DHT || !self.connection_ready()
     }
 
     #[allow(dead_code)]

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -581,8 +581,8 @@ impl Sim2hWorker {
     /// Tells us if Sim2hWorker should render the local core instance to be self-suficient,
     /// i.e. storing everything locally and answering to queries locally.
     fn is_autonomous_node(&mut self) -> bool {
-        return true;
-        //self.is_full_sync_DHT || !self.connection_ready()
+        //return true;
+        self.is_full_sync_DHT || !self.connection_ready()
     }
 
     #[allow(dead_code)]

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -581,8 +581,8 @@ impl Sim2hWorker {
     /// Tells us if Sim2hWorker should render the local core instance to be self-suficient,
     /// i.e. storing everything locally and answering to queries locally.
     fn is_autonomous_node(&mut self) -> bool {
-        //return true;
-        self.is_full_sync_DHT || !self.connection_ready()
+        return true;
+        //self.is_full_sync_DHT || !self.connection_ready()
     }
 
     #[allow(dead_code)]

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -957,7 +957,7 @@ fn spawn_handle_message_fetch_entry_result(
                 }
             }
 
-            for (agent_id, (multi_message, mut holding)) in to_agent.drain() {
+            for (agent_id, (multi_message, mut _holding)) in to_agent.drain() {
                 let uri = match state.lookup_joined(&space_hash, &agent_id) {
                     None => continue,
                     Some(uri) => uri,
@@ -967,6 +967,7 @@ fn spawn_handle_message_fetch_entry_result(
 
                 sim2h_handle.send((&*agent_id).clone(), (&*uri).clone(), &multi_send);
 
+                /* Conductor currently has some
                 for (entry_hash, aspects) in holding.drain() {
                     sim2h_handle.state().spawn_agent_holds_aspects(
                         (&*space_hash).clone(),
@@ -974,7 +975,7 @@ fn spawn_handle_message_fetch_entry_result(
                         entry_hash,
                         aspects,
                     );
-                }
+                }*/
             }
         }
         .instrument(debug_span!("spawn_handle_message_fetch_entry_result")),

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -926,10 +926,10 @@ fn spawn_handle_message_fetch_entry_result(
             #[allow(clippy::type_complexity)]
             let mut to_agent: std::collections::HashMap<
                 MonoRef<AgentId>,
-                (
-                    Vec<ht::EncodedSpanWrap<Lib3hToClient>>,
-                    std::collections::HashMap<EntryHash, im::HashSet<AspectHash>>,
-                ),
+                //(
+                Vec<ht::EncodedSpanWrap<Lib3hToClient>>,
+                //   std::collections::HashMap<EntryHash, im::HashSet<AspectHash>>,
+                //),
             > = std::collections::HashMap::new();
 
             for aspect in fetch_result.entry.aspect_list {
@@ -948,16 +948,16 @@ fn spawn_handle_message_fetch_entry_result(
                         entry_address: fetch_result.entry.entry_address.clone(),
                         entry_aspect: aspect.clone(),
                     });
-                    m.0.push(ht::span_wrap_encode!(Level::INFO, data).into());
+                    m./*0.*/push(ht::span_wrap_encode!(Level::INFO, data).into());
 
-                    let e =
+                    /*let e =
                         m.1.entry(fetch_result.entry.entry_address.clone())
                             .or_default();
-                    e.insert(aspect.aspect_address.clone());
+                    e.insert(aspect.aspect_address.clone());*/
                 }
             }
 
-            for (agent_id, (multi_message, mut _holding)) in to_agent.drain() {
+            for (agent_id, /*(*/ multi_message /*, mut holding)*/) in to_agent.drain() {
                 let uri = match state.lookup_joined(&space_hash, &agent_id) {
                     None => continue,
                     Some(uri) => uri,
@@ -967,7 +967,9 @@ fn spawn_handle_message_fetch_entry_result(
 
                 sim2h_handle.send((&*agent_id).clone(), (&*uri).clone(), &multi_send);
 
-                /* Conductor currently has some
+                /* Conductor may not actually hold when told because of a consistency error so
+                   we can't mark this as held.  Conductor will send back a partial gossip list
+                   after a hold request to tell us that it's held the aspects.
                 for (entry_hash, aspects) in holding.drain() {
                     sim2h_handle.state().spawn_agent_holds_aspects(
                         (&*space_hash).clone(),
@@ -975,7 +977,8 @@ fn spawn_handle_message_fetch_entry_result(
                         entry_hash,
                         aspects,
                     );
-                }*/
+                }
+                 */
             }
         }
         .instrument(debug_span!("spawn_handle_message_fetch_entry_result")),

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -766,12 +766,12 @@ fn spawn_handle_message_publish_entry(
     }
 
     tokio::task::spawn(async move {
-        let aspect_list: im::HashSet<AspectHash> = data
-            .entry
-            .aspect_list
-            .iter()
-            .map(|a| a.aspect_address.clone())
-            .collect();
+        /*        let aspect_list: im::HashSet<AspectHash> = data
+        .entry
+        .aspect_list
+        .iter()
+        .map(|a| a.aspect_address.clone())
+        .collect();*/
         let mut multi_message = Vec::new();
         for aspect in data.entry.aspect_list {
             let data = Lib3hToClient::HandleStoreEntryAspect(StoreEntryAspectData {
@@ -801,12 +801,13 @@ fn spawn_handle_message_publish_entry(
             if let Some(uri) = state.lookup_joined(&space_hash, &agent_id) {
                 sim2h_handle.send((&*agent_id).clone(), uri.clone(), &multi_message);
             }
+            /* send not guaranteed to work so we can't mark as held.
             sim2h_handle.state().spawn_agent_holds_aspects(
                 (&*space_hash).clone(),
                 (&*agent_id).clone(),
                 data.entry.entry_address.clone(),
                 aspect_list.clone(),
-            );
+            );*/
         }
     });
 }

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -926,10 +926,10 @@ fn spawn_handle_message_fetch_entry_result(
             #[allow(clippy::type_complexity)]
             let mut to_agent: std::collections::HashMap<
                 MonoRef<AgentId>,
-                //(
-                Vec<ht::EncodedSpanWrap<Lib3hToClient>>,
-                //   std::collections::HashMap<EntryHash, im::HashSet<AspectHash>>,
-                //),
+                (
+                    Vec<ht::EncodedSpanWrap<Lib3hToClient>>,
+                    std::collections::HashMap<EntryHash, im::HashSet<AspectHash>>,
+                ),
             > = std::collections::HashMap::new();
 
             for aspect in fetch_result.entry.aspect_list {
@@ -948,16 +948,16 @@ fn spawn_handle_message_fetch_entry_result(
                         entry_address: fetch_result.entry.entry_address.clone(),
                         entry_aspect: aspect.clone(),
                     });
-                    m./*0.*/push(ht::span_wrap_encode!(Level::INFO, data).into());
+                    m.0.push(ht::span_wrap_encode!(Level::INFO, data).into());
 
-                    /*let e =
+                    let e =
                         m.1.entry(fetch_result.entry.entry_address.clone())
                             .or_default();
-                    e.insert(aspect.aspect_address.clone());*/
+                    e.insert(aspect.aspect_address.clone());
                 }
             }
 
-            for (agent_id, /*(*/ multi_message /*, mut holding)*/) in to_agent.drain() {
+            for (agent_id, (multi_message, mut _holding)) in to_agent.drain() {
                 let uri = match state.lookup_joined(&space_hash, &agent_id) {
                     None => continue,
                     Some(uri) => uri,
@@ -967,9 +967,7 @@ fn spawn_handle_message_fetch_entry_result(
 
                 sim2h_handle.send((&*agent_id).clone(), (&*uri).clone(), &multi_send);
 
-                /* Conductor may not actually hold when told because of a consistency error so
-                   we can't mark this as held.  Conductor will send back a partial gossip list
-                   after a hold request to tell us that it's held the aspects.
+                /* Conductor currently has some
                 for (entry_hash, aspects) in holding.drain() {
                     sim2h_handle.state().spawn_agent_holds_aspects(
                         (&*space_hash).clone(),
@@ -977,8 +975,7 @@ fn spawn_handle_message_fetch_entry_result(
                         entry_hash,
                         aspects,
                     );
-                }
-                 */
+                }*/
             }
         }
         .instrument(debug_span!("spawn_handle_message_fetch_entry_result")),

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -640,6 +640,6 @@ pub fn assert_zome_internal_errors_equivalent(left: &ZomeApiError, right: &ZomeA
 
 fn internal_error_substr<'a>(error_string: &'a str) -> Option<&'a str> {
     error_string
-        .find(r#""line":"#)
+        .find(r#":"#)
         .map(|idx| &error_string[0..idx])
 }


### PR DESCRIPTION
## PR summary

This PR adds:

- [x] an optimization of not querying the DHT for get links requests when we know that we are the DHT authority for the base of the query.
- [x] two conductor fixes during error cases (like base hasn't arrived yet) in hold_aspects request:
    - stop incorrectly recording aspects as held
    - stop locking up the future
- [x] because sim2h doesn't get error messages from a hold_aspect request it must also no longer records aspects sent in those messages as held, and thus the conductor must explicitly send back a list of aspects held after a hold_aspect request
- [x] get authoring list doesn't really work because correct items won't be gossiped and the optimization now breaks this.  Fix this by not responding with the list, and instead re-publishing.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
