### PR TITLE
Replace s.consistency with sleep fn in scaffold

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+* Replaced `await s.consistency()` with generic JS sleep function in scenario test scaffold template [#2209](https://github.com/holochain/holochain-rust/pull/2209)
+
 ### Fixed
 
 ### Security

--- a/crates/cli/src/cli/js-tests-scaffold/index.js
+++ b/crates/cli/src/cli/js-tests-scaffold/index.js
@@ -42,7 +42,8 @@ orchestrator.registerScenario("description of example test", async (s, t) => {
   // indicating the function, and passing it an input
   const addr = await alice.call("myInstanceName", "my_zome", "create_my_entry", {"entry" : {"content":"sample content"}})
 
-  // Wait for all network activity to settle
+  // Wait 1s for all network activity to settle; you may need to adjust this
+  // number to suit your scenario.
   await new Promise(r => setTimeout(r, 1000));
 
   const result = await bob.call("myInstanceName", "my_zome", "get_my_entry", {"address": addr.Ok})

--- a/crates/cli/src/cli/js-tests-scaffold/index.js
+++ b/crates/cli/src/cli/js-tests-scaffold/index.js
@@ -43,7 +43,7 @@ orchestrator.registerScenario("description of example test", async (s, t) => {
   const addr = await alice.call("myInstanceName", "my_zome", "create_my_entry", {"entry" : {"content":"sample content"}})
 
   // Wait for all network activity to settle
-  await s.consistency()
+  await new Promise(r => setTimeout(r, 1000));
 
   const result = await bob.call("myInstanceName", "my_zome", "get_my_entry", {"address": addr.Ok})
 


### PR DESCRIPTION
## PR summary

This replaces the (now broken) `await s.consistency()` with a one-second sleep function in the scaffolded test script. Discovered when I was going through the blessing process for .52.

## testing/benchmarking notes

( if any manual testing or benchmarking was/should be done, add notes and/or screenshots here )

## followups

( any new tickets/concerns that were discovered or created during this work but aren't in scope for review here )

## changelog

- [x] if this is a code change that effects some consumer (e.g. zome developers) of holochain core,  then it has been added to [our between-release changelog](https://github.com/holochain/holochain-rust/blob/develop/CHANGELOG-UNRELEASED.md) with the format 

```markdown
- summary of change [PR#1234](https://github.com/holochain/holochain-rust/pull/1234)
```

## documentation

- [x] this code has been documented according to our [docs checklist](https://hackmd.io/@freesig/Hk9AmKJNS)
