### PR TITLE
Fix holding-list/eavi mismatch bug for Update entries

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -14,5 +14,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-### Security
+- Fixed bug in calculating entry address of a Content EntryAspect that cause entry updates to not validate correctly [2204](https://github.com/holochain/holochain-rust/pull/2204)
 
+### Security

--- a/crates/core/src/dht/dht_reducers.rs
+++ b/crates/core/src/dht/dht_reducers.rs
@@ -64,7 +64,7 @@ pub(crate) fn reduce_commit_entry(
     match reduce_store_entry_inner(&mut new_store, entry) {
         Ok(()) => Some(new_store),
         Err(e) => {
-            println!("{}", e);
+            error!("{}", e);
             None
         }
     }

--- a/crates/core_types/src/network/entry_aspect.rs
+++ b/crates/core_types/src/network/entry_aspect.rs
@@ -97,12 +97,11 @@ impl EntryAspect {
     }
     /// NB: this is the inverse function of entry_to_meta_aspect,
     /// so it is very important that they agree!
+    /// NOTE: the ContentAspect address is always the entry address and this
+    /// is not used by entry_to_meta_aspect
     pub fn entry_address(&self) -> Result<Address, HolochainError> {
         Ok(match self {
-            EntryAspect::Content(_, header) => match header.link_update_delete() {
-                Some(ref updated_entry) => updated_entry.clone(),
-                None => header.entry_address().clone(),
-            },
+            EntryAspect::Content(_, header) => header.entry_address().clone(),
             EntryAspect::LinkAdd(link_data, _) => link_data.link.base().clone(),
             EntryAspect::LinkRemove((link_data, _), _) => link_data.link.base().clone(),
             EntryAspect::Update(_, header) | EntryAspect::Deletion(header) => {


### PR DESCRIPTION
## PR summary

fixed bug in calculating entry address of a Content EntryAspect

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
