### PR TITLE
fix for failed publish of authored entries

### DIFF
--- a/crates/net/src/sim2h_worker.rs
+++ b/crates/net/src/sim2h_worker.rs
@@ -483,24 +483,25 @@ impl Sim2hWorker {
             Lib3hClientProtocol::PublishEntry(provided_entry_data) => {
                 //let log_context = "ClientToLib3h::PublishEntry";
 
-                if self.is_autonomous_node() {
-                    // As with QueryEntry, if we are in full-sync DHT mode,
-                    // this means that we can play back PublishEntry messages already locally
-                    // as HandleStoreEntryAspects.
-                    // This makes instances with Sim2hWorker work even if offline,
-                    // i.e. not connected to the sim2h node.
-                    for aspect in &provided_entry_data.entry.aspect_list {
-                        let msg =
-                            Lib3hServerProtocol::HandleStoreEntryAspect(StoreEntryAspectData {
-                                request_id: "".into(),
-                                space_address: provided_entry_data.space_address.clone(),
-                                provider_agent_id: provided_entry_data.provider_agent_id.clone(),
-                                entry_address: provided_entry_data.entry.entry_address.clone(),
-                                entry_aspect: aspect.clone(),
-                            });
-                        self.to_core.push(span_wrap.swapped(msg));
-                    }
+                // route publish back to self always in case the connection is actually
+                // bad.
+                //     if self.is_autonomous_node() {
+                // As with QueryEntry, if we are in full-sync DHT mode,
+                // this means that we can play back PublishEntry messages already locally
+                // as HandleStoreEntryAspects.
+                // This makes instances with Sim2hWorker work even if offline,
+                // i.e. not connected to the sim2h node.
+                for aspect in &provided_entry_data.entry.aspect_list {
+                    let msg = Lib3hServerProtocol::HandleStoreEntryAspect(StoreEntryAspectData {
+                        request_id: "".into(),
+                        space_address: provided_entry_data.space_address.clone(),
+                        provider_agent_id: provided_entry_data.provider_agent_id.clone(),
+                        entry_address: provided_entry_data.entry.entry_address.clone(),
+                        entry_aspect: aspect.clone(),
+                    });
+                    self.to_core.push(span_wrap.swapped(msg));
                 }
+                //  }
 
                 self.send_wire_message(WireMessage::ClientToLib3h(
                     span_wrap.swapped(ClientToLib3h::PublishEntry(provided_entry_data)),


### PR DESCRIPTION
## PR summary

Fixes bug caused by the failure of the conductor to ever hold authored entries in the case that the initial publishing failed. 

There is already a mechanism in place where the conductor correctly holds authored items in it's own DHT when it is in "autonomous mode" i.e. when it knows that it's disconnected from sim2h. However, there are cases when the node doesn't know that it's disconnected, i.e. the low level socket connection is still open and hasn't been closed properly (or sim2h is just busy) . If the conductor is shut down then, or if other actions are taken this can yield mismatches between the holding list and what's in the CAS.

The fix is to always treat Publishing as if we are in autonomous mode.  This will yield an extra unnecessary HoldEntryEntryAspect message from sim2h, but that will just be ignored.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
