### PR TITLE
Add get_meta into admin interface

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added get_meta to admin interface for access to DHT info  [#2207](https://github.com/holochain/holochain-rust/pull/2208)
+
 ### Changed
 
 ### Deprecated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "jsonrpc-ws-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lib3h 0.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lib3h_protocol 0.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "lib3h_sodium 0.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/conductor_lib/Cargo.toml
+++ b/crates/conductor_lib/Cargo.toml
@@ -25,6 +25,7 @@ holochain_net = { version = "=0.0.51-alpha1", path = "../net" }
 holochain_tracing = "=0.0.24"
 holochain_tracing_macros = "=0.0.24"
 lib3h = "=0.0.42"
+lib3h_protocol = "=0.0.42"
 lib3h_sodium = "=0.0.42"
 holochain_metrics = { version = "=0.0.51-alpha1", path = "../metrics" }
 chrono = "=0.4.6"

--- a/crates/conductor_lib/src/conductor/base.rs
+++ b/crates/conductor_lib/src/conductor/base.rs
@@ -14,11 +14,14 @@ use crate::{
 };
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use holochain_common::paths::DNA_EXTENSION;
-use holochain_core::{logger::Logger, signal::Signal};
+use holochain_core::{
+    logger::Logger, network::handler::fetch::fetch_aspects_for_entry, signal::Signal,
+};
 use holochain_core_types::{
     agent::AgentId,
     dna::Dna,
     error::{HcResult, HolochainError},
+    network::entry_aspect::EntryAspect,
 };
 use holochain_dpki::{key_bundle::KeyBundle, password_encryption::PwHashConfig};
 use holochain_json_api::json::JsonString;
@@ -27,6 +30,7 @@ use holochain_logging::{rule::RuleFilter, FastLogger, FastLoggerBuilder};
 use holochain_persistence_api::{cas::content::AddressableContent, hash::HashString};
 use holochain_tracing as ht;
 use jsonrpc_ws_server::jsonrpc_core::IoHandler;
+use lib3h_protocol::types::AspectHash;
 use std::{
     clone::Clone,
     collections::HashMap,
@@ -102,6 +106,19 @@ type TraceReporterMap = HashMap<
         ht::reporter::JaegerCompactReporter,
     ),
 >;
+
+/// options for GetMeta request
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetMetaOptions {}
+
+/// result structure for GetMeta requests
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GetMetaResponse {
+    headers: Vec<HashString>,
+    aspects: Vec<(AspectHash, String)>, //Aspects and type
+    link_add_count: u32,
+    link_remove_count: u32,
+}
 
 /// Main representation of the conductor.
 /// Holds a `HashMap` of Holochain instances referenced by ID.
@@ -508,6 +525,48 @@ impl Conductor {
             notify(format!("Server started for \"{}\"", id))
         });
         Ok(())
+    }
+
+    /// Get data from instance
+    pub fn instance_get_meta(
+        &mut self,
+        id: &String,
+        hash: HashString,
+        _options: GetMetaOptions,
+    ) -> Result<GetMetaResponse, HolochainInstanceError> {
+        let instance = self.instances.get(id)?.read().unwrap();
+        let context = instance.context()?;
+
+        let headers = match context
+            .state()
+            .expect("Could not get state for handle_fetch_entry")
+            .get_headers(hash.clone())
+        {
+            Err(_error) => Vec::new(),
+            Ok(headers) => headers.into_iter().map(|h| h.address()).collect(),
+        };
+
+        let mut add_links = 0;
+        let mut remove_links = 0;
+        let aspects = fetch_aspects_for_entry(&hash.into(), context);
+        let aspects = aspects
+            .into_iter()
+            .map(|a| {
+                match a {
+                    EntryAspect::LinkAdd(_, _) => add_links += 1,
+                    EntryAspect::LinkRemove(_, _) => remove_links += 1,
+                    _ => (),
+                }
+                (a.address().into(), a.type_hint())
+            })
+            .collect();
+        let response = GetMetaResponse {
+            headers,
+            aspects,
+            link_add_count: add_links,
+            link_remove_count: remove_links,
+        };
+        Ok(response)
     }
 
     pub fn start_instance(&mut self, id: &String) -> Result<(), HolochainInstanceError> {

--- a/crates/conductor_lib/src/conductor/mod.rs
+++ b/crates/conductor_lib/src/conductor/mod.rs
@@ -8,7 +8,7 @@ pub mod ui_admin;
 
 pub use self::{
     admin::ConductorAdmin,
-    base::{mount_conductor_from_config, Conductor, CONDUCTOR},
+    base::{mount_conductor_from_config, Conductor, GetMetaOptions, GetMetaResponse, CONDUCTOR},
     debug::ConductorDebug,
     test_admin::ConductorTestAdmin,
     ui_admin::ConductorUiAdmin,

--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -421,7 +421,6 @@ impl ConductorApiBuilder {
     ///     Params:
     ///     * `id`: [string] Which instance to get data from?
     ///     * `hash`: [string] hash to get data about
-    ///     * `options`: [object] options about what data to return
     ///
     ///  * `admin/instance/list`
     ///     Returns an array of all instances that are configured.

--- a/crates/conductor_lib/src/interface.rs
+++ b/crates/conductor_lib/src/interface.rs
@@ -19,7 +19,10 @@ use jsonrpc_core::{self, types::params::Params, IoHandler, Value};
 use std::{collections::HashMap, convert::TryFrom, path::PathBuf, sync::Arc, thread};
 
 use crate::{
-    conductor::{ConductorAdmin, ConductorDebug, ConductorTestAdmin, ConductorUiAdmin, CONDUCTOR},
+    conductor::{
+        ConductorAdmin, ConductorDebug, ConductorTestAdmin, ConductorUiAdmin, GetMetaOptions,
+        CONDUCTOR,
+    },
     config::{
         AgentConfiguration, Bridge, DnaConfiguration, InstanceConfiguration,
         InterfaceConfiguration, InterfaceDriver, UiBundleConfiguration, UiInterfaceConfiguration,
@@ -413,6 +416,13 @@ impl ConductorApiBuilder {
     ///     Params:
     ///     * `id`: [string] Which instance to stop?
     ///
+    ///  * `admin/instance/get_meta`
+    ///     Gets meta-data about a hash on an instance
+    ///     Params:
+    ///     * `id`: [string] Which instance to get data from?
+    ///     * `hash`: [string] hash to get data about
+    ///     * `options`: [object] options about what data to return
+    ///
     ///  * `admin/instance/list`
     ///     Returns an array of all instances that are configured.
     ///
@@ -571,6 +581,17 @@ impl ConductorApiBuilder {
             conductor_call!(|c| c.start_instance(&id))?;
             Ok(json!({"success": true}))
         });
+
+        self.io
+            .add_method("admin/instance/get_meta", move |params| {
+                let params_map = Self::unwrap_params_map(params)?;
+                let id = Self::get_as_string("id", &params_map)?;
+                let hash = Self::get_as_string("hash", &params_map)?;
+                let response =
+                    conductor_call!(|c| c.instance_get_meta(&id, hash.into(), GetMetaOptions {}))?;
+                Ok(serde_json::to_value(response)
+                    .map_err(|_| jsonrpc_core::Error::internal_error())?)
+            });
 
         self.io.add_method("admin/instance/stop", move |params| {
             let params_map = Self::unwrap_params_map(params)?;


### PR DESCRIPTION
## PR summary

This PR adds the ability to get DHT information from the admin interface which will enable updates to tryorama for waiting for particular network states to occur so testing can progress.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [ ] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [ ] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
