### PR TITLE
Update tarpaulin attributes

### DIFF
--- a/crates/core/src/context.rs
+++ b/crates/core/src/context.rs
@@ -480,7 +480,7 @@ pub async fn get_dna_and_agent(context: &Arc<Context>) -> HcResult<(Address, Str
 /// require an optional network name. The reasoning for this is that tests which only require a
 /// single instance may simply pass None and get a unique network name, but tests which require two
 /// instances to be on the same network need to ensure both contexts use the same network name.
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_memory_network_config(network_name: Option<&str>) -> P2pConfig {
     network_name
         .map(|name| P2pConfig::new_with_memory_backend(name))

--- a/crates/core/src/instance.rs
+++ b/crates/core/src/instance.rs
@@ -570,7 +570,7 @@ pub mod tests {
     use holochain_persistence_mem::{cas::memory::MemoryStorage, eav::memory::EavMemoryStorage};
 
     /// create a test context and TestLogger pair so we can use the logger in assertions
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context_and_logger(
         agent_name: &str,
         network_name: Option<&str>,
@@ -579,7 +579,7 @@ pub mod tests {
     }
 
     /// create a test context and TestLogger pair so we can use the logger in assertions
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context_and_logger_with_in_memory_network(
         agent_name: &str,
         network_name: Option<&str>,
@@ -609,13 +609,13 @@ pub mod tests {
     }
 
     /// create a test context
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context(agent_name: &str, network_name: Option<&str>) -> Arc<Context> {
         let (context, _) = test_context_and_logger(agent_name, network_name);
         context
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context_with_memory_network(
         agent_name: &str,
         network_name: Option<&str>,
@@ -625,7 +625,7 @@ pub mod tests {
     }
 
     /// create a test context
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context_with_channels(
         agent_name: &str,
         action_channel: &ActionSender,
@@ -661,7 +661,7 @@ pub mod tests {
         )
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context_with_state(network_name: Option<&str>) -> Arc<Context> {
         let file_storage = Arc::new(RwLock::new(
             FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap(),
@@ -691,7 +691,7 @@ pub mod tests {
         Arc::new(context)
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_context_with_agent_state(network_name: Option<&str>) -> Arc<Context> {
         let file_system =
             FilesystemStorage::new(tempdir().unwrap().path().to_str().unwrap()).unwrap();
@@ -729,13 +729,13 @@ pub mod tests {
         Arc::new(context)
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_instance(dna: Dna, network_name: Option<&str>) -> Result<Instance, String> {
         test_instance_and_context(dna, network_name).map(|tuple| tuple.0)
     }
 
     /// create a canonical test instance
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_instance_and_context(
         dna: Dna,
         network_name: Option<&str>,
@@ -743,7 +743,7 @@ pub mod tests {
         test_instance_and_context_by_name(dna, "jane", network_name)
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_instance_and_context_by_name(
         dna: Dna,
         name: &str,
@@ -753,7 +753,7 @@ pub mod tests {
     }
 
     /// create a test instance
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_instance_and_context_with_memory_network_nodes(
         dna: Dna,
         name: &str,
@@ -798,7 +798,7 @@ pub mod tests {
     }
 
     /// create a test instance with a blank DNA
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_instance_blank() -> Instance {
         let mut dna = Dna::new();
         dna.zomes.insert("".to_string(), Zome::empty());

--- a/crates/core/src/network/test_utils.rs
+++ b/crates/core/src/network/test_utils.rs
@@ -7,7 +7,7 @@ use holochain_persistence_api::cas::content::Address;
 use std::sync::Arc;
 
 /// create a test instance
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_instance_with_spoofed_dna(
     dna: Dna,
     spoofed_dna_address: Address,

--- a/crates/core/src/nucleus/actions/mod.rs
+++ b/crates/core/src/nucleus/actions/mod.rs
@@ -32,12 +32,12 @@ pub mod tests {
     use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
     use test_utils::*;
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn instance(network_name: Option<&str>) -> (Instance, Arc<Context>) {
         instance_by_name("jane", test_dna(), network_name)
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_dna() -> Dna {
         // Setup the holochain instance
         let target_path: PathBuf = [
@@ -89,7 +89,7 @@ pub mod tests {
         dna
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn instance_by_name(
         name: &str,
         dna: Dna,
@@ -101,7 +101,7 @@ pub mod tests {
         (instance, initialized_context)
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn instance_with_bootstrap_nodes(
         name: &str,
         dna: Dna,
@@ -114,27 +114,27 @@ pub mod tests {
         (instance, initialized_context)
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_entry_package_entry() -> Entry {
         Entry::App("package_entry".into(), RawString::from("test value").into())
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_entry_package_chain_entries() -> Entry {
         Entry::App("package_chain_entries".into(), "test value".into())
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_entry_package_chain_headers() -> Entry {
         Entry::App("package_chain_headers".into(), "test value".into())
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_entry_package_chain_full() -> Entry {
         Entry::App("package_chain_full".into(), "test value".into())
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn commit(entry: Entry, context: &Arc<Context>) -> ChainHeader {
         let chain = context.state().unwrap().agent().chain_store();
 

--- a/crates/core/src/wasm_engine/api/call.rs
+++ b/crates/core/src/wasm_engine/api/call.rs
@@ -221,7 +221,7 @@ pub mod tests {
     use test_utils::create_test_dna_with_defs;
 
     /// dummy commit args from standard test entry
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_bad_args_bytes() -> Vec<u8> {
         let args = ZomeFnCallArgs {
             instance_handle: "instance_handle".to_string(),
@@ -235,7 +235,7 @@ pub mod tests {
             .into_bytes()
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn test_args_bytes() -> Vec<u8> {
         let args = ZomeFnCallArgs {
             instance_handle: THIS_INSTANCE.to_string(),
@@ -262,7 +262,7 @@ pub mod tests {
         TestSetup { context, instance }
     }
 
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     fn test_reduce_call(
         test_setup: &TestSetup,
         cap_request: CapabilityRequest,

--- a/crates/core/src/wasm_engine/api/macros.rs
+++ b/crates/core/src/wasm_engine/api/macros.rs
@@ -67,7 +67,7 @@ macro_rules! link_zome_api {
 
         impl ZomeApiFunction {
             // cannot test this because PartialEq is not implemented for fns
-            #[cfg_attr(tarpaulin, skip)]
+            #[cfg(not(tarpaulin_include))]
             pub fn apply(&self, runtime: &mut Runtime, args: &RuntimeArgs) -> ZomeApiResult {
                 // TODO Implement a proper "abort" function for handling assemblyscript aborts
                 // @see: https://github.com/holochain/holochain-rust/issues/324

--- a/crates/core/src/wasm_engine/callback/mod.rs
+++ b/crates/core/src/wasm_engine/callback/mod.rs
@@ -64,7 +64,7 @@ impl FromStr for Callback {
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
 impl Callback {
     // cannot test this because PartialEq is not implemented for fns
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     pub fn as_fn(
         &self,
     ) -> fn(context: Arc<Context>, zome: &str, params: &CallbackParams) -> CallbackResult {

--- a/crates/core_types/src/entry/entry_type.rs
+++ b/crates/core_types/src/entry/entry_type.rs
@@ -159,7 +159,7 @@ impl Display for EntryType {
 }
 
 /// dummy entry type
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_app_entry_type() -> AppEntryType {
     AppEntryType::from("testEntryType")
 }
@@ -169,7 +169,7 @@ pub fn test_entry_type() -> EntryType {
 }
 
 /// dummy entry type, same as test_type()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_app_entry_type_a() -> AppEntryType {
     test_app_entry_type()
 }
@@ -179,7 +179,7 @@ pub fn test_entry_type_a() -> EntryType {
 }
 
 /// dummy entry type, differs from test_type()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_app_entry_type_b() -> AppEntryType {
     AppEntryType::from("testEntryTypeB")
 }

--- a/crates/core_types/src/entry/mod.rs
+++ b/crates/core_types/src/entry/mod.rs
@@ -139,7 +139,7 @@ pub struct EntryWithMetaAndHeader {
 }
 
 /// dummy entry value
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_value() -> JsonString {
     JsonString::from(RawString::from("test entry value"))
 }
@@ -149,32 +149,32 @@ pub fn test_entry_content() -> Content {
 }
 
 /// dummy entry content, same as test_entry_value()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_value_a() -> JsonString {
     test_entry_value()
 }
 
 /// dummy entry content, differs from test_entry_value()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_value_b() -> JsonString {
     JsonString::from(RawString::from("other test entry value"))
 }
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_value_c() -> JsonString {
     RawString::from("value C").into()
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_sys_entry_value() -> AgentId {
     test_agent_id()
 }
 
 /// dummy entry
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry() -> Entry {
     Entry::App(test_app_entry_type(), test_entry_value())
 }
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_with_value(value: &'static str) -> Entry {
     Entry::App(test_app_entry_type(), JsonString::from_json(&value))
 }
@@ -184,19 +184,19 @@ pub fn expected_serialized_entry_content() -> JsonString {
 }
 
 /// the correct address for test_entry()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn expected_entry_address() -> Address {
     Address::from("Qma6RfzvZRL127UCEVEktPhQ7YSS1inxEFw7SjEsfMJcrq".to_string())
 }
 
 /// dummy entry, same as test_entry()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_a() -> Entry {
     test_entry()
 }
 
 /// dummy entry, differs from test_entry()
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_b() -> Entry {
     Entry::App(test_app_entry_type_b(), test_entry_value_b())
 }
@@ -205,7 +205,7 @@ pub fn test_entry_c() -> Entry {
 }
 
 /// dummy entry with unique string content
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_entry_unique() -> Entry {
     Entry::App(
         test_app_entry_type(),
@@ -213,7 +213,7 @@ pub fn test_entry_unique() -> Entry {
     )
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_sys_entry() -> Entry {
     Entry::AgentId(test_sys_entry_value())
 }
@@ -224,7 +224,7 @@ pub fn test_sys_entry_address() -> Address {
     ))
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn test_unpublishable_entry() -> Entry {
     Entry::Dna(Box::new(Dna::new()))
 }

--- a/crates/holochain/src/main.rs
+++ b/crates/holochain/src/main.rs
@@ -97,7 +97,7 @@ impl Default for SignalConfiguration {
 // NOTE: don't change without also changing in crates/trycp_server/src/main.rs
 const MAGIC_STRING: &str = "*** Done. All interfaces started.";
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CONDUCTOR)]
 fn main() {
     assert!(*SET_THREAD_PANIC_FATAL2);
@@ -279,7 +279,7 @@ fn main() {
     };
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CONDUCTOR)]
 fn bootstrap_from_config(path: &str) -> Result<(), HolochainError> {
     let config = load_config_file(&String::from(path))?;
@@ -304,7 +304,7 @@ fn bootstrap_from_config(path: &str) -> Result<(), HolochainError> {
     Ok(())
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CONDUCTOR)]
 fn load_config_file(path: &String) -> Result<Configuration, HolochainError> {
     let mut f = File::open(path)?;

--- a/crates/net/src/in_memory/memory_worker.rs
+++ b/crates/net/src/in_memory/memory_worker.rs
@@ -180,7 +180,7 @@ mod tests {
     //static AGENT_ID_1: &'static str = "HcScIkRaAaaaaaaaaaAaaaAAAAaaaaaaaaAaaaaAaaaaaaaaAaaAAAAatzu4aqa";
 
     #[test]
-    #[cfg_attr(tarpaulin, skip)]
+    #[cfg(not(tarpaulin_include))]
     fn can_memory_worker_double_track() {
         // setup client 1
         let memory_config = &JsonString::from(P2pConfig::unique_memory_backend_json());

--- a/crates/wasm_utils/src/lib.rs
+++ b/crates/wasm_utils/src/lib.rs
@@ -11,7 +11,7 @@ pub extern crate holochain_json_api;
 pub extern crate holochain_persistence_api;
 
 /// ignore api_serialization because it is nothing but structs to hold serialization
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub mod api_serialization;
 
 pub mod macros;

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -252,7 +252,7 @@ pub enum TestNodeConfig {
     LegacyInMemory,
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg(not(tarpaulin_include))]
 pub fn create_test_context_with_logger_and_signal(
     agent_name: &str,
     network_name: Option<&str>,


### PR DESCRIPTION
## PR summary

So in 0.13.4 (yanked) tarpaulin actually started passing --cfg=tarpaulin so users could do #[cfg_attr(tarpaulin, ignore)] to ignore certain tests in coverage and also conditionally include/exclude code in coverage. This had the unintended result of breaking the recommended skip attr.

Because of that 0.13.4 was yanked and later on a 0.14.0 version released which still did --cfg=tarpaulin but also --cfg=tarpaulin_include so that code could now be skipped but still included if you did #[cfg(not(tarpaulin_include))]. There's also an unstable #[tarpaulin::skip] tool attribute for those using nightly.

This PR changes time to use the new attributes as a user of time and tarpaulin found this broke their coverage CI.

Link to relevant tarpaulin issue: xd009642/tarpaulin#487

## testing/benchmarking notes

I struggled to get holochain building and running coverage on it. Still working on that but it shouldn't functionally impact any code just driving the tarpaulin source analysis and exclusion functionality.
