### PR TITLE
Get links on agent id locally

### DIFF
--- a/crates/core/src/network/actions/query.rs
+++ b/crates/core/src/network/actions/query.rs
@@ -28,6 +28,14 @@ pub enum QueryMethod {
     Link(GetLinksArgs, GetLinksNetworkQuery),
 }
 
+pub fn crud_status_from_link_args(link_args: &GetLinksArgs) -> Option<CrudStatus> {
+    match link_args.options.status_request {
+        LinksStatusRequestKind::All => None,
+        LinksStatusRequestKind::Deleted => Some(CrudStatus::Deleted),
+        LinksStatusRequestKind::Live => Some(CrudStatus::Live),
+    }
+}
+
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn query(
     context: Arc<Context>,
@@ -49,11 +57,7 @@ pub async fn query(
                 tag: link_args.tag.clone(),
                 id: nanoid::simple(),
             };
-            let crud_status = match link_args.options.status_request {
-                LinksStatusRequestKind::All => None,
-                LinksStatusRequestKind::Deleted => Some(CrudStatus::Deleted),
-                LinksStatusRequestKind::Live => Some(CrudStatus::Live),
-            };
+            let crud_status = crud_status_from_link_args(&link_args);
             (
                 QueryKey::Links(key),
                 QueryPayload::Links((crud_status, query)),

--- a/crates/core/src/network/handler/query.rs
+++ b/crates/core/src/network/handler/query.rs
@@ -26,7 +26,7 @@ use std::{convert::TryInto, sync::Arc};
 
 pub type LinkTag = String;
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
-fn get_links(
+pub fn get_links(
     context: &Arc<Context>,
     base: Address,
     link_type: Option<String>,

--- a/crates/core/src/network/reducers/query.rs
+++ b/crates/core/src/network/reducers/query.rs
@@ -80,7 +80,8 @@ pub fn reduce_query_timeout(
         network_state.get_query_results.insert(
             key.clone(),
             Some(Err(HolochainError::Timeout(format!(
-                "timeout src: {}:{}",
+                "key: {:?}, timeout src: {}:{}",
+                key,
                 file!(),
                 line!()
             )))),

--- a/crates/core/src/workflows/get_link_result.rs
+++ b/crates/core/src/workflows/get_link_result.rs
@@ -1,7 +1,8 @@
 use crate::{
     context::Context,
     network::{
-        actions::query::{query, QueryMethod},
+        actions::query::{crud_status_from_link_args, query, QueryMethod},
+        handler::query::get_links,
         query::{
             GetLinksNetworkQuery, GetLinksNetworkResult, GetLinksQueryConfiguration,
             NetworkQueryResult,
@@ -10,10 +11,19 @@ use crate::{
 };
 
 use holochain_core_types::error::HolochainError;
+use holochain_persistence_api::cas::content::{Address, AddressableContent};
 use holochain_wasm_utils::api_serialization::get_links::{
     GetLinksArgs, GetLinksResult, LinksResult,
 };
 use std::sync::Arc;
+
+// check to see if we are an authority on the DHT for this base, if so no need
+// to go out to request this from anybody else.  We know for sure that we are an authority
+// for anything that is linked on our own agent hash.
+pub fn am_i_dht_authority_for_base<'a>(context: &'a Arc<Context>, base: &Address) -> bool {
+    let me: Address = context.agent_id.address();
+    *base == me
+}
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn get_link_result_workflow<'a>(
@@ -25,32 +35,48 @@ pub async fn get_link_result_workflow<'a>(
         pagination: link_args.options.pagination.clone(),
         sort_order: link_args.options.sort_order.clone(),
     };
-    let method = QueryMethod::Link(link_args.clone(), GetLinksNetworkQuery::Links(config));
-    let response = query(context.clone(), method, link_args.options.timeout.clone()).await?;
-
-    let links_result = match response {
-        NetworkQueryResult::Links(query, _, _) => Ok(query),
-        _ => Err(HolochainError::ErrorGeneric(
-            "Wrong type for response type Entry".to_string(),
-        )),
-    }?;
-
-    match links_result {
-        GetLinksNetworkResult::Links(links) => {
-            let get_links_result = links
-                .into_iter()
-                .map(|get_entry_crud| LinksResult {
-                    address: get_entry_crud.target.clone(),
-                    headers: get_entry_crud.headers.unwrap_or_default(),
-                    status: get_entry_crud.crud_status,
-                    tag: get_entry_crud.tag.clone(),
-                })
-                .collect::<Vec<LinksResult>>();
-
-            Ok(GetLinksResult::new(get_links_result))
+    let method = QueryMethod::Link(
+        link_args.clone(),
+        GetLinksNetworkQuery::Links(config.clone()),
+    );
+    let links = if am_i_dht_authority_for_base(context, &link_args.entry_address) {
+        // get the results from the local DHT
+        let links = get_links(
+            context,
+            link_args.entry_address.clone(),
+            link_args.link_type.clone(),
+            link_args.tag.clone(),
+            crud_status_from_link_args(&link_args),
+            config,
+        )?;
+        links
+    } else {
+        let response = query(context.clone(), method, link_args.options.timeout.clone()).await?;
+        let links_result = match response {
+            NetworkQueryResult::Links(query, _, _) => Ok(query),
+            _ => Err(HolochainError::ErrorGeneric(
+                "Wrong type for response type Entry".to_string(),
+            )),
+        }?;
+        match links_result {
+            GetLinksNetworkResult::Links(links) => links,
+            _ => {
+                return Err(HolochainError::ErrorGeneric(
+                    "Could not get links".to_string(),
+                ))
+            }
         }
-        _ => Err(HolochainError::ErrorGeneric(
-            "Could not get links".to_string(),
-        )),
-    }
+    };
+
+    let get_links_result = links
+        .into_iter()
+        .map(|get_entry_crud| LinksResult {
+            address: get_entry_crud.target.clone(),
+            headers: get_entry_crud.headers.unwrap_or_default(),
+            status: get_entry_crud.crud_status,
+            tag: get_entry_crud.tag.clone(),
+        })
+        .collect::<Vec<LinksResult>>();
+
+    Ok(GetLinksResult::new(get_links_result))
 }


### PR DESCRIPTION
## PR summary

This PR adds:

- [x] an optimization of not querying the DHT for get links requests that are placed on a node's own agent id because we must be responsible for holding that part of the DHT.

Note this does not include the optimization for not querying for other links that we are currently holding because sim2h currently does not tell us to stop holding things as neighborhoods change so we always need to check the dht for other links lest what we are holding be out-of-date.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
