### PR TITLE
Batch sends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "holochain_persistence_api 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_tracing 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "holochain_tracing_macros 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "im 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "in_stream 0.0.49-alpha1",
  "jsonrpc-core 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/core/src/dht/actions/hold_aspect.rs
+++ b/crates/core/src/dht/actions/hold_aspect.rs
@@ -1,11 +1,12 @@
 use crate::{
     action::{Action, ActionWrapper},
     context::Context,
-    dht::{aspect_map::AspectMap, dht_store::HoldAspectAttemptId},
+    dht::dht_store::HoldAspectAttemptId,
     instance::dispatch_action,
 };
 use futures::{future::Future, task::Poll};
 use holochain_core_types::{error::HolochainError, network::entry_aspect::EntryAspect};
+use holochain_net::aspect_map::AspectMap;
 use holochain_persistence_api::cas::content::AddressableContent;
 use lib3h_protocol::data_types::EntryListData;
 use snowflake::ProcessUniqueId;

--- a/crates/core/src/dht/dht_store.rs
+++ b/crates/core/src/dht/dht_store.rs
@@ -2,7 +2,6 @@ use crate::{
     content_store::{AddContent, GetContent},
     dht::{
         actions::remove_queued_holding_workflow::HoldingWorkflowQueueing,
-        aspect_map::{AspectMap, AspectMapBare},
         pending_validations::{PendingValidationWithTimeout, ValidationTimeout},
     },
     instance::RETRY_VALIDATION_DURATION_MIN,
@@ -20,6 +19,7 @@ use holochain_core_types::{
 };
 use holochain_json_api::{error::JsonError, json::JsonString};
 use holochain_locksmith::RwLock;
+use holochain_net::aspect_map::{AspectMap, AspectMapBare};
 use holochain_persistence_api::{
     cas::{
         content::{Address, AddressableContent, Content},

--- a/crates/core/src/dht/mod.rs
+++ b/crates/core/src/dht/mod.rs
@@ -2,7 +2,6 @@
 
 #[autotrace]
 pub mod actions;
-pub mod aspect_map;
 pub mod dht_reducers;
 #[autotrace]
 pub mod dht_store;

--- a/crates/core/src/dht/pending_validations.rs
+++ b/crates/core/src/dht/pending_validations.rs
@@ -2,6 +2,7 @@ use crate::{
     entry::validation_dependencies::ValidationDependencies,
     network::entry_with_header::EntryWithHeader,
 };
+use chrono::{offset::Utc, DateTime};
 use holochain_core_types::{
     entry::{deletion_entry::DeletionEntry, Entry},
     error::HolochainError,
@@ -13,6 +14,7 @@ use snowflake::ProcessUniqueId;
 use std::{
     convert::TryFrom,
     fmt,
+    ops::Add,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -171,6 +173,13 @@ impl From<PendingValidationStruct> for EntryAspect {
 pub struct ValidationTimeout {
     pub time_of_dispatch: SystemTime,
     pub delay: Duration,
+}
+
+impl fmt::Display for ValidationTimeout {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let datetime: DateTime<Utc> = self.time_of_dispatch.add(self.delay).into();
+        write!(f, "{}", datetime.format("%d/%m/%Y %T"))
+    }
 }
 
 impl ValidationTimeout {

--- a/crates/core/src/network/handler/lists.rs
+++ b/crates/core/src/network/handler/lists.rs
@@ -2,7 +2,6 @@ use crate::{
     action::{Action, ActionWrapper},
     agent::state::create_entry_with_header_for_header,
     context::Context,
-    dht::aspect_map::{AspectMap, AspectMapBare},
     entry::CanPublish,
     instance::dispatch_action,
     network::{
@@ -10,6 +9,7 @@ use crate::{
         handler::{entry_to_meta_aspect, get_content_aspects_from_chain},
     },
 };
+use holochain_net::aspect_map::{AspectMap, AspectMapBare};
 use holochain_persistence_api::cas::content::{Address, AddressableContent};
 use im::HashSet;
 use lib3h_protocol::{

--- a/crates/core/src/state_dump.rs
+++ b/crates/core/src/state_dump.rs
@@ -2,7 +2,7 @@ use crate::{
     action::QueryKey,
     content_store::GetContent,
     context::Context,
-    dht::{aspect_map::AspectMapBare, pending_validations::PendingValidationWithTimeout},
+    dht::pending_validations::PendingValidationWithTimeout,
     network::{direct_message::DirectMessage, entry_with_header::EntryWithHeader},
     nucleus::{ZomeFnCall, ZomeFnCallState},
 };
@@ -13,6 +13,7 @@ use holochain_core_types::{
     error::HolochainError,
 };
 use holochain_json_api::json::JsonString;
+use holochain_net::aspect_map::AspectMapBare;
 use holochain_persistence_api::{
     cas::content::{Address, AddressableContent},
     eav::IndexFilter,

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -51,6 +51,7 @@ env_logger = "=0.6.1"
 holochain_logging = "=0.0.7"
 log = "0.4.8"
 newrelic = { version = "=0.2.2", optional = true }
+im = { version = "=14.0.0", features = ["serde"] }
 
 [features]
 default = []

--- a/crates/net/src/aspect_map.rs
+++ b/crates/net/src/aspect_map.rs
@@ -181,8 +181,8 @@ mod tests {
         map1.insert("a".into(), hashset![AspectHash::from("x")]);
         map2.insert("b".into(), hashset![AspectHash::from("y")]);
         let (map1, map2): (AspectMap, AspectMap) = (map1.into(), map2.into());
-        let merged = AspectMap::merge(map1.clone(), map2.clone());
-        let merged2 = AspectMap::merge(map2.clone(), map1.clone());
+        let merged = AspectMap::merge(&map1.clone(), &map2.clone());
+        let merged2 = AspectMap::merge(&map2.clone(), &map1.clone());
         assert_eq!(merged.0, merged2.0);
         assert_eq!(merged.0.len(), 2);
         assert_eq!(merged.0.get(&EntryHash::from("a")).unwrap().len(), 1);
@@ -199,8 +199,8 @@ mod tests {
             hashset![AspectHash::from("x"), AspectHash::from("y")],
         );
         let (map1, map2): (AspectMap, AspectMap) = (map1.into(), map2.into());
-        let merged = AspectMap::merge(map1.clone(), map2.clone());
-        let merged2 = AspectMap::merge(map1, map2);
+        let merged = AspectMap::merge(&map1.clone(), &map2.clone());
+        let merged2 = AspectMap::merge(&map1, &map2);
         assert_eq!(merged.0, merged2.0);
         assert_eq!(merged.0.len(), 1);
         assert_eq!(merged.0.get(&EntryHash::from("a")).unwrap().len(), 2);
@@ -231,8 +231,8 @@ mod tests {
             hashset![AspectHash::from("v"), AspectHash::from("w")],
         );
         let (map1, map2): (AspectMap, AspectMap) = (map1.into(), map2.into());
-        let merged = AspectMap::merge(map1.clone(), map2.clone());
-        let merged2 = AspectMap::merge(map2, map1);
+        let merged = AspectMap::merge(&map1.clone(), &map2.clone());
+        let merged2 = AspectMap::merge(&map2, &map1);
         assert_eq!(merged.0, merged2.0);
         assert_eq!(merged.0.len(), 2);
         assert_eq!(merged.0.get(&EntryHash::from("a")).unwrap().len(), 3);

--- a/crates/net/src/aspect_map.rs
+++ b/crates/net/src/aspect_map.rs
@@ -1,5 +1,5 @@
-use crate::holochain_wasm_utils::holochain_persistence_api::cas::content::AddressableContent;
 use holochain_core_types::network::entry_aspect::EntryAspect;
+use holochain_persistence_api::cas::content::AddressableContent;
 use im::{HashMap, HashSet};
 use lib3h_protocol::types::{AspectHash, EntryHash};
 use std::collections::HashMap as StdHashMap;
@@ -83,7 +83,11 @@ impl AspectMap {
             .join("\n")
     }
 
-    pub fn merge(map1: AspectMap, map2: AspectMap) -> AspectMap {
+    pub fn empty(&self) -> bool {
+        self.0.len() == 0
+    }
+
+    pub fn merge(map1: &AspectMap, map2: &AspectMap) -> AspectMap {
         map1.0
             .keys()
             .chain(map2.0.keys())
@@ -104,6 +108,22 @@ impl AspectMap {
 impl From<AspectMapBare> for AspectMap {
     fn from(map: AspectMapBare) -> AspectMap {
         AspectMap { 0: map }
+    }
+}
+
+impl From<&std::collections::HashMap<EntryHash, Vec<AspectHash>>> for AspectMap {
+    fn from(a: &std::collections::HashMap<EntryHash, Vec<AspectHash>>) -> AspectMap {
+        let mut result = AspectMap::new();
+        for (entry_address, aspect_list) in a.iter() {
+            for aspect_address in aspect_list {
+                result
+                    .0
+                    .entry(entry_address.clone())
+                    .or_insert_with(HashSet::new)
+                    .insert(aspect_address.clone());
+            }
+        }
+        result
     }
 }
 

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -24,6 +24,7 @@ extern crate serde_derive;
 
 #[macro_use]
 extern crate holochain_tracing_macros;
+pub mod aspect_map;
 pub mod connection;
 pub mod error;
 pub mod in_memory;

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -388,6 +388,18 @@ impl Sim2hHandle {
                 WireMessage::Lib3hToClientResponse(ht::EncodedSpanWrap { data, .. }) => {
                     return lib3h_to_client_response(data, uri, sim2h_handle, signer, space_hash);
                 }
+                WireMessage::MultiSendResponse(messages) => {
+                    for ht::EncodedSpanWrap { data, .. } in messages {
+                        lib3h_to_client_response(
+                            data,
+                            uri.clone(),
+                            sim2h_handle.clone(),
+                            signer.clone(),
+                            space_hash.clone(),
+                        );
+                    }
+                    return;
+                }
                 message @ _ => {
                     error!("unhandled message type {:?}", message);
                     return;

--- a/crates/sim2h/src/wire_message.rs
+++ b/crates/sim2h/src/wire_message.rs
@@ -39,6 +39,7 @@ pub enum WireMessage {
     Lib3hToClient(ht::EncodedSpanWrap<Lib3hToClient>),
     Lib3hToClientResponse(ht::EncodedSpanWrap<Lib3hToClientResponse>),
     MultiSend(Vec<ht::EncodedSpanWrap<Lib3hToClient>>),
+    MultiSendResponse(Vec<ht::EncodedSpanWrap<Lib3hToClientResponse>>),
     Err(WireError),
     Ping,
     Pong,
@@ -114,6 +115,10 @@ impl WireMessage {
                 let messages: Vec<&Lib3hToClient> = m.iter().map(|w| &w.data).collect();
                 get_multi_type(messages)
             }
+            WireMessage::MultiSendResponse(m) => {
+                let messages: Vec<&Lib3hToClientResponse> = m.iter().map(|w| &w.data).collect();
+                get_multi_response_type(messages)
+            }
             WireMessage::Err(_) => "[Error] {:?}",
             WireMessage::Ack(_) => "[Ack] {:?}",
         })
@@ -139,6 +144,19 @@ fn get_multi_type(list: Vec<&Lib3hToClient>) -> &str {
         }
     } else {
         "[L>C]MultiSend::EMPTY_SEND"
+    }
+}
+
+fn get_multi_response_type(list: Vec<&Lib3hToClientResponse>) -> &str {
+    if list.len() > 0 {
+        match list.get(0).unwrap() {
+            Lib3hToClientResponse::HandleFetchEntryResult(_) => {
+                "[L>C]MultiSendResponse::HandleFetchEntryResult"
+            }
+            _ => "[L>C]MultiSendResponse::UNEXPECTED_VARIANT",
+        }
+    } else {
+        "[L>C]MultiSendResponse::EMPTY_SEND"
     }
 }
 


### PR DESCRIPTION
## PR summary

Fat-acks put a lot of stress on the linear sim2h outgoing messages queue.  This PR implements collecting them up in batches and sending them all at once.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
