### PR TITLE
Validation timeout fixes

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -22,5 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixes sending of already timed-out direct messages on sim2h reconnect bug [2196](https://github.com/holochain/holochain-rust/pull/2196)
 - Fixes incorrect regeneration of remove link aspects from eavi.  [2196](https://github.com/holochain/holochain-rust/pull/2196)
 - Validation no longer unnecessarily run twice when holding an add_link or a remove_link
+- Increases timeout getting headers when building a validation package from the dht (1 second isn't enough) [#2199](https://github.com/holochain/holochain-rust/pull/2199)
+- Pending items were being de-queued when processing, which meant that if another request arrived from sim2h (which could happen often under some circumstances), then the same item would be queued multiple times, which could snowball.  The solution was to move in-process items to another queue for checking. [#2199](https://github.com/holochain/holochain-rust/pull/2199)
+- Fixed DHT queries for ChainHeader entries which were failing because there are no headers for headers stored in the DHT which the code was expecting. [#2199](https://github.com/holochain/holochain-rust/pull/2199)
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ dependencies = [
  "holochain_persistence_api 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_tracing 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_tracing_macros 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "holochain_wasm_utils 0.0.49-alpha1",
  "im 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lib3h_protocol 0.0.42 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/conductor_lib/src/holochain.rs
+++ b/crates/conductor_lib/src/holochain.rs
@@ -63,20 +63,20 @@
 //!
 //! // The conductor API, together with the storage and the agent ID
 //! // constitute the instance's context:
-//! let context = ContextBuilder::new()
+//! let context = Arc::new(ContextBuilder::new()
 //!     .with_agent(agent)
 //!     .with_conductor_api(conductor_api)
 //!     .with_file_storage(storage_directory_path)
 //!     .expect("Tempdir should be accessible")
-//!     .spawn();
+//!     .spawn());
 //!
-//! let mut hc = Holochain::new(dna,Arc::new(context)).unwrap();
+//! let mut hc = Holochain::new(dna, context.clone()).unwrap();
 //!
 //! // start up the holochain instance
 //! hc.start().expect("couldn't start the holochain instance");
 //!
 //! // call a function in the zome code
-//! hc.call_zome_function("test_zome", CapabilityRequest::new(Address::from("some_token"), Address::from("caller"), Signature::fake()), "some_fn", "{}");
+//! // Holochain::call_zome_function(context, "test_zome", CapabilityRequest::new(Address::from("some_token"), Address::from("caller"), Signature::fake()), "some_fn", "{}");
 //!
 //! // get the state
 //! {

--- a/crates/core/src/action.rs
+++ b/crates/core/src/action.rs
@@ -1,6 +1,9 @@
 use crate::{
     agent::state::AgentState,
-    dht::{dht_store::HoldAspectAttemptId, pending_validations::PendingValidation},
+    dht::{
+        actions::remove_queued_holding_workflow::HoldingWorkflowQueueing,
+        dht_store::HoldAspectAttemptId, pending_validations::PendingValidation,
+    },
     network::{
         direct_message::DirectMessage,
         entry_aspect::EntryAspect,
@@ -116,7 +119,7 @@ pub enum Action {
     QueueHoldingWorkflow((PendingValidation, Option<(SystemTime, Duration)>)),
 
     /// Removes the given item from the holding queue.
-    RemoveQueuedHoldingWorkflow(PendingValidation),
+    RemoveQueuedHoldingWorkflow((HoldingWorkflowQueueing, PendingValidation)),
 
     /// Adds an entry aspect to the local DHT shard.
     /// Does not validate, assumes referenced entry is valid.

--- a/crates/core/src/dht/actions/queue_holding_workflow.rs
+++ b/crates/core/src/dht/actions/queue_holding_workflow.rs
@@ -24,6 +24,7 @@ pub fn dispatch_queue_holding_workflow(
     dispatch_action(context.action_channel(), action_wrapper);
 }
 
+/*
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 pub async fn queue_holding_workflow(
     pending: PendingValidation,
@@ -52,7 +53,7 @@ pub async fn queue_holding_workflow(
             pending
         );
     }
-}
+}*/
 
 pub struct QueueHoldingWorkflowFuture {
     context: Arc<Context>,

--- a/crates/core/src/dht/actions/remove_queued_holding_workflow.rs
+++ b/crates/core/src/dht/actions/remove_queued_holding_workflow.rs
@@ -8,6 +8,11 @@ use futures::{future::Future, task::Poll};
 use snowflake::ProcessUniqueId;
 use std::{pin::Pin, sync::Arc, time::Duration};
 
+// This enum is used to specify what to do with the item
+// Processing moves it to the in_process queue
+// waiting moves it back from the in_process queue to the holding queue
+// and Done removes it from the in_process queue entirely.
+// this is implemented in dht_reducers.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum HoldingWorkflowQueueing {
     Processing,

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -202,6 +202,9 @@ pub fn reduce_queue_holding_workflow(
         if old_store.has_same_queued_holding_worfkow(pending) {
             warn!("Tried to add pending validation to queue which is already queued!");
             None
+        } else if old_store.has_same_in_process_holding_worfkow(pending) {
+            warn!("Tried to add pending validation to queue which is already in process!");
+            None
         } else {
             let mut new_store = (*old_store).clone();
             new_store
@@ -246,12 +249,9 @@ pub fn reduce_remove_queued_holding_workflow(
     action_wrapper: &ActionWrapper,
 ) -> Option<DhtStore> {
     let action = action_wrapper.action();
-    let pending = unwrap_to!(action => Action::RemoveQueuedHoldingWorkflow);
+    let (state, pending) = unwrap_to!(action => Action::RemoveQueuedHoldingWorkflow);
     let mut new_store = (*old_store).clone();
-    if let None = new_store.remove_holding_workflow(pending) {
-        error!("Got Action::PopNextHoldingWorkflow on an empty holding queue!");
-    }
-
+    new_store.update_queued_holding_workflow(state, pending);
     Some(new_store)
 }
 

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -262,6 +262,7 @@ pub mod tests {
         action::{Action, ActionWrapper},
         content_store::{AddContent, GetContent},
         dht::{
+            actions::remove_queued_holding_workflow::HoldingWorkflowQueueing,
             dht_reducers::{
                 reduce, reduce_hold_aspect, reduce_queue_holding_workflow,
                 reduce_remove_queued_holding_workflow,
@@ -640,7 +641,15 @@ pub mod tests {
         assert!(store.has_exact_queued_holding_workflow(&hold_link));
 
         // the link won't validate while the entry is pending so we have to remove it
-        let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow(hold.clone()));
+        let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow((
+            HoldingWorkflowQueueing::Processing,
+            hold.clone(),
+        )));
+        let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
+        let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow((
+            HoldingWorkflowQueueing::Done,
+            hold.clone(),
+        )));
         let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
 
         let (next_pending, _) = store.next_queued_holding_workflow().unwrap();
@@ -659,7 +668,15 @@ pub mod tests {
         assert!(store.has_exact_queued_holding_workflow(&update));
         assert!(store.has_exact_queued_holding_workflow(&hold_link));
 
-        let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow(hold_link.clone()));
+        let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow((
+            HoldingWorkflowQueueing::Processing,
+            hold_link.clone(),
+        )));
+        let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
+        let action = ActionWrapper::new(Action::RemoveQueuedHoldingWorkflow((
+            HoldingWorkflowQueueing::Done,
+            hold_link.clone(),
+        )));
         let store = reduce_remove_queued_holding_workflow(&store, &action).unwrap();
 
         assert_eq!(store.queued_holding_workflows().len(), 1);

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -393,8 +393,7 @@ impl DhtStore {
             |PendingValidationWithTimeout {
                  pending: current, ..
              }| {
-                current.entry_with_header.header.entry_address()
-                    == pending.entry_with_header.header.entry_address()
+                current.entry_with_header.header == pending.entry_with_header.header
                     && current.workflow == pending.workflow
             },
         )
@@ -405,8 +404,7 @@ impl DhtStore {
             |PendingValidationWithTimeout {
                  pending: current, ..
              }| {
-                current.entry_with_header.header.entry_address()
-                    == pending.entry_with_header.header.entry_address()
+                current.entry_with_header.header == pending.entry_with_header.header
                     && current.workflow == pending.workflow
             },
         )

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -440,9 +440,8 @@ impl DhtStore {
                         );
                     }
                     Some(pending) => {
-                        let mut pending = pending.clone();
-                        pending.timeout =
-                            Some(ValidationTimeout::new(SystemTime::now(), delay.clone()));
+                        let mut pending = pending;
+                        pending.timeout = Some(ValidationTimeout::new(SystemTime::now(), *delay));
                         self.queued_holding_workflows.push_back(pending);
                     }
                 }

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -290,7 +290,7 @@ impl DhtStore {
             &header.address(),
         )?;
         self.add(header)?;
-        self.meta_storage.write().unwrap().add_eavi(&eavi)?;
+        self.add_eavi(&eavi)?;
         Ok(())
     }
 

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -41,7 +41,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(500);
+pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(15000);
 pub const RETRY_VALIDATION_DURATION_MAX: Duration = Duration::from_secs(60 * 60);
 
 pub enum WakerRequest {
@@ -413,7 +413,7 @@ impl Instance {
                             break;
                         }
                     }
-                    std::thread::sleep(Duration::from_millis(10));
+                    std::thread::sleep(Duration::from_millis(50));
                 }
             })
             .expect("Could not spawn holding thread");

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -41,8 +41,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-pub const RECV_DEFAULT_TIMEOUT_MS: Duration = Duration::from_millis(10000);
-
 pub const RETRY_VALIDATION_DURATION_MIN: Duration = Duration::from_millis(500);
 pub const RETRY_VALIDATION_DURATION_MAX: Duration = Duration::from_secs(60 * 60);
 

--- a/crates/core/src/network/reducers/send_direct_message.rs
+++ b/crates/core/src/network/reducers/send_direct_message.rs
@@ -54,7 +54,7 @@ pub fn reduce_send_direct_message(
             .insert(dm_data.msg_id.clone(), timeout.clone());
     }
     if let Err(error) = inner(network_state, dm_data) {
-        println!("err/net: Error sending direct message: {:?}", error);
+        error!("err/net: Error sending direct message: {:?}", error);
     }
 }
 

--- a/crates/core/src/nucleus/actions/call_zome_function.rs
+++ b/crates/core/src/nucleus/actions/call_zome_function.rs
@@ -302,7 +302,10 @@ pub fn spawn_zome_function(context: Arc<Context>, zome_call: ZomeFnCall) {
             let elapsed = Instant::now().duration_since(start);
             log_debug!(
                 context,
-                "actions/call_zome_fn: {:?}\nreturned:  {:?}\nafter {:?}", zome_call, call_result, elapsed
+                "actions/call_zome_fn: {:?}\nreturned:  {:?}\nafter {:?}",
+                zome_call,
+                call_result,
+                elapsed
             );
             // Construct response
             let response = ExecuteZomeFnResponse::new(zome_call.clone(), call_result);

--- a/crates/core/src/nucleus/validation/build_from_dht.rs
+++ b/crates/core/src/nucleus/validation/build_from_dht.rs
@@ -12,7 +12,7 @@ use holochain_core_types::{
 
 use std::sync::Arc;
 
-const GET_TIMEOUT_MS: usize = 1000;
+const GET_TIMEOUT_MS: usize = 10000;
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 async fn all_chain_headers_before_header_dht(

--- a/crates/core/src/scheduled_jobs/state_dump.rs
+++ b/crates/core/src/scheduled_jobs/state_dump.rs
@@ -67,6 +67,24 @@ pub fn state_dump(context: Arc<Context>, options: DumpOptions) {
         })
         .collect::<Vec<String>>();
 
+    let in_process_holding_workflows_strings = dump
+        .in_process_holding_workflows
+        .iter()
+        .map(|PendingValidationWithTimeout { pending, .. }| {
+            format!(
+                "<{}({})> {}: depends on : {:?}",
+                pending.workflow.to_string(),
+                pending.entry_with_header.header.entry_type(),
+                pending.entry_with_header.entry.address(),
+                pending
+                    .dependencies
+                    .iter()
+                    .map(|addr| addr.to_string())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect::<Vec<String>>();
+
     let holding_strings = dump
         .held_aspects
         .iter()
@@ -123,6 +141,9 @@ Dht:
 ====
 Queued validations:
 {queued_holding_workflows_strings}
+
+In-process validations:
+{in_process_holding_workflows_strings}
 --------
 Holding:
 {holding_list}
@@ -133,6 +154,7 @@ Holding:
         call_results = dump.call_results,
         calls = dump.running_calls,
         queued_holding_workflows_strings = queued_holding_workflows_strings.join("\n"),
+        in_process_holding_workflows_strings = in_process_holding_workflows_strings.join("\n"),
         flows = dump.query_flows,
         validation_packages = dump.validation_package_flows,
         direct_messages = dump.direct_message_flows,

--- a/crates/core/src/state_dump.rs
+++ b/crates/core/src/state_dump.rs
@@ -28,6 +28,7 @@ pub struct StateDump {
     pub validation_package_flows: Vec<Address>,
     pub direct_message_flows: Vec<(String, DirectMessage)>,
     pub queued_holding_workflows: VecDeque<PendingValidationWithTimeout>,
+    pub in_process_holding_workflows: VecDeque<PendingValidationWithTimeout>,
     pub held_aspects: AspectMapBare,
     pub source_chain: Vec<(EntryWithHeader, Address)>,
     pub eavis: Option<Vec<EntityAttributeValueIndex>>,
@@ -108,6 +109,7 @@ impl StateDump {
             .collect();
 
         let queued_holding_workflows = dht.queued_holding_workflows().clone();
+        let in_process_holding_workflows = dht.in_process_holding_workflows().clone();
 
         let held_aspects = dht.get_holding_map().bare().clone();
 
@@ -138,6 +140,7 @@ impl StateDump {
             validation_package_flows,
             direct_message_flows,
             queued_holding_workflows,
+            in_process_holding_workflows,
             held_aspects,
             source_chain,
             eavis: maybe_eavis,

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -13,6 +13,7 @@ holochain_persistence_api = "=0.0.18"
 holochain_core = { version = "=0.0.49-alpha1", path = "../core" }
 holochain_core_types = { version = "=0.0.49-alpha1", path = "../core_types" }
 holochain_conductor_lib = { version = "=0.0.49-alpha1", path = "../conductor_lib" }
+holochain_wasm_utils = { version = "=0.0.49-alpha1", path = "../wasm_utils" }
 lib3h_sodium = "=0.0.42"
 lib3h_protocol = "=0.0.42"
 holochain_common = { version = "=0.0.49-alpha1", path = "../common" }

--- a/crates/holochain/src/main.rs
+++ b/crates/holochain/src/main.rs
@@ -247,7 +247,7 @@ fn main() {
                     );
                     shell.new_command(
                         "get_links",
-                        "make a get_links call on an instance dht",
+                        "make a get_links call on an instance dht: ",
                         2,
                         |io, conductor, args| {
                             let instance = args[0];
@@ -258,7 +258,6 @@ fn main() {
                                 } else {
                                     None
                                 };
-                                //                                let tag: LinkMatch<&str>,
                                 let mut options = GetLinksOptions::default();
                                 options.status_request = LinksStatusRequestKind::All;
                                 options.headers = true;
@@ -271,8 +270,9 @@ fn main() {
                                 };
                                 let context = hc.read().unwrap().context()?;
                                 let result =
-                                    context.block_on(get_link_result_workflow(&context, &args));
-                                writeln!(io, "get_links result: {:?}", result)?;
+                                    context.block_on(get_link_result_workflow(&context, &args))?;
+
+                                writeln!(io, "get_links {} links found:\n{:?}", result.links().len() , result)?;
                             } else {
                                 writeln!(io, "instance {} not found", args[0])?;
                             }

--- a/crates/holochain/src/main.rs
+++ b/crates/holochain/src/main.rs
@@ -272,7 +272,12 @@ fn main() {
                                 let result =
                                     context.block_on(get_link_result_workflow(&context, &args))?;
 
-                                writeln!(io, "get_links {} links found:\n{:?}", result.links().len() , result)?;
+                                writeln!(
+                                    io,
+                                    "get_links {} links found:\n{:?}",
+                                    result.links().len(),
+                                    result
+                                )?;
                             } else {
                                 writeln!(io, "instance {} not found", args[0])?;
                             }


### PR DESCRIPTION
## PR summary

This PR fixes some long-standing problems in validation:
- Increases timeout getting headers when building a validation package from the dht (1 second isn't enough)
- Pending items were being de-queued when processing, which meant that if another request arrived from sim2h (which could happen often under some circumstances), then the same item would be queued multiple times, which could snowball.  The solution was to move in-process items to another queue for checking.

And one bug in DHT queries:
- Fixed DHT queries for ChainHeader entries which were failing because there are no headers for headers stored in the DHT which the code was expecting.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
