### PR TITLE
add options to dump so eavi data can be dumped optionally

### DIFF
--- a/crates/conductor_lib/src/conductor/debug.rs
+++ b/crates/conductor_lib/src/conductor/debug.rs
@@ -1,11 +1,15 @@
 use crate::conductor::Conductor;
-use holochain_core::state_dump::StateDump;
+use holochain_core::state_dump::{DumpOptions, StateDump};
 use holochain_core_types::error::HolochainError;
 use holochain_persistence_api::cas::content::Address;
 
 pub trait ConductorDebug {
     fn running_instances(&self) -> Result<Vec<String>, HolochainError>;
-    fn state_dump_for_instance(&self, instance_id: &String) -> Result<StateDump, HolochainError>;
+    fn state_dump_for_instance(
+        &self,
+        instance_id: &String,
+        options: DumpOptions,
+    ) -> Result<StateDump, HolochainError>;
     fn get_type_and_content_from_cas(
         &self,
         address: &Address,
@@ -19,9 +23,13 @@ impl ConductorDebug for Conductor {
         Ok(self.instances.keys().cloned().collect())
     }
 
-    fn state_dump_for_instance(&self, instance_id: &String) -> Result<StateDump, HolochainError> {
+    fn state_dump_for_instance(
+        &self,
+        instance_id: &String,
+        options: DumpOptions,
+    ) -> Result<StateDump, HolochainError> {
         let hc = self.instances.get(instance_id)?;
-        Ok(hc.read().unwrap().get_state_dump()?)
+        Ok(hc.read().unwrap().get_state_dump(options)?)
     }
 
     fn get_type_and_content_from_cas(

--- a/crates/conductor_lib/src/holochain.rs
+++ b/crates/conductor_lib/src/holochain.rs
@@ -108,7 +108,7 @@ use holochain_json_api::json::JsonString;
 
 use holochain_core::{
     state::StateWrapper,
-    state_dump::{address_to_content_and_type, StateDump},
+    state_dump::{address_to_content_and_type, DumpOptions, StateDump},
 };
 use holochain_persistence_api::cas::content::Address;
 use jsonrpc_core::IoHandler;
@@ -289,11 +289,17 @@ impl Holochain {
         Ok(())
     }
 
-    pub fn get_state_dump(&self) -> Result<StateDump, HolochainInstanceError> {
+    pub fn get_state_dump(
+        &self,
+        options: DumpOptions,
+    ) -> Result<StateDump, HolochainInstanceError> {
         self.check_instance()?;
-        Ok(StateDump::from(self.context.clone().expect(
-            "Context must be Some since we've checked it with check_instance()? above",
-        )))
+        Ok(StateDump::new(
+            self.context
+                .clone()
+                .expect("Context must be Some since we've checked it with check_instance()? above"),
+            options,
+        ))
     }
 
     pub fn get_type_and_content_from_cas(

--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -1,7 +1,9 @@
 use crate::{conductor::broadcaster::Broadcaster, holo_signing_service::request_service};
 use base64;
 use crossbeam_channel::Receiver;
-use holochain_core::nucleus::actions::call_zome_function::make_cap_request_for_call;
+use holochain_core::{
+    nucleus::actions::call_zome_function::make_cap_request_for_call, state_dump::DumpOptions,
+};
 
 use crate::Holochain;
 use holochain_core_types::{
@@ -789,7 +791,12 @@ impl ConductorApiBuilder {
             let params_map = Self::unwrap_params_map(params)?;
             let instance_id = Self::get_as_string("instance_id", &params_map)?;
 
-            let mut dump = conductor_call!(|c| c.state_dump_for_instance(&instance_id))?;
+            let mut dump = conductor_call!(|c| c.state_dump_for_instance(
+                &instance_id,
+                DumpOptions {
+                    include_eavis: false
+                }
+            ))?;
 
             if Ok(false) == Self::get_as_bool("source_chain", &params_map) {
                 dump.source_chain.clear()

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -11,6 +11,7 @@ use crate::{
     scheduled_jobs,
     signal::Signal,
     state::{State, StateWrapper},
+    state_dump::DumpOptions,
     workflows::{application, run_holding_workflow},
 };
 #[cfg(test)]
@@ -84,7 +85,12 @@ impl Instance {
         let mut scheduler = Scheduler::new();
         scheduler
             .every(10.seconds())
-            .run(scheduled_jobs::create_state_dump_callback(context.clone()));
+            .run(scheduled_jobs::create_state_dump_callback(
+                context.clone(),
+                DumpOptions {
+                    include_eavis: false,
+                },
+            ));
         scheduler
             .every(1.second())
             .run(scheduled_jobs::create_timeout_callback(context.clone()));

--- a/crates/core/src/scheduled_jobs/mod.rs
+++ b/crates/core/src/scheduled_jobs/mod.rs
@@ -5,14 +5,18 @@ use crate::{
     action::{Action, ActionWrapper},
     context::Context,
     instance::dispatch_action,
+    state_dump::DumpOptions,
 };
 use std::sync::Arc;
 
-pub fn create_state_dump_callback(context: Arc<Context>) -> impl 'static + FnMut() + Sync + Send {
+pub fn create_state_dump_callback(
+    context: Arc<Context>,
+    options: DumpOptions,
+) -> impl 'static + FnMut() + Sync + Send {
     move || {
         //log_debug!(context, "scheduled_jobs: tick");
         if context.state_dump_logging {
-            state_dump::state_dump(context.clone());
+            state_dump::state_dump(context.clone(), options.clone());
         }
     }
 }

--- a/crates/core/src/scheduled_jobs/state_dump.rs
+++ b/crates/core/src/scheduled_jobs/state_dump.rs
@@ -1,7 +1,7 @@
 use crate::{
     context::Context,
     dht::pending_validations::PendingValidationWithTimeout,
-    state_dump::{address_to_content_and_type, StateDump},
+    state_dump::{address_to_content_and_type, DumpOptions, StateDump},
 };
 use holochain_core_types::chain_header::ChainHeader;
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
@@ -46,8 +46,8 @@ fn address_to_content_string(address: &Address, context: Arc<Context>) -> String
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
-pub fn state_dump(context: Arc<Context>) {
-    let dump = StateDump::from(context.clone());
+pub fn state_dump(context: Arc<Context>, options: DumpOptions) {
+    let dump = StateDump::new(context.clone(), options);
 
     let queued_holding_workflows_strings = dump
         .queued_holding_workflows


### PR DESCRIPTION
## PR summary

makes dumping of eavi data optional an limits doing so to holochain -d and -r commands (i.e. not to live state-dumps in debug log or when requested over the admin websocket).

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
