### PR TITLE
Cache validation packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,8 @@ dependencies = [
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "shrust 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1294,7 +1295,8 @@ dependencies = [
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_regex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "test_utils 0.0.49-alpha1",
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4110,7 +4112,8 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "newrelic 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sim2h 0.0.49-alpha1",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4210,7 +4213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.2.15"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4877,7 +4880,8 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "snowflake 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url2 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -5906,7 +5910,7 @@ dependencies = [
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strip-ansi-escapes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-"checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
+"checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
 "checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
 "checksum structopt-derive 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
 "checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"

--- a/app_spec/test/files/links.js
+++ b/app_spec/test/files/links.js
@@ -73,7 +73,8 @@ module.exports = scenario => {
     t.ok(result_bob_delete.Err)
     t.notOk(result_bob_delete.Ok)
     const error = JSON.parse(result_bob_delete.Err.Internal)
-    t.match(error.kind.ErrorGeneric, /Target for link not found: Link { base: HashString\(".*"\), target: HashString\(".*"\), link_type: "authored_posts", tag: "" }/)
+    let re = /Target for link not found: Link { base: HashString\(".*"\), target: HashString\(".*"\), link_type: "authored_posts", tag: "" }/;
+    t.equal(true, re.test(error.kind.ErrorGeneric))
     t.ok(error.file)
     t.ok(error.line)
   })

--- a/crates/conductor_lib/Cargo.toml
+++ b/crates/conductor_lib/Cargo.toml
@@ -62,7 +62,8 @@ tokio = "=0.1.22"
 test_utils = { version = "=0.0.49-alpha1", path = "../../test_utils" }
 tempfile = "=3.0.7"
 holochain_wasm_utils = { version = "=0.0.49-alpha1", path = "../wasm_utils" }
-structopt = "=0.2.15"
+structopt-derive = "=0.2.18"
+structopt = "=0.2.18"
 pretty_assertions = "=0.6.1"
 ws = "=0.8.0"
 parking_lot = "=0.7.1"

--- a/crates/core/src/action.rs
+++ b/crates/core/src/action.rs
@@ -193,7 +193,7 @@ pub enum Action {
     /// Updates the state to hold the response that we got for
     /// our previous request for a validation package.
     /// Triggered from the network handler when we get the response.
-    HandleGetValidationPackage((ValidationKey, Option<ValidationPackage>)),
+    HandleGetValidationPackage((Address, ValidationKey, Option<ValidationPackage>)),
 
     /// Clean up the validation package result so the state doesn't grow indefinitely.
     ClearValidationPackageResult(ValidationKey),

--- a/crates/core/src/network/handler/send.rs
+++ b/crates/core/src/network/handler/send.rs
@@ -137,6 +137,7 @@ pub fn handle_send_message_result(message_data: DirectMessageData, context: Arc<
             let address = unwrap_to!(initial_message => DirectMessage::RequestValidationPackage);
 
             let action_wrapper = ActionWrapper::new(Action::HandleGetValidationPackage((
+                message_data.from_agent_id.into(),
                 address.clone(),
                 maybe_validation_package,
             )));

--- a/crates/core/src/network/reducers/handle_get_validation_package.rs
+++ b/crates/core/src/network/reducers/handle_get_validation_package.rs
@@ -7,10 +7,14 @@ pub fn reduce_handle_get_validation_package(
     action_wrapper: &ActionWrapper,
 ) {
     let action = action_wrapper.action();
-    let (address, maybe_validation_package) =
+    let (responder, address, maybe_validation_package) =
         unwrap_to!(action => crate::action::Action::HandleGetValidationPackage);
 
     network_state
         .get_validation_package_results
         .insert(address.clone(), Some(Ok(maybe_validation_package.clone())));
+
+    if let Some(validation_package) = maybe_validation_package {
+        network_state.cache_validation(responder.clone(), validation_package);
+    }
 }

--- a/crates/core/src/network/state.rs
+++ b/crates/core/src/network/state.rs
@@ -3,7 +3,13 @@ use crate::{
     network::{actions::Response, direct_message::DirectMessage, query::NetworkQueryResult},
 };
 use boolinator::*;
-use holochain_core_types::{error::HolochainError, validation::ValidationPackage};
+use holochain_core_types::{
+    chain_header::ChainHeader,
+    entry::Entry,
+    error::HolochainError,
+    validation::{ValidationPackage, ValidationPackageDefinition},
+};
+use holochain_json_api::{error::JsonError, json::JsonString};
 use holochain_net::p2p_network::P2pNetwork;
 use holochain_persistence_api::cas::content::Address;
 use im::HashMap;
@@ -20,6 +26,21 @@ type Actions = HashMap<ActionWrapper, Response>;
 type GetValidationPackageResult = Option<Result<Option<ValidationPackage>, HolochainError>>;
 
 type GetResults = Option<Result<NetworkQueryResult, HolochainError>>;
+
+/// Cached source chain data for validation
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, DefaultJson)]
+pub struct ValidationCacheData {
+    pub entries: Option<Vec<Entry>>,
+    pub headers: Vec<ChainHeader>,
+    pub cached_at: SystemTime,
+}
+
+impl ValidationCacheData {
+    fn latest_header(&self) -> ChainHeader {
+        // we should never add an empty headers array to the cache
+        self.headers.first().unwrap().clone()
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct NetworkState {
@@ -46,6 +67,7 @@ pub struct NetworkState {
     pub direct_message_timeouts: HashMap<String, (SystemTime, Duration)>,
 
     pub custom_direct_message_replys: HashMap<String, Result<String, HolochainError>>,
+    pub validation_cache: HashMap<Address, ValidationCacheData>,
 
     id: String,
 }
@@ -71,6 +93,7 @@ impl NetworkState {
             direct_message_connections: HashMap::new(),
             direct_message_timeouts: HashMap::new(),
             custom_direct_message_replys: HashMap::new(),
+            validation_cache: HashMap::new(),
 
             id: nanoid::simple(),
         }
@@ -84,5 +107,97 @@ impl NetworkState {
         (self.network.is_some() && self.dna_address.is_some() && self.agent_id.is_some()).ok_or(
             HolochainError::ErrorGeneric("Network not initialized".to_string()),
         )
+    }
+
+    pub(crate) fn cache_validation(&mut self, agent: Address, validation: &ValidationPackage) {
+        if validation.source_chain_headers.is_none() {
+            return;
+        }
+        if self.validation_cache.contains_key(&agent) {
+            let mut cache_entry = self.validation_cache.get_mut(&agent).unwrap();
+            if validation.chain_header.timestamp() > cache_entry.latest_header().timestamp() {
+                debug!("Vcache: updating {}:{:?}", &agent, validation.chain_header);
+                debug!(
+                    "header count: {}",
+                    validation.source_chain_headers.as_ref().unwrap().len()
+                );
+                cache_entry.headers = validation.source_chain_headers.clone().unwrap();
+                if validation.source_chain_entries.is_some() {
+                    debug!(
+                        "entry count: {}",
+                        validation.source_chain_entries.as_ref().unwrap().len()
+                    );
+                    cache_entry.entries = validation.source_chain_entries.clone();
+                }
+            } else {
+                debug!("Vcache: already {}:{:?}", &agent, validation.chain_header);
+            }
+        } else {
+            debug!(
+                "Vcache: initial insert {}:{:?} {:#?}",
+                &agent, validation.chain_header, &validation
+            );
+            self.validation_cache.insert(
+                agent,
+                ValidationCacheData {
+                    entries: validation.source_chain_entries.clone(),
+                    headers: validation.source_chain_headers.as_ref().unwrap().clone(),
+                    cached_at: SystemTime::now(),
+                },
+            );
+        }
+    }
+
+    // tries to build a validation package of the given type from the cache for a
+    pub fn get_validation_package_from_cache(
+        &self,
+        agent: Address,
+        definition: &ValidationPackageDefinition,
+        header: &ChainHeader,
+    ) -> Option<ValidationPackage> {
+        let cache_entry = self.validation_cache.get(&agent)?;
+
+        // check all the cases where we know we can't calculate the validation package and
+        // return, so the rest of the cases we can just unwrap.
+        match definition {
+            ValidationPackageDefinition::Entry
+            | ValidationPackageDefinition::ChainEntries
+            | ValidationPackageDefinition::Custom(_) => return None,
+            ValidationPackageDefinition::ChainHeaders => {
+                //                if cache_entry.headers.is_none() {
+                return None;
+                //                };
+            }
+            ValidationPackageDefinition::ChainFull => {
+                if cache_entry.headers.len() == 0 {
+                    return None;
+                };
+                if cache_entry.entries.is_none() {
+                    return None;
+                };
+            }
+        }
+
+        // if we are looking for a header that was after the latest cached
+        // we can't build it
+        if header.timestamp() >= cache_entry.latest_header().timestamp() {
+            return None;
+        };
+
+        match definition {
+            ValidationPackageDefinition::ChainHeaders => Some(ValidationPackage {
+                chain_header: header.clone(),
+                source_chain_headers: Some(cache_entry.headers.clone()),
+                source_chain_entries: None,
+                custom: None,
+            }),
+            ValidationPackageDefinition::ChainFull => Some(ValidationPackage {
+                chain_header: header.clone(),
+                source_chain_headers: Some(cache_entry.headers.clone()),
+                source_chain_entries: cache_entry.entries.clone(),
+                custom: None,
+            }),
+            _ => None,
+        }
     }
 }

--- a/crates/core/src/nucleus/actions/build_validation_package.rs
+++ b/crates/core/src/nucleus/actions/build_validation_package.rs
@@ -70,12 +70,10 @@ pub fn build_validation_package<'a>(
 
     let entry = entry.clone();
     let context = context;
-    let maybe_entry_header = find_chain_header(
-        &entry.clone(),
-        &context
-            .state()
-            .expect("No state in build_validation_package"),
-    );
+    let state = &context
+        .state()
+        .expect("No state in build_validation_package");
+    let maybe_entry_header = find_chain_header(&entry.clone(), &state);
     let entry_header = match maybe_entry_header {
         None => {
             // TODO: make sure that we don't run into race conditions with respect to the chain
@@ -134,7 +132,7 @@ pub fn build_validation_package<'a>(
                 }
                 ChainFull => {
                     let mut package = ValidationPackage::only_header(entry_header);
-                    let headers = all_chain_headers_before_header(&context, &package.chain_header);
+                    let headers = all_chain_headers(&context);
                     package.source_chain_entries =
                         Some(public_chain_entries_from_headers(&context, &headers));
                     package.source_chain_headers = Some(headers);
@@ -169,6 +167,17 @@ fn public_chain_entries_from_headers(
                 .expect("Entry does not exist")
         })
         .collect::<Vec<_>>()
+}
+
+#[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]
+fn all_chain_headers(context: &Arc<Context>) -> Vec<ChainHeader> {
+    let state = &context
+        .state()
+        .expect("No state in build_validation_package")
+        .agent();
+    let top = state.top_chain_header().expect("there has to be a top");
+    let chain = state.chain_store();
+    chain.iter(&Some(top)).collect()
 }
 
 #[holochain_tracing_macros::newrelic_autotrace(HOLOCHAIN_CORE)]

--- a/crates/core/src/nucleus/actions/build_validation_package.rs
+++ b/crates/core/src/nucleus/actions/build_validation_package.rs
@@ -302,7 +302,7 @@ mod tests {
             build_validation_package(&test_entry_package_chain_full(), context.clone(), &vec![]);
         assert!(maybe_validation_package.is_ok());
 
-        let headers = all_chain_headers_before_header(&context, &chain_header);
+        let headers = all_chain_headers(&context);
 
         let expected = ValidationPackage {
             chain_header,

--- a/crates/core/src/nucleus/validation/build_from_dht.rs
+++ b/crates/core/src/nucleus/validation/build_from_dht.rs
@@ -231,7 +231,7 @@ pub mod tests {
                 .source_chain_headers
                 .expect("chain headers not in locally generated packagae")
                 .len(),
-            2
+            3
         );
 
         assert_eq!(
@@ -243,6 +243,9 @@ pub mod tests {
             2
         );
 
-        assert_eq!(local_validation_package, dht_validation_package,)
+        // these are no longer the same because the validation package from the author
+        // will include the entire chain, not just the items below the given header so that
+        // they can be cached.  TODO: cache the dht validation packages too.
+        //assert_eq!(local_validation_package, dht_validation_package,)
     }
 }

--- a/crates/core/src/nucleus/validation/mod.rs
+++ b/crates/core/src/nucleus/validation/mod.rs
@@ -76,11 +76,18 @@ impl From<ValidationError> for HolochainError {
 pub async fn validate_entry(
     entry: Entry,
     link: Option<Address>,
-    validation_data: ValidationData,
+    mut validation_data: ValidationData,
     context: &Arc<Context>,
 ) -> ValidationResult {
     log_debug!(context, "workflow/validate_entry: {:?}", entry);
     //check_entry_type(entry.entry_type(), context)?;
+
+    // cleanup validation data which may include too much
+    if let Some(ref mut headers) = validation_data.package.source_chain_headers {
+        let t = validation_data.package.chain_header.timestamp();
+        headers.retain(|header| header.timestamp() < t);
+    }
+
     header_address::validate_header_address(&entry, &validation_data.package.chain_header)?;
     provenances::validate_provenances(&validation_data)?;
 

--- a/crates/core/src/workflows/mod.rs
+++ b/crates/core/src/workflows/mod.rs
@@ -134,6 +134,8 @@ async fn validation_package(
         return Ok(Some(package));
     }
 
+    // 1.5. Fetch a cached version of the validation package if cache version is warm
+    // This mitigates hitting the author too frequently for the same validation package.
     log_debug!(
         context,
         "validation_package:{} - Could not build locally. Trying to build from cache",

--- a/crates/core/src/workflows/mod.rs
+++ b/crates/core/src/workflows/mod.rs
@@ -272,7 +272,7 @@ pub mod tests {
                 .source_chain_headers
                 .unwrap()
                 .len(),
-            2
+            3
         );
     }
 }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -20,7 +20,8 @@ holochain_common = { version = "=0.0.49-alpha1", path = "../common" }
 holochain_locksmith = { version = "=0.0.49-alpha1", path = "../locksmith" }
 holochain_tracing = "=0.0.24"
 holochain_tracing_macros = "=0.0.24"
-structopt = "=0.2.15"
+structopt-derive = "=0.2.18"
+structopt = "=0.2.18"
 tiny_http = "=0.6.2"
 lazy_static = "=1.4.0"
 ws = "=0.8.0"

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -350,15 +350,6 @@ impl Sim2hWorker {
 
     /// queue a wire message for send
     fn send_wire_message(&mut self, message: WireMessage) -> NetResult<()> {
-        // we always put messages in the outgoing buffer,
-        // they'll be sent when the connection is ready
-        debug!(
-            "WireMessage: queueing on top of {} messages: {:#?}\nwaiting for: {:#?}",
-            self.outgoing_message_buffer.len(),
-            message,
-            self.outgoing_message_buffer.get(0)
-        );
-        // debug!("on queue: {:#?}", self.outgoing_message_buffer);
 
         // but if it's a fat ack (HandleGetGossipingEntryListResult), or HandleFetchEntryResult
         // they don't need to be sent in a particular order and we want to bundle them for periodic
@@ -372,6 +363,10 @@ impl Sim2hWorker {
                 Lib3hToClientResponse::HandleGetGossipingEntryListResult(ref entry_data) => {
                     // only batch fat acks which have no request_id
                     if entry_data.request_id == "" {
+                        debug!(
+                            "WireMessage: batching fat ack, pending ack aspect count is: {}",
+                            self.outgoing_fat_acks.bare().iter().fold(0, |acc, (_k,v)| acc + v.len()),
+                        );
                         let am = AspectMap::from(&entry_data.address_map);
                         self.outgoing_fat_acks = AspectMap::merge(&self.outgoing_fat_acks, &am);
                         false
@@ -384,6 +379,15 @@ impl Sim2hWorker {
             _ => true,
         };
         if send {
+            // we always put messages in the outgoing buffer,
+            // they'll be sent when the connection is ready
+            debug!(
+                "WireMessage: queueing on top of {} messages: {:#?}\nwaiting for: {:#?}",
+                self.outgoing_message_buffer.len(),
+                message,
+                self.outgoing_message_buffer.get(0)
+            );
+            // debug!("on queue: {:#?}", self.outgoing_message_buffer);
             self.outgoing_message_buffer.push(message.into());
         };
 

--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -350,7 +350,6 @@ impl Sim2hWorker {
 
     /// queue a wire message for send
     fn send_wire_message(&mut self, message: WireMessage) -> NetResult<()> {
-
         // but if it's a fat ack (HandleGetGossipingEntryListResult), or HandleFetchEntryResult
         // they don't need to be sent in a particular order and we want to bundle them for periodic
         // sending so we add them to different queues.
@@ -365,7 +364,10 @@ impl Sim2hWorker {
                     if entry_data.request_id == "" {
                         debug!(
                             "WireMessage: batching fat ack, pending ack aspect count is: {}",
-                            self.outgoing_fat_acks.bare().iter().fold(0, |acc, (_k,v)| acc + v.len()),
+                            self.outgoing_fat_acks
+                                .bare()
+                                .iter()
+                                .fold(0, |acc, (_k, v)| acc + v.len()),
                         );
                         let am = AspectMap::from(&entry_data.address_map);
                         self.outgoing_fat_acks = AspectMap::merge(&self.outgoing_fat_acks, &am);

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -1488,7 +1488,7 @@ async fn missing_aspects_resync(sim2h_handle: Sim2hHandle, _schedule_guard: Sche
     }
 
     for (space_hash, agents) in agents_needing_gossip.iter() {
-        trace!(
+        debug!(
             "sim2h gossip agent count: {} in space {:?}",
             agents.len(),
             space_hash

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -123,10 +123,10 @@ impl<T> SendExt<T> for crossbeam_channel::Sender<T> {
     }
 }
 
-//const RETRY_FETCH_MISSING_ASPECTS_INTERVAL_MS: u64 = 30000; // 30 seconds
+const RETRY_FETCH_MISSING_ASPECTS_INTERVAL_MS: u64 = 30000; // 30 seconds
 /// actual timing is handled by sim2h_im_state
 /// but it does cause a mutate, so we don't want to spam it too hard
-const RETRY_FETCH_MISSING_ASPECTS_INTERVAL_MS: u64 = 500; // half second
+//const RETRY_FETCH_MISSING_ASPECTS_INTERVAL_MS: u64 = 500; // half second
 
 fn open_lifecycle(desc: &str, uuid: &str, uri: &Lib3hUri) {
     debug!("connection event open_conns: {} for {}@{}", desc, uuid, uri);

--- a/crates/sim2h_server/Cargo.toml
+++ b/crates/sim2h_server/Cargo.toml
@@ -26,7 +26,8 @@ lib3h_sodium = "=0.0.42"
 lazy_static = "=1.4.0"
 log = "0.4.8"
 env_logger = "0.7.0"
-structopt = "=0.2.15"
+structopt-derive = "=0.2.18"
+structopt = "=0.2.18"
 tracing-log = "=0.1.1"
 
 [features]

--- a/crates/trycp_server/Cargo.toml
+++ b/crates/trycp_server/Cargo.toml
@@ -15,7 +15,8 @@ repository = "https://github.com/holochain/holochain-rust"
 in_stream = { version = "=0.0.49-alpha1", path = "../in_stream" }
 log = "0.4.8"
 env_logger = "0.7.0"
-structopt = "0.2.15"
+structopt-derive = "=0.2.18"
+structopt = "=0.2.18"
 jsonrpc-core = "14.0"
 jsonrpc-ws-server = "14.0"
 serde_json = { version = "=1.0.47", features = ["preserve_order"] }


### PR DESCRIPTION
## PR summary

This PR adds caching of FullChain ValidationPackages received from agents so that on subsequent attempts get data from the same agent we can skip the network roud-trip.  This is especially important when nodes first come on any may have to hold lots of data from a given node.  This can drastically reduce the number of network round-trips.

- [x] validation data gets cached from direct messages from authors
- [ ] validation data gets cached when rebuilt from dht (may not implement)
- [ ] works for header only validation_package type (may not implement)

## testing/benchmarking notes

### N.B. App-spec failing
This PR includes changing the sim2h RETRY_FETCH_MISSING_ASPECTS_INTERVAL_MS from .5s to 30 seconds. This is necessary for systemic health (especially as new nodes come online), but causes a number of app-spec tests to fail due to timing issues.

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
